### PR TITLE
Pre-commit `--fast` lane for the check runner (~7 s)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,31 @@ Always use the checker script for compilation, linting, formatting, and tests. I
   full list, or multiple `--check` flags.
 - All Rust/Svelte checks: `./scripts/check.sh --rust` or `--svelte`
 - All checks: `./scripts/check.sh`
+
+### When to run what
+
+Three cadences. Pick the one that matches where you are in the work, not the one closest to "done."
+
+- **`./scripts/check.sh --fast` — every few file edits, on a self-imposed rhythm (~7 s).** Don't wait for "before
+  commit"; that's too late, by then a regression is buried under follow-up edits. Run after a small natural unit of
+  work: a function rewritten, a test added, a config touched. Catches roughly half the things the full suite catches,
+  for ~5% of the wall time, so use it liberally. The lane is editorially curated, not derived from timings; mutually
+  exclusive with `--include-slow` / `--only-slow`. Covers:
+  - All formatters (`oxfmt`, `rustfmt`, `gofmt`) and most non-compiling static linters (`cfg-gate`, `log-error-macro`,
+    `error-string-match`, `ipc-enum-camelcase`, `cargo-machete`, `knip`, `import-cycles`, `type-drift`, `stylelint`,
+    `css-unused`, `a11y-contrast`, `a11y-coverage`, `e2e-linux-typecheck`).
+  - Go: `go-vet`, `staticcheck`, `ineffassign`, `misspell`, `gocyclo`, `go-tests`.
+  - API server: `typecheck`, `tests`.
+  - Website: `html-validate` (self-skips when `dist/` is absent).
+  - Warn-only metrics: `file-length`, `claude-md-reminder`, `changelog-links`.
+  - **Does NOT cover**: `clippy`, Rust tests, `cargo-audit`, `cargo-deny`, `jscpd`, `bindings-fresh`, desktop ESLint /
+    `svelte-check` / Svelte tests, website ESLint / typecheck / build / e2e, `docker-build`, or any E2E suite.
+- **`./scripts/check.sh` — before every commit.** The full default suite (everything not marked `IsSlow`). Catches what
+  `--fast` skips: `clippy`, Rust tests, audit/deny, svelte-check, website build, etc. This is the contract that what
+  you're committing won't break CI.
+- **`./scripts/check.sh --include-slow` — before wrapping a milestone, declaring a feature done, or pushing a branch
+  you've been sitting on.** Adds the slow lane on top of the default suite: `desktop-e2e-linux`,
+  `desktop-e2e-playwright`, `rust-tests-linux`, `eslint-typecheck`. Allow ~20 min; this is the gate before "I'm done."
 - **`oxfmt` must always run before you call a task done.** It's monorepo-wide (markdown, YAML, JSON, JS/TS across every
   app) and takes ~1 second, so there's no reason to skip it. It's registered under `AppOther`, which means `--rust` and
   `--svelte` do NOT include it. If you only ran those, CI will catch unformatted markdown / JSON / etc. that you missed.

--- a/docs/tooling/testing.md
+++ b/docs/tooling/testing.md
@@ -150,4 +150,5 @@ race).
 
 The single entry point for all linters, formatters, type checkers, and test runners. Always use it instead of raw
 `cargo`, `pnpm vitest`, `eslint`, etc. Its output is concise and CI-aligned. Per-check: `--check <name>`. By language:
-`--rust` / `--svelte`. Slow checks (E2E, Docker): `--only-slow`. See AGENTS.md "Testing and checking".
+`--rust` / `--svelte`. Fast pre-commit lane (~7 s, curated): `--fast`. Slow checks (E2E, Docker): `--only-slow`. See
+AGENTS.md "Testing and checking" for the three-cadence guidance.

--- a/scripts/check/CLAUDE.md
+++ b/scripts/check/CLAUDE.md
@@ -24,6 +24,9 @@ go run ./scripts/check --include-slow
 # Run only slow checks
 go run ./scripts/check --only-slow
 
