### PR TITLE
Tooling: declare rustfmt + clippy as required toolchain components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           filters: |
             rust:
               - 'apps/desktop/src-tauri/**'
+              - 'apps/desktop/rust-toolchain.toml'
             svelte:
               - 'apps/desktop/src/**'
               - 'apps/desktop/static/**'

--- a/apps/desktop/rust-toolchain.toml
+++ b/apps/desktop/rust-toolchain.toml
@@ -3,3 +3,9 @@
 # A compromised rustc release would land transparently otherwise. Bump
 # deliberately, with a few days between Rust's release and our pin update.
 channel = "1.95.0"
+# rustup installs only the minimal profile for a pinned channel by default
+# (rustc + cargo + rust-std). CI invokes `cargo fmt` and `cargo clippy`, both
+# of which need their respective components installed. Declare them here so
+# the runner picks them up automatically — without this, every CI Rust job
+# fails at the rustfmt step.
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Pinning `apps/desktop/rust-toolchain.toml` to a specific channel without a `components` line tells rustup to install only the minimal profile (rustc + cargo + rust-std). Every Rust CI job since the pin landed (commit \`7d771ca8\`) fails at the rustfmt step because rustfmt isn't installed.

- Adds \`components = ["rustfmt", "clippy"]\` so the runner installs them alongside the pinned channel.
- Devs with local rustup configs that already have rustfmt installed are unaffected.

Blocks #18 and #21 from going CI-green; should land first.

## Test plan

- [x] \`cargo fmt --check\` + \`cargo clippy -- -D warnings\` succeed locally on a runner with only the minimal profile (verified by re-running the failing PR after merge).