### PR TITLE
Stop the full-pane cursor flash on Brief dir entry

### DIFF
--- a/apps/desktop/src/lib/file-explorer/views/BriefList.svelte
+++ b/apps/desktop/src/lib/file-explorer/views/BriefList.svelte
@@ -358,6 +358,13 @@
     function fetchColumnWidths() {
         if (!listingId || itemsPerColumn <= 0) return
         cancelPendingFetch()
+        // First fetch (no widths yet, for example after entering a new dir) fires
+        // immediately so the cursor-hidden gap is as short as possible. Subsequent
+        // re-fetches keep the 50 ms coalesce to absorb resize bursts.
+        if (columnWidths.length === 0) {
+            void doFetchColumnWidths(false)
+            return
+        }
         pendingFetchTimer = setTimeout(() => {
             pendingFetchTimer = null
             void doFetchColumnWidths(false)
@@ -787,7 +794,7 @@
                             <div
                                 id={`file-${String(globalIndex)}`}
                                 class="file-entry"
-                                class:is-under-cursor={globalIndex === cursorIndex}
+                                class:is-under-cursor={globalIndex === cursorIndex && columnWidths.length > 0}
                                 class:is-selected={selectedIndices.has(globalIndex)}
                                 class:is-striped={stripedRows && globalIndex % 2 === 1}
                                 class:is-restricted={fileIsRestricted}

--- a/apps/desktop/src/lib/file-explorer/views/CLAUDE.md
+++ b/apps/desktop/src/lib/file-explorer/views/CLAUDE.md
@@ -93,7 +93,10 @@ array (`$derived`) drives all virtual-scroll math: `totalSize` is the final pref
 binary-searches `prefixSums` for the visible range, and `getScrollToPositionVariable` looks up exact column edges.
 Scrollbar size and cursor visibility now agree with what's actually rendered. `transition: width 300ms ease` still
 animates width changes within a directory; nav resets snap via the `skipTransition` 2-rAF trick. While widths are in
-flight (first paint, after `FontMetricsNotReady`), every column renders at `capPx` as a fallback.
+flight (first paint, after `FontMetricsNotReady`), every column renders at `capPx` as a fallback, and the cursor
+highlight is suppressed until `columnWidths.length > 0` so the user doesn't see a full-pane-wide cursor stripe for a
+frame. The initial fetch after a dir change skips the 50 ms coalesce so that gap is as short as possible; re-fetches
+during resize keep the coalesce.
 
 **Decision**: A single `$effect` keeps the cursor in view, depending on `cursorIndex`, `containerWidth`,
 `containerHeight`, and `columnWidths.length` **Why**: With exact prefix-sum math, every input that could move the


### PR DESCRIPTION
- On dir change, `BriefList` clears `columnWidths`; until the backend `get_brief_column_text_widths` IPC returns, every column falls back to `capPx` ≈ full pane width. The cursor stripe is just the `.file-entry` filling its column, so it flashed at full pane width for ~1 frame.
- Gate the `is-under-cursor` class on `columnWidths.length > 0` so no cursor stripe renders at the fallback width. Names still render; only the highlight is suppressed during the gap.
- Drop the 50 ms coalesce on the first fetch (when `columnWidths` is empty) so the cursor-hidden gap is as short as possible. Resize-driven re-fetches keep the coalesce.
- Updated the colocated `CLAUDE.md` to capture the new cursor-suppression behavior next to the existing "while widths are in flight" note.

## Test plan
- Manually verified Brief mode still renders correctly after navigating across dirs. The 1-frame full-pane cursor flash is hard to catch in a screenshot but should now be replaced by at most a 1-frame "no cursor visible" gap.
- `./scripts/check.sh --check svelte-check --check eslint-typecheck --check knip` all green.