+# Run only the curated fast pre-commit lane (~10s)
+go run ./scripts/check --fast
+
 # CI mode (no auto-fixing, stop on first failure)
 go run ./scripts/check --ci --fail-fast
 
@@ -46,6 +49,7 @@ go run ./scripts/check --only-freestyle
 | `--verbose`                 | Show detailed output                                    |
 | `--include-slow`            | Include slow checks (excluded by default)               |
 | `--only-slow`               | Run only slow checks                                    |
+| `--fast`                    | Run only the curated fast pre-commit check set          |
 | `--only-freestyle`          | Run freestyle-compatible checks on a VM (skip the rest) |
 | `--prefer-freestyle`        | Run compat checks on VM + the rest locally in parallel  |
 | `--fail-fast`               | Stop on first failure                                   |
@@ -70,6 +74,7 @@ go run ./scripts/check --only-freestyle
     -> selectChecks()                # filter AllChecks by flags
     -> FilterSlowChecks()            # drop IsSlow=true unless --include-slow or --check used
     -> FilterCIOnlyChecks()          # drop CIOnly=true unless --ci or --check named it
+    -> FilterFastChecks()            # if --fast: keep IsFast=true (or named via --check)
     -> ensurePnpmDependencies()      # pnpm install once at root (skipped for Rust-only runs)
     -> Runner.Run():
         goroutine pool (NumCPU semaphore)
@@ -114,6 +119,12 @@ counted as failed. Dependencies not in the selected run set are treated as satis
 **Slow checks:** `IsSlow: true` marks checks excluded by default (currently: `rust-tests-linux`, `desktop-e2e-linux`,
 `desktop-e2e-playwright`). Named `--check` invocations implicitly include slow checks
 (`includeSlow = len(checkNames) > 0`).
+
+**Fast lane (`--fast`):** `IsFast: true` marks the curated pre-commit check set: ~28 checks that finish in roughly 10s
+on a warm cache, intended to run before every commit. It's an editorial pick, not a timing-derived list (see Key
+decisions below). Named `--check` invocations bypass the filter so `--fast --check svelte-check` still runs
+svelte-check. Mutually exclusive with `--include-slow` / `--only-slow` — combining them errors out, since the lanes are
+intentionally separate.
 
 **CI-only checks:** `CIOnly: true` marks checks that run only in `--ci` mode (currently: `cargo-udeps`). They're
 silently dropped from local runs (no SKIPPED line) and are not pulled in by `--include-slow` or `--only-slow`. Escape
@@ -161,6 +172,7 @@ DisplayName:       "eslint", // shown in output
 App:               AppDesktop,
 Tech:              "🎨 Svelte",
 IsSlow:            false,
+IsFast:            false, // true = included in --fast (curated pre-commit lane)
 CIOnly:            false, // true = run only in --ci mode (or explicit --check)
 FreestyleIncompat: true, // can NOT run on freestyle.sh VMs (Rust, Docker)
 DependsOn:         []string{"desktop-svelte-prettier"},
@@ -304,6 +316,14 @@ runs only in CI" colocated with the check definition rather than as a hardcoded 
 Orthogonal to `IsSlow`: `--include-slow` and `--only-slow` do NOT pull in CI-only checks (you'd otherwise lose the
 ability to run "all slow checks locally without the CI-only ones"). Negative-sense default (`false` = runs locally)
 matches the other gating fields.
+
+**Decision**: `IsFast` field on `CheckDefinition` and a curated `--fast` pre-commit lane. **Why**: A pre-commit run
+should finish in ~10s so it actually gets used. The list is editorially curated, not derived from CSV timings: warm
+average is what matters, but cold-cache outliers (`cargo-audit` spiking to ~3 min on advisory DB refresh) would silently
+make the lane unreliable on the first run of the day. Mirrors the `IsSlow` / `CIOnly` field pattern (negative-sense
+boolean default, same colocated style). Mutually exclusive with `--include-slow` / `--only-slow` to keep the semantics
+unambiguous: "give me the fast lane" and "give me the slow lane" can't both be true. Named `--check` invocations bypass
+the filter (same escape hatch as `IsSlow` and `CIOnly`).
 
 **Decision**: Skip `pnpm install` when lockfile is unchanged. **Why**: `pnpm install` takes ~20s and pegs all CPUs even
 when deps haven't changed. A marker file (`node_modules/.pnpm-install-marker`) stores `pnpm-lock.yaml`'s mtime after

