### PR TITLE
Make PostHog cookieless with persistence: 'memory'

### DIFF
--- a/apps/website/public/scripts/posthog-init.js
+++ b/apps/website/public/scripts/posthog-init.js
@@ -48,5 +48,6 @@ posthog.init(document.currentScript.dataset.phKey, {
     api_host: document.currentScript.dataset.phHost,
     person_profiles: 'identified_only',
     capture_pageleave: true,
+    persistence: 'memory',
 })
 /* eslint-enable */

--- a/apps/website/src/pages/privacy-policy.astro
+++ b/apps/website/src/pages/privacy-policy.astro
@@ -5,7 +5,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
 <LegalLayout
     title="Privacy policy"
     description="How Cmdr collects, uses, and protects your personal data. GDPR compliant."
-    lastUpdated="2026-02-11"
+    lastUpdated="2026-03-07"
 >
     <p>
         Your privacy matters to us a lot. This policy explains what data we collect, why, and how we protect it. We've
@@ -38,7 +38,7 @@ import LegalLayout from '../layouts/LegalLayout.astro'
         </li>
         <li>
             <strong>Analytics</strong>: we use PostHog to understand how visitors use our website. This includes pages
-            visited, referrer, browser type, and approximate location (country level). PostHog may set cookies for this.
+            visited, referrer, browser type, and approximate location (country level). PostHog runs without cookies.
         </li>
         <li>
             <strong>Payment info</strong>: if you buy a license, payment is handled by Paddle. We see your email address
@@ -159,17 +159,9 @@ import LegalLayout from '../layouts/LegalLayout.astro'
     </ul>
 
     <h2>8. Cookies</h2>
-    <p>We use cookies for:</p>
-    <ul>
-        <li>
-            <strong>Analytics</strong> — PostHog sets cookies to understand how you use our website. These are first-party
-            cookies.
-        </li>
-    </ul>
-    <p>We don't use third-party advertising cookies or cross-site tracking.</p>
     <p>
-        You can disable cookies in your browser settings. The website will still work, but we won't be able to improve
-        our service based on your usage data.
+        We don't use cookies. Our analytics tools (Umami and PostHog) are both configured to run without cookies. We
+        don't use third-party advertising cookies or cross-site tracking either.
     </p>
 
     <h2>9. Your rights (GDPR)</h2>


### PR DESCRIPTION
Eliminates the need for a cookie consent banner by configuring PostHog to use in-memory storage instead of cookies. Session replay and heatmaps still work within a single page session.

Updates privacy policy to reflect the cookieless setup.

https://claude.ai/code/session_011rqgmAfy5zssjhapNbWs

## Summary
- Configured PostHog with persistence: 'memory' so it stores session data in memory instead of cookies
- Updated privacy policy to reflect the cookieless setup (sections 2 and 8)
- Eliminates the need for a cookie consent banner while maintaining GDPR compliance

## Trade-off
PostHog can no longer link visits across sessions, but single-session replay and heatmaps still work. Umami (already cookieless) handles page-level analytics.

## Test plan
- [ ] Verify PostHog session replay still works on the deployed site
- [ ] Confirm no ph_* cookies are set (check browser DevTools > Application > Cookies)
- [ ] Review updated privacy policy at /privacy-policy