--- a/scripts/check/checks/common.go
+++ b/scripts/check/checks/common.go
@@ -90,6 +90,7 @@ type CheckDefinition struct {
 	App               App
 	Tech              string
 	IsSlow            bool
+	IsFast            bool // true = included in --fast (pre-commit lane). Curated, not derived.
 	CIOnly            bool // true = run only when --ci is set (or when explicitly named via --check)
 	FreestyleIncompat bool // true = can NOT run on freestyle.sh VMs (Rust compilation, Docker, etc.)
 	// NeedsSmb declares that this check requires the smb-consumer Docker stack

--- a/scripts/check/checks/registry.go
+++ b/scripts/check/checks/registry.go
@@ -13,6 +13,7 @@ var AllChecks = []CheckDefinition{
 		Tech:              "📐 Format",
 		FreestyleIncompat: true,
 		DependsOn:         nil,
+		IsFast:            true,
 		Run:               RunOxfmt,
 	},
 
@@ -25,6 +26,7 @@ var AllChecks = []CheckDefinition{
 		Tech:              "🦀 Rust",
 		FreestyleIncompat: true,
 		DependsOn:         nil,
+		IsFast:            true,
 		Run:               RunRustfmt,
 	},
 	{
@@ -65,6 +67,7 @@ var AllChecks = []CheckDefinition{
 		Tech:              "🦀 Rust",
 		FreestyleIncompat: true,
 		DependsOn:         nil,
+		IsFast:            true,
 		Run:               RunCargoMachete,
 	},
 	{
@@ -96,6 +99,7 @@ var AllChecks = []CheckDefinition{
 		Tech:              "🦀 Rust",
 		FreestyleIncompat: true,
 		DependsOn:         nil,
+		IsFast:            true,
 		Run:               RunCfgGate,
 	},
 	{
@@ -106,6 +110,7 @@ var AllChecks = []CheckDefinition{
 		Tech:              "🦀 Rust",
 		FreestyleIncompat: false,
 		DependsOn:         nil,
+		IsFast:            true,
 		Run:               RunLogErrorMacro,
 	},
 	{
@@ -116,6 +121,7 @@ var AllChecks = []CheckDefinition{
 		Tech:              "🦀 Rust",
 		FreestyleIncompat: false,
 		DependsOn:         nil,
+		IsFast:            true,
 		Run:               RunErrorStringMatch,
 	},
 	{
@@ -136,6 +142,7 @@ var AllChecks = []CheckDefinition{
 		Tech:              "🦀 Rust",
 		FreestyleIncompat: false,
 		DependsOn:         nil,
+		IsFast:            true,
 		Run:               RunIpcEnumCamelCase,
 	},
 	{
@@ -197,6 +204,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppDesktop,
 		Tech:        "🎨 Svelte",
 		DependsOn:   []string{"oxfmt"},
+		IsFast:      true,
 		Run:         RunStylelint,
 	},
 	{
@@ -206,6 +214,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppDesktop,
 		Tech:        "🎨 Svelte",
 		DependsOn:   []string{"desktop-svelte-stylelint"},
+		IsFast:      true,
 		Run:         RunCSSUnused,
 	},
 	{
@@ -215,6 +224,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppDesktop,
 		Tech:        "🎨 Svelte",
 		DependsOn:   []string{"desktop-svelte-stylelint"},
+		IsFast:      true,
 		Run:         RunA11yContrast,
 	},
 	{
@@ -223,6 +233,7 @@ var AllChecks = []CheckDefinition{
 		DisplayName: "a11y-coverage",
 		App:         AppDesktop,
 		Tech:        "🎨 Svelte",
+		IsFast:      true,
 		Run:         RunA11yCoverage,
 	},
 	{
@@ -241,6 +252,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppDesktop,
 		Tech:        "🎨 Svelte",
 		DependsOn:   nil,
+		IsFast:      true,
 		Run:         RunImportCycles,
 	},
 	{
@@ -250,6 +262,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppDesktop,
 		Tech:        "🎨 Svelte",
 		DependsOn:   nil,
+		IsFast:      true,
 		Run:         RunKnip,
 	},
 	{
@@ -259,6 +272,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppDesktop,
 		Tech:        "🎨 Svelte",
 		DependsOn:   nil,
+		IsFast:      true,
 		Run:         RunTypeDrift,
 	},
 	{
@@ -277,6 +291,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppDesktop,
 		Tech:        "🎨 Svelte",
 		DependsOn:   nil,
+		IsFast:      true,
 		Run:         RunDesktopE2ELinuxTypecheck,
 	},
 	{
@@ -344,6 +359,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppWebsite,
 		Tech:        "🚀 Astro",
 		DependsOn:   []string{"website-build"},
+		IsFast:      true,
 		Run:         RunWebsiteHTMLValidate,
 	},
 	{
@@ -370,6 +386,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppApiServer,
 		Tech:        "⸆⸉ TS",
 		DependsOn:   []string{"api-server-eslint"},
+		IsFast:      true,
 		Run:         RunApiServerTypecheck,
 	},
 	{
@@ -378,6 +395,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppApiServer,
 		Tech:        "⸆⸉ TS",
 		DependsOn:   []string{"api-server-typecheck"},
+		IsFast:      true,
 		Run:         RunApiServerTests,
 	},
 
@@ -390,6 +408,7 @@ var AllChecks = []CheckDefinition{
 		Tech:              "🐹 Go",
 		FreestyleIncompat: true,
 		DependsOn:         nil,
+		IsFast:            true,
 		Run:               RunGoFmt,
 	},
 	{
@@ -399,6 +418,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppScripts,
 		Tech:        "🐹 Go",
 		DependsOn:   []string{"scripts-go-gofmt"},
+		IsFast:      true,
 		Run:         RunGoVet,
 	},
 	{
@@ -408,6 +428,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppScripts,
 		Tech:        "🐹 Go",
 		DependsOn:   []string{"scripts-go-gofmt"},
+		IsFast:      true,
 		Run:         RunStaticcheck,
 	},
 	{
@@ -417,6 +438,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppScripts,
 		Tech:        "🐹 Go",
 		DependsOn:   []string{"scripts-go-gofmt"},
+		IsFast:      true,
 		Run:         RunIneffassign,
 	},
 	{
@@ -426,6 +448,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppScripts,
 		Tech:        "🐹 Go",
 		DependsOn:   nil,
+		IsFast:      true,
 		Run:         RunMisspell,
 	},
 	{
@@ -435,6 +458,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppScripts,
 		Tech:        "🐹 Go",
 		DependsOn:   []string{"scripts-go-gofmt"},
+		IsFast:      true,
 		Run:         RunGocyclo,
 	},
 	{
@@ -462,6 +486,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppScripts,
 		Tech:        "🐹 Go",
 		DependsOn:   []string{"scripts-go-vet"},
+		IsFast:      true,
 		Run:         RunGoTests,
 	},
 
@@ -472,6 +497,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppOther,
 		Tech:        "📏 Metrics",
 		DependsOn:   nil,
+		IsFast:      true,
 		Run:         RunFileLength,
 	},
 	{
@@ -480,6 +506,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppOther,
 		Tech:        "📏 Metrics",
 		DependsOn:   nil,
+		IsFast:      true,
 		Run:         RunClaudeMdReminder,
 	},
 	{
@@ -489,6 +516,7 @@ var AllChecks = []CheckDefinition{
 		App:         AppOther,
 		Tech:        "🔗 Links",
 		DependsOn:   nil,
+		IsFast:      true,
 		Run:         RunChangelogCommitLinks,
 	},
 }
@@ -586,6 +614,29 @@ func FilterSlowChecks(defs []CheckDefinition, includeSlow bool) []CheckDefinitio
 	var result []CheckDefinition
 	for _, def := range defs {
 		if !def.IsSlow {
+			result = append(result, def)
+		}
+	}
+	return result
+}
+
+// FilterFastChecks keeps only checks marked IsFast (the curated pre-commit
+// lane) when `fast` is true; otherwise returns `defs` unchanged. Checks the
+// user explicitly named via --check bypass the filter, so
+// `--fast --check svelte-check` still runs svelte-check alongside the fast set.
+func FilterFastChecks(defs []CheckDefinition, fast bool, namedChecks []string) []CheckDefinition {
+	if !fast {
+		return defs
+	}
+	named := make(map[string]bool, len(namedChecks))
+	for _, name := range namedChecks {
+		if c := GetCheckByID(name); c != nil {
+			named[c.ID] = true
+		}
+	}
+	var result []CheckDefinition
+	for _, def := range defs {
+		if def.IsFast || named[def.ID] {
 			result = append(result, def)
 		}
 	}

--- a/scripts/check/main.go
+++ b/scripts/check/main.go
@@ -41,6 +41,7 @@ type cliFlags struct {
 	verbose         bool
 	includeSlow     bool
 	onlySlow        bool
+	fast            bool
 	failFast        bool
 	noLog           bool
 	onlyFreestyle   bool
@@ -103,6 +104,7 @@ func main() {
 
 	checksToRun = checks.FilterSlowChecks(checksToRun, flags.includeSlow)
 	checksToRun = checks.FilterCIOnlyChecks(checksToRun, flags.ciMode, flags.checkNames)
+	checksToRun = checks.FilterFastChecks(checksToRun, flags.fast, flags.checkNames)
 
 	if flags.freestyleRemote {
 		checksToRun = checks.FilterFreestyleCompat(checksToRun)
@@ -201,6 +203,7 @@ func parseFlags() *cliFlags {
 		verbose         = flag.Bool("verbose", false, "Show detailed output")
 		includeSlow     = flag.Bool("include-slow", false, "Include slow checks (excluded by default)")
 		onlySlow        = flag.Bool("only-slow", false, "Run only slow checks")
+		fast            = flag.Bool("fast", false, "Run only the curated fast pre-commit check set")
 		failFast        = flag.Bool("fail-fast", false, "Stop on first failure")
 		noLog           = flag.Bool("no-log", false, "Disable CSV stats logging")
 		onlyFreestyle   = flag.Bool("only-freestyle", false, "Run only freestyle-compatible checks on a VM (skip the rest)")
@@ -217,6 +220,11 @@ func parseFlags() *cliFlags {
 		return nil
 	}
 
+	if *fast && (*includeSlow || *onlySlow) {
+		printError("--fast is mutually exclusive with --include-slow / --only-slow")
+		os.Exit(1)
+	}
+
 	return &cliFlags{
 		rustOnly:        *rustOnly || *rustOnly2,
 		svelteOnly:      *svelteOnly || *svelteOnly2,
@@ -227,6 +235,7 @@ func parseFlags() *cliFlags {
 		verbose:         *verbose,
 		includeSlow:     *includeSlow || *onlySlow || len(checkNames) > 0,
 		onlySlow:        *onlySlow,
+		fast:            *fast,
 		failFast:        *failFast,
 		noLog:           *noLog || *ciMode,
 		onlyFreestyle:   *onlyFreestyle,
@@ -391,6 +400,7 @@ func showUsage() {
 	fmt.Println("    --verbose                Show detailed output")
 	fmt.Println("    --include-slow           Include slow checks (excluded by default)")
 	fmt.Println("    --only-slow              Run only slow checks")
+	fmt.Println("    --fast                   Run only the curated fast pre-commit check set")
 	fmt.Println("    --only-freestyle         Run freestyle-compatible checks on a VM (skip the rest)")
 	fmt.Println("    --prefer-freestyle       Run compat checks on VM + the rest locally in parallel")
 	fmt.Println("    --fail-fast              Stop on first failure")
@@ -404,6 +414,7 @@ func showUsage() {
 	fmt.Println("    go run ./scripts/check --app desktop                # Run only desktop app checks")
 	fmt.Println("    go run ./scripts/check --check desktop-rust-clippy  # Run specific check")
 	fmt.Println("    go run ./scripts/check --include-slow               # Include slow checks")
+	fmt.Println("    go run ./scripts/check --fast                       # Pre-commit lane (fastest)")
 	fmt.Println("    go run ./scripts/check --ci --fail-fast             # CI mode, stop on first failure")
 	fmt.Println()
 	fmt.Println("Available checks:")


### PR DESCRIPTION
- New `IsFast: true` field on `CheckDefinition`, mirroring the existing `IsSlow` / `CIOnly` / `FreestyleIncompat` gating fields. Negative-sense default (`false` = not in the lane), so only opt-ins need to touch their definition.
- 28 checks tagged `IsFast`: all formatters (`oxfmt`, `rustfmt`, `gofmt`), most non-compiling static linters (`cfg-gate`, `log-error-macro`, `error-string-match`, `ipc-enum-camelcase`, `cargo-machete`, `knip`, `import-cycles`, `type-drift`, `stylelint`, `css-unused`, `a11y-contrast`, `a11y-coverage`, `e2e-linux-typecheck`), all Go checks except `nilaway` / `deadcode` (`go-vet`, `staticcheck`, `ineffassign`, `misspell`, `gocyclo`, `go-tests`), API server typecheck + tests, website `html-validate`, and the warn-only metrics (`file-length`, `claude-md-reminder`, `changelog-links`).
- Excluded from the lane: `clippy`, Rust tests, `cargo-audit`, `cargo-deny`, `jscpd`, `bindings-fresh`, desktop ESLint / `svelte-check` / Svelte tests, website ESLint / typecheck / build / e2e, `docker-build`, and any E2E suite. `cargo-audit` was deliberately dropped because its first-of-the-day run hits the advisory DB and can spike to ~3 min.
- New `--fast` flag in `main.go` filters the run set to `IsFast` checks. Named `--check` invocations bypass the filter, so `--fast --check svelte-check` runs svelte-check even though it isn't in the lane (same escape hatch `IsSlow` / `CIOnly` have).
- `--fast` is mutually exclusive with `--include-slow` / `--only-slow`: combining them errors out at flag-parse time with a clear message. The lanes are intentionally separate.
- `FilterFastChecks` short-circuits when the flag is off so `main()` stays under the gocyclo threshold (16 → 15 after refactor; the conditional moved into the helper).
- `AGENTS.md` gains a "When to run what" subsection with three-cadence guidance: `--fast` mid-work on a self-imposed rhythm, full suite before every commit, `--include-slow` before milestone wrap-up. Explicitly lists what `--fast` does and doesn't cover so agents (and humans) don't have to guess.
- `scripts/check/CLAUDE.md` updated with the new field in the definition shape, an architecture-diagram entry for `FilterFastChecks()`, a Key Patterns entry for the fast lane, and a Decision entry explaining why the list is editorially curated rather than timing-derived.
- `docs/tooling/testing.md` one-liner cadence reference updated.
- `--help` and the README-style quick-start in `CLAUDE.md` both list the new flag.

## Test plan

- Unit tests in `scripts/check/...` pass (3.2 s).
- `./scripts/check.sh --fast` runs all 28 checks in ~4–7 s end-to-end (varies with warm/cold cache). Verified all pass on this branch.
- `./scripts/check.sh --fast --rust` correctly intersects: 6 Rust∩fast checks, finishes in ~675 ms.
- `./scripts/check.sh --fast --check svelte-check` correctly bypasses the filter for the named check.
- `./scripts/check.sh --fast --include-slow` and `--fast --only-slow` both exit 1 with the mutual-exclusion error message.
- Programmatically enumerated the `IsFast` set and confirmed it contains exactly the 28 agreed checks (no `cargo-audit`).
- Existing `--include-slow` / `--only-slow` / `--rust` / `--svelte` / `--check` paths unchanged (FilterFastChecks short-circuits when `--fast` is off).