### PR TITLE
feat(website): `pnpm check` enforces canonical Tailwind classes on the website and the analytics dashboard

### DIFF
--- a/apps/analytics-dashboard/DETAILS.md
+++ b/apps/analytics-dashboard/DETAILS.md
@@ -305,7 +305,9 @@ What's specific to this app's configs:
 
 - **ESLint** (`eslint.config.js`) mirrors the api-server's `strictTypeChecked` base plus the desktop app's Svelte parser
   blocks. Type-aware rules need `.svelte-kit/tsconfig.json`, which `tsconfig.json` extends, so `svelte-kit sync` has to
-  run first; the `dashboard-eslint` check hard-fails when it's missing rather than let the rules quietly no-op.
+  run first; the `dashboard-eslint` check hard-fails when it's missing rather than let the rules quietly no-op. It also
+  carries the website's `eslint-plugin-better-tailwindcss` rule set (`src/app.css` as the entry point); the rationale
+  per rule is in `apps/website/DETAILS.md` § Tailwind class hygiene.
 - Config files (`svelte.config.js`, `vite.config.ts`, `vitest.config.ts`) lint with `disableTypeChecked`. They sit
   outside the generated tsconfig's include list, and adding them to the TS project purely to satisfy the linter would be
   the tail wagging the dog.

--- a/apps/analytics-dashboard/eslint.config.js
+++ b/apps/analytics-dashboard/eslint.config.js
@@ -15,6 +15,7 @@ import prettierConfig from 'eslint-config-prettier'
 import tseslint from 'typescript-eslint'
 import svelte from 'eslint-plugin-svelte'
 import svelteParser from 'svelte-eslint-parser'
+import betterTailwindcss from 'eslint-plugin-better-tailwindcss'
 import globals from 'globals'
 import noErrorStringMatch from '../../eslint-plugins/no-error-string-match.js'
 import noConfusableCallbackParams from '../../eslint-plugins/no-confusable-callback-params.js'
@@ -81,6 +82,21 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-vars': unusedVarsRule,
       'no-console': 'warn',
       complexity: ['error', { max: 15 }],
+    },
+  },
+  {
+    // Tailwind class hygiene, the same rule set as the website (`apps/website/eslint.config.js` explains
+    // each choice).
+    files: ['src/**/*.{ts,svelte}'],
+    plugins: { 'better-tailwindcss': betterTailwindcss },
+    settings: { 'better-tailwindcss': { entryPoint: 'src/app.css' } },
+    rules: {
+      'better-tailwindcss/enforce-canonical-classes': 'error',
+      'better-tailwindcss/enforce-consistent-class-order': 'error',
+      'better-tailwindcss/no-conflicting-classes': 'error',
+      'better-tailwindcss/no-deprecated-classes': 'error',
+      'better-tailwindcss/no-duplicate-classes': 'error',
+      'better-tailwindcss/no-unnecessary-whitespace': 'error',
     },
   },
   {

--- a/apps/analytics-dashboard/knip.json
+++ b/apps/analytics-dashboard/knip.json
@@ -3,7 +3,6 @@
   "treatConfigHintsAsErrors": true,
   "ignoreExportsUsedInFile": true,
   "project": ["src/**/*.{ts,svelte,css}"],
-  "ignoreDependencies": ["oxlint"],
   "svelte": {
     "entry": [
       "src/routes/**/+page.svelte",

--- a/apps/analytics-dashboard/package.json
+++ b/apps/analytics-dashboard/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "eslint": "^10.7.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-better-tailwindcss": "4.7.0",
     "eslint-plugin-svelte": "^3.20.0",
     "globals": "^17.7.0",
     "knip": "^6.27.0",

--- a/apps/analytics-dashboard/src/lib/components/CountryTable.svelte
+++ b/apps/analytics-dashboard/src/lib/components/CountryTable.svelte
@@ -35,7 +35,7 @@
     <table class="w-full text-left text-sm">
         <thead>
             <tr class="border-b border-border-subtle text-text-tertiary">
-                <th class="pb-2 pr-4 font-medium">Country</th>
+                <th class="pr-4 pb-2 font-medium">Country</th>
                 <th class="pb-2 text-right font-medium">Downloads</th>
             </tr>
         </thead>
@@ -53,7 +53,7 @@
                     }}
                 >
                     <td class="py-1.5 pr-4 text-text-primary">{formatCountry(item.x)}</td>
-                    <td class="py-1.5 text-right tabular-nums text-text-secondary">{formatNumber(item.y)}</td>
+                    <td class="py-1.5 text-right text-text-secondary tabular-nums">{formatNumber(item.y)}</td>
                 </tr>
             {/each}
         </tbody>
@@ -79,7 +79,7 @@
                 <div class="mb-1">
                     <div class="flex items-baseline justify-between text-xs">
                         <span class="text-text-secondary">{arch.x}</span>
-                        <span class="tabular-nums text-text-tertiary">{formatNumber(arch.y)}</span>
+                        <span class="text-text-tertiary tabular-nums">{formatNumber(arch.y)}</span>
                     </div>
                     <MiniTimeline data={td} height={48} maxY={archMaxY} xMin={zoomXMin} xMax={zoomXMax} />
                 </div>
@@ -93,7 +93,7 @@
                 <div class="mb-1">
                     <div class="flex items-baseline justify-between text-xs">
                         <span class="text-text-secondary">{ver.x}</span>
-                        <span class="tabular-nums text-text-tertiary">{formatNumber(ver.y)}</span>
+                        <span class="text-text-tertiary tabular-nums">{formatNumber(ver.y)}</span>
                     </div>
                     <MiniTimeline data={td} height={48} maxY={verMaxY} xMin={zoomXMin} xMax={zoomXMax} />
                 </div>

--- a/apps/analytics-dashboard/src/lib/components/FunnelTable.svelte
+++ b/apps/analytics-dashboard/src/lib/components/FunnelTable.svelte
@@ -83,17 +83,17 @@
                                         >(today, partial)</span
                                     >{/if}
                             </td>
-                            <td class="py-1.5 pr-4 text-right tabular-nums text-text-secondary">{funnelCell(row.visitors)}</td>
-                            <td class="py-1.5 pr-4 text-right tabular-nums text-text-secondary">{funnelCell(row.downloadClicks)}</td>
-                            <td class="py-1.5 pr-4 text-right tabular-nums text-text-secondary">{funnelCell(row.serverDownloads)}</td>
-                            <td class="py-1.5 pr-4 text-right tabular-nums text-text-secondary">{funnelCell(row.newInstalls)}</td>
-                            <td class="py-1.5 pr-4 text-right tabular-nums text-text-secondary">
+                            <td class="py-1.5 pr-4 text-right text-text-secondary tabular-nums">{funnelCell(row.visitors)}</td>
+                            <td class="py-1.5 pr-4 text-right text-text-secondary tabular-nums">{funnelCell(row.downloadClicks)}</td>
+                            <td class="py-1.5 pr-4 text-right text-text-secondary tabular-nums">{funnelCell(row.serverDownloads)}</td>
+                            <td class="py-1.5 pr-4 text-right text-text-secondary tabular-nums">{funnelCell(row.newInstalls)}</td>
+                            <td class="py-1.5 pr-4 text-right text-text-secondary tabular-nums">
                                 {funnelPercent(row.d7Retention)}{#if row.d7Retained !== null}<span
                                         class="ml-1 text-xs text-text-tertiary">({row.d7Retained})</span
                                     >{/if}
                             </td>
-                            <td class="py-1.5 pr-4 text-right tabular-nums text-text-secondary">{funnelCell(row.newsletterSignups)}</td>
-                            <td class="py-1.5 text-right tabular-nums text-text-secondary">{funnelCell(row.purchases)}</td>
+                            <td class="py-1.5 pr-4 text-right text-text-secondary tabular-nums">{funnelCell(row.newsletterSignups)}</td>
+                            <td class="py-1.5 text-right text-text-secondary tabular-nums">{funnelCell(row.purchases)}</td>
                         </tr>
                     {/each}
                 </tbody>
@@ -175,7 +175,7 @@
             {:else}
                 <p class="mb-2 text-sm text-text-secondary">
                     Human installs:
-                    <span class="font-semibold tabular-nums text-text-primary">{formatNumber(ua.humanInstalls)}</span>
+                    <span class="font-semibold text-text-primary tabular-nums">{formatNumber(ua.humanInstalls)}</span>
                     <span class="text-text-tertiary">of {formatNumber(ua.total)} raw server downloads</span>
                 </p>
                 <MetricTable

--- a/apps/analytics-dashboard/src/lib/components/Methodology.svelte
+++ b/apps/analytics-dashboard/src/lib/components/Methodology.svelte
@@ -3,4 +3,4 @@
     const { text }: { text: string } = $props()
 </script>
 
-<p class="mt-2 text-xs leading-relaxed text-text-tertiary">{text}</p>
+<p class="mt-2 text-xs/relaxed text-text-tertiary">{text}</p>

--- a/apps/analytics-dashboard/src/lib/components/MetricRow.svelte
+++ b/apps/analytics-dashboard/src/lib/components/MetricRow.svelte
@@ -15,12 +15,12 @@
         <div>
             <p class="flex items-center gap-1.5 text-xs text-text-tertiary">
                 {#if metric.color}
-                    <span class="inline-block h-2 w-2 rounded-full" style="background: {metric.color}"></span>
+                    <span class="inline-block size-2 rounded-full" style="background: {metric.color}"></span>
                 {/if}
                 {metric.label}
             </p>
             <div class="flex items-baseline gap-2">
-                <p class="text-2xl font-bold tabular-nums text-text-primary">{metric.value}</p>
+                <p class="text-2xl font-bold text-text-primary tabular-nums">{metric.value}</p>
                 {#if metric.delta}
                     <span class="text-sm tabular-nums {metric.delta.positive ? 'text-success' : 'text-danger'}">
                         {metric.delta.text}

--- a/apps/analytics-dashboard/src/lib/components/MetricTable.svelte
+++ b/apps/analytics-dashboard/src/lib/components/MetricTable.svelte
@@ -13,7 +13,7 @@
     <table class="w-full text-left text-sm">
         <thead>
             <tr class="border-b border-border-subtle text-text-tertiary">
-                <th class="pb-2 pr-4 font-medium">{colLabel}</th>
+                <th class="pr-4 pb-2 font-medium">{colLabel}</th>
                 <th class="pb-2 text-right font-medium">{colValue}</th>
             </tr>
         </thead>
@@ -21,7 +21,7 @@
             {#each items as item (item.x)}
                 <tr class="border-b border-border-subtle/50">
                     <td class="py-1.5 pr-4 text-text-primary">{item.x || '(direct)'}</td>
-                    <td class="py-1.5 text-right tabular-nums text-text-secondary">{formatNumber(item.y)}</td>
+                    <td class="py-1.5 text-right text-text-secondary tabular-nums">{formatNumber(item.y)}</td>
                 </tr>
             {/each}
         </tbody>

--- a/apps/analytics-dashboard/src/lib/components/PieChart.svelte
+++ b/apps/analytics-dashboard/src/lib/components/PieChart.svelte
@@ -71,11 +71,11 @@
     </svg>
     <div class="mt-1 space-y-px">
         {#each arcs as arc (arc.label)}
-            <div class="flex items-center gap-1.5 text-xs leading-tight">
+            <div class="flex items-center gap-1.5 text-xs/tight">
                 <span style="color: {arc.color}" class="text-[10px]">●</span>
                 <span class="text-text-secondary">{arc.label}</span>
-                <span class="ml-auto tabular-nums text-text-tertiary">{arc.value}</span>
-                <span class="w-9 tabular-nums text-text-tertiary text-right">{(arc.frac * 100).toFixed(0)}%</span>
+                <span class="ml-auto text-text-tertiary tabular-nums">{arc.value}</span>
+                <span class="w-9 text-right text-text-tertiary tabular-nums">{(arc.frac * 100).toFixed(0)}%</span>
             </div>
         {/each}
     </div>

--- a/apps/analytics-dashboard/src/lib/components/SectionDescription.svelte
+++ b/apps/analytics-dashboard/src/lib/components/SectionDescription.svelte
@@ -6,7 +6,7 @@
     const { insight, caveat }: { insight: string; caveat?: string } = $props()
 </script>
 
-<p class="mb-4 text-xs leading-relaxed text-text-secondary">
+<p class="mb-4 text-xs/relaxed text-text-secondary">
     {insight}
     {#if caveat}<span class="text-text-tertiary">{caveat}</span>{/if}
 </p>

--- a/apps/analytics-dashboard/src/lib/components/StackedBarChart.svelte
+++ b/apps/analytics-dashboard/src/lib/components/StackedBarChart.svelte
@@ -74,7 +74,7 @@
     <!-- X-axis labels -->
     <div class="mt-1 flex gap-px">
         {#each days as day, dayIdx (day)}
-            <div class="flex-1 text-center text-[9px] tabular-nums text-text-tertiary">
+            <div class="flex-1 text-center text-[9px] text-text-tertiary tabular-nums">
                 {dayIdx % labelEvery === 0 ? shortDay(day) : ''}
             </div>
         {/each}
@@ -84,7 +84,7 @@
     <div class="mt-2 flex flex-wrap gap-x-3 gap-y-1">
         {#each series as s (s.key)}
             <div class="flex items-center gap-1.5 text-xs text-text-secondary">
-                <span class="inline-block h-2.5 w-2.5 rounded-sm" style="background-color: {s.color};"></span>
+                <span class="inline-block size-2.5 rounded-sm" style="background-color: {s.color};"></span>
                 {s.label}
             </div>
         {/each}
@@ -96,17 +96,17 @@
         <div class="mt-3 inline-block rounded-lg border border-border bg-surface-elevated p-3 text-sm">
             <p class="mb-1 font-medium text-text-primary">
                 {days[dayIdx]}
-                <span class="ml-2 tabular-nums text-text-secondary">{dayTotals[dayIdx]} {unitLabel}</span>
+                <span class="ml-2 text-text-secondary tabular-nums">{dayTotals[dayIdx]} {unitLabel}</span>
             </p>
             <div class="flex flex-col gap-0.5">
                 {#each series as s (s.key)}
                     {@const value = s.values[dayIdx] ?? 0}
                     <div class="flex items-center justify-between gap-4 text-xs">
                         <span class="flex items-center gap-1.5 text-text-secondary">
-                            <span class="inline-block h-2.5 w-2.5 rounded-sm" style="background-color: {s.color};"></span>
+                            <span class="inline-block size-2.5 rounded-sm" style="background-color: {s.color};"></span>
                             {s.label}
                         </span>
-                        <span class="tabular-nums text-text-primary">{value}</span>
+                        <span class="text-text-primary tabular-nums">{value}</span>
                     </div>
                 {/each}
             </div>

--- a/apps/analytics-dashboard/src/lib/components/sections/ActiveUseSection.svelte
+++ b/apps/analytics-dashboard/src/lib/components/sections/ActiveUseSection.svelte
@@ -62,7 +62,7 @@
                 ]}
             />
 
-            <p class="mt-3 text-xs leading-relaxed text-text-tertiary">
+            <p class="mt-3 text-xs/relaxed text-text-tertiary">
                 The low end counts install ids we heard from, so those installs definitely ran Cmdr. The high end counts
                 the separate addresses that checked for updates, which catches people who turned analytics off.
                 {#if unseen !== null}
@@ -117,12 +117,12 @@
             <div class="mt-4 flex gap-6">
                 <div>
                     <p class="text-xs text-text-tertiary">Total activations</p>
-                    <p class="text-lg font-semibold tabular-nums text-text-primary">{formatNumber(lic.totalActivations)}</p>
+                    <p class="text-lg font-semibold text-text-primary tabular-nums">{formatNumber(lic.totalActivations)}</p>
                 </div>
                 {#if lic.activeDevices !== null}
                     <div>
                         <p class="text-xs text-text-tertiary">Active devices</p>
-                        <p class="text-lg font-semibold tabular-nums text-text-primary">{formatNumber(lic.activeDevices)}</p>
+                        <p class="text-lg font-semibold text-text-primary tabular-nums">{formatNumber(lic.activeDevices)}</p>
                     </div>
                 {/if}
             </div>

--- a/apps/analytics-dashboard/src/lib/components/sections/DownloadSection.svelte
+++ b/apps/analytics-dashboard/src/lib/components/sections/DownloadSection.svelte
@@ -150,7 +150,7 @@
                                 <div class="mb-1">
                                     <div class="flex items-baseline justify-between text-xs">
                                         <span class="text-text-primary">{version.x}</span>
-                                        <span class="tabular-nums text-text-secondary">{formatNumber(version.y)}</span>
+                                        <span class="text-text-secondary tabular-nums">{formatNumber(version.y)}</span>
                                     </div>
                                     <MiniTimeline
                                         data={timelineData}
@@ -191,7 +191,7 @@
                             >
                                 <p class="mb-2 text-sm font-medium text-text-primary">
                                     {day}
-                                    <span class="ml-2 tabular-nums text-text-secondary">{formatNumber(dayTotal)} downloads</span>
+                                    <span class="ml-2 text-text-secondary tabular-nums">{formatNumber(dayTotal)} downloads</span>
                                 </p>
                                 <div class="flex items-start gap-5">
                                     <div>
@@ -259,7 +259,7 @@
                         <table class="w-full text-left text-sm">
                             <thead>
                                 <tr class="border-b border-border-subtle text-text-tertiary">
-                                    <th class="pb-2 pr-4 font-medium">Release</th>
+                                    <th class="pr-4 pb-2 font-medium">Release</th>
                                     <th class="pb-2 text-right font-medium tabular-nums">Downloads</th>
                                 </tr>
                             </thead>
@@ -267,7 +267,7 @@
                                 {#each github.data.releases.slice(0, 5) as release (release.tagName)}
                                     <tr class="border-b border-border-subtle/50">
                                         <td class="py-1.5 pr-4 text-text-primary">{release.tagName}</td>
-                                        <td class="py-1.5 text-right tabular-nums text-text-secondary"
+                                        <td class="py-1.5 text-right text-text-secondary tabular-nums"
                                             >{formatNumber(release.totalDownloads)}</td
                                         >
                                     </tr>

--- a/apps/analytics-dashboard/src/lib/components/sections/FeedbackErrorsSection.svelte
+++ b/apps/analytics-dashboard/src/lib/components/sections/FeedbackErrorsSection.svelte
@@ -91,7 +91,7 @@
                 <div class="space-y-2">
                     {#each fe.feedback.slice(0, 15) as msg (msg.id)}
                         <div class="rounded-lg border border-border-subtle bg-surface-elevated px-3 py-2">
-                            <p class="whitespace-pre-wrap text-sm text-text-primary">{msg.feedback}</p>
+                            <p class="text-sm whitespace-pre-wrap text-text-primary">{msg.feedback}</p>
                             <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-tertiary">
                                 <span class="tabular-nums">{msg.createdAt.split(' ')[0]}</span>
                                 <span>v{msg.appVersion}</span>
@@ -120,9 +120,9 @@
                     <table class="w-full text-left text-sm">
                         <thead>
                             <tr class="border-b border-border-subtle text-text-tertiary">
-                                <th class="pb-2 pr-4 font-medium">ID</th>
-                                <th class="pb-2 pr-4 font-medium">Kind</th>
-                                <th class="pb-2 pr-4 font-medium">Version</th>
+                                <th class="pr-4 pb-2 font-medium">ID</th>
+                                <th class="pr-4 pb-2 font-medium">Kind</th>
+                                <th class="pr-4 pb-2 font-medium">Version</th>
                                 <th class="pb-2 text-right font-medium">Date</th>
                             </tr>
                         </thead>
@@ -131,8 +131,8 @@
                                 <tr class="border-b border-border-subtle/50">
                                     <td class="py-1.5 pr-4 font-mono text-text-primary">{report.id}</td>
                                     <td class="py-1.5 pr-4 text-text-secondary">{report.kind}</td>
-                                    <td class="py-1.5 pr-4 tabular-nums text-text-secondary">{report.appVersion}</td>
-                                    <td class="py-1.5 text-right tabular-nums text-text-tertiary">{report.date}</td>
+                                    <td class="py-1.5 pr-4 text-text-secondary tabular-nums">{report.appVersion}</td>
+                                    <td class="py-1.5 text-right text-text-tertiary tabular-nums">{report.date}</td>
                                 </tr>
                             {/each}
                         </tbody>

--- a/apps/analytics-dashboard/src/lib/components/sections/PaymentSection.svelte
+++ b/apps/analytics-dashboard/src/lib/components/sections/PaymentSection.svelte
@@ -43,17 +43,17 @@
                     <table class="w-full text-left text-sm">
                         <thead>
                             <tr class="border-b border-border-subtle text-text-tertiary">
-                                <th class="pb-2 pr-4 font-medium">Date</th>
-                                <th class="pb-2 pr-4 font-medium">Status</th>
+                                <th class="pr-4 pb-2 font-medium">Date</th>
+                                <th class="pr-4 pb-2 font-medium">Status</th>
                                 <th class="pb-2 text-right font-medium">Amount</th>
                             </tr>
                         </thead>
                         <tbody>
                             {#each p.transactions.slice(0, 10) as txn (txn.id)}
                                 <tr class="border-b border-border-subtle/50">
-                                    <td class="py-1.5 pr-4 tabular-nums text-text-primary">{txn.createdAt.split('T')[0]}</td>
+                                    <td class="py-1.5 pr-4 text-text-primary tabular-nums">{txn.createdAt.split('T')[0]}</td>
                                     <td class="py-1.5 pr-4 text-text-secondary">{txn.status}</td>
-                                    <td class="py-1.5 text-right tabular-nums text-text-secondary"
+                                    <td class="py-1.5 text-right text-text-secondary tabular-nums"
                                         >{formatCurrency(txn.total, txn.currencyCode)}</td
                                     >
                                 </tr>

--- a/apps/analytics-dashboard/src/lib/components/sections/SettingsAdoptionSection.svelte
+++ b/apps/analytics-dashboard/src/lib/components/sections/SettingsAdoptionSection.svelte
@@ -78,10 +78,10 @@
                         <table class="w-full text-left text-sm">
                             <thead>
                                 <tr class="border-b border-border-subtle text-text-tertiary">
-                                    <th class="pb-2 pr-4 font-medium">Setting</th>
-                                    <th class="pb-2 pr-4 font-medium">Default</th>
-                                    <th class="pb-2 pr-4 text-right font-medium">Installs</th>
-                                    <th class="pb-2 pr-4 text-right font-medium">On default</th>
+                                    <th class="pr-4 pb-2 font-medium">Setting</th>
+                                    <th class="pr-4 pb-2 font-medium">Default</th>
+                                    <th class="pr-4 pb-2 text-right font-medium">Installs</th>
+                                    <th class="pr-4 pb-2 text-right font-medium">On default</th>
                                     <th class="pb-2 font-medium">Most common change</th>
                                 </tr>
                             </thead>
@@ -92,10 +92,10 @@
                                     <tr class="border-b border-border-subtle/50">
                                         <td class="py-1.5 pr-4 font-mono text-xs text-text-primary">{setting.key}</td>
                                         <td class="py-1.5 pr-4 text-text-secondary">{setting.defaultLabel ?? 'changed by version'}</td>
-                                        <td class="py-1.5 pr-4 text-right tabular-nums text-text-secondary">
+                                        <td class="py-1.5 pr-4 text-right text-text-secondary tabular-nums">
                                             {formatNumber(setting.eligible)}
                                         </td>
-                                        <td class="py-1.5 pr-4 text-right tabular-nums text-text-secondary">
+                                        <td class="py-1.5 pr-4 text-right text-text-secondary tabular-nums">
                                             {share === null ? '–' : formatShare(share)}
                                         </td>
                                         <td class="py-1.5 text-text-secondary">

--- a/apps/analytics-dashboard/src/routes/+layout.svelte
+++ b/apps/analytics-dashboard/src/routes/+layout.svelte
@@ -53,7 +53,7 @@
     }
 </script>
 
-<div class="mx-auto max-w-[1800px] px-6 pb-8 pt-14">
+<div class="mx-auto max-w-[1800px] px-6 pt-14 pb-8">
     <!-- Header (sticky): brand, page nav, and the range/day picker -->
     <header
         class="fixed inset-x-0 top-0 z-40 flex items-center justify-between gap-4 border-b border-border bg-surface/90 px-6 py-2 backdrop-blur-sm"

--- a/apps/analytics-dashboard/src/routes/links/+page.svelte
+++ b/apps/analytics-dashboard/src/routes/links/+page.svelte
@@ -58,7 +58,7 @@
         caveat="Unknown codes still pass through as their own source verbatim, so this map only exists to give a short code a friendlier meaning. Edits take up to about 5 minutes to reach visitors, since the public list is cached at the edge."
     />
 
-    <div class="mb-6 rounded-lg border border-border-subtle bg-surface-elevated/50 p-4 text-xs leading-relaxed text-text-secondary">
+    <div class="mb-6 rounded-lg border border-border-subtle bg-surface-elevated/50 p-4 text-xs/relaxed text-text-secondary">
         <p class="mb-1 font-medium text-text-primary">Adding a code before a post</p>
         <ul class="list-disc space-y-1 pl-4">
             <li>
@@ -201,10 +201,10 @@
             <table class="w-full text-left text-sm">
                 <thead>
                     <tr class="border-b border-border-subtle text-text-tertiary">
-                        <th class="pb-2 pr-4 font-medium">Code</th>
-                        <th class="pb-2 pr-4 font-medium">Source</th>
-                        <th class="pb-2 pr-4 font-medium">Medium</th>
-                        <th class="pb-2 pr-4 font-medium">Note</th>
+                        <th class="pr-4 pb-2 font-medium">Code</th>
+                        <th class="pr-4 pb-2 font-medium">Source</th>
+                        <th class="pr-4 pb-2 font-medium">Medium</th>
+                        <th class="pr-4 pb-2 font-medium">Note</th>
                         <th class="pb-2 text-right font-medium">Actions</th>
                     </tr>
                 </thead>

--- a/apps/website/CLAUDE.md
+++ b/apps/website/CLAUDE.md
@@ -54,6 +54,9 @@ Color scheme.
 - Don't hardcode colors; use `global.css` CSS variables. (OG images excepted: Satori can't read them, so keep their
   hardcoded colors in sync.)
 - Accent buttons: text uses `--color-accent-contrast` (not `--color-background`) so it stays dark across modes.
+- Color utilities use the `@theme` names (`text-text-secondary`, `bg-accent/10`, `border-border`), never
+  `text-[var(--color-…)]` or `text-(--color-…)`. `pnpm check eslint` enforces it (`better-tailwindcss`), and
+  `pnpm lint:fix` rewrites the long forms. [DETAILS.md](DETAILS.md) § Tailwind class hygiene.
 
 ## Gotchas
 

--- a/apps/website/DETAILS.md
+++ b/apps/website/DETAILS.md
@@ -169,7 +169,7 @@ How it's wired:
 Using it:
 
 - `<Icon name="rocket" size={40} />`. Default gold comes from `.icon { color: var(--color-accent) }` plus Lucide's
-  `currentColor` stroke; recolor by passing a `class` (e.g. a Tailwind `text-[…]`).
+  `currentColor` stroke; recolor by passing a `class` (e.g. a Tailwind `text-text-secondary`).
 - When a data array feeds `<Icon name={…}>` (the `Features.astro` / `features.astro` grids), type its `icon` field as
   `IconName` via `satisfies { …; icon: IconName }[]` so a bad name is a compile error at the data site.
 - **Size is applied as CSS `width`/`height`, never as width/height attributes.** Lucide glyphs already ship
@@ -209,6 +209,44 @@ All pages support both light and dark mode. Users can override their system pref
 
 **Decision/Why**: The dual-selector pattern (media query + `data-theme` attribute) ensures the site works correctly
 without JS (falls back to system preference) while supporting explicit overrides via the toggle.
+
+## Tailwind class hygiene
+
+`eslint-plugin-better-tailwindcss` runs on `src/**/*.astro` and `src/**/*.ts` from `eslint.config.js`, with
+`src/styles/global.css` as the Tailwind entry point so it knows every `@theme` token. Nothing else enforced class
+hygiene before it: IntelliSense's editor nudges never reached `pnpm check` or CI, and the site had drifted to some 255
+`text-[var(--color-…)]`-style utilities.
+
+- **The canonical form is the theme name.** `text-text-secondary`, `bg-accent/10`, `border-border`,
+  `hover:text-accent-hover`, `from-surface`, `outline-accent`. Tailwind's own canonicalizer sometimes stops at the
+  variable shorthand (`border-(--color-border)`, `bg-(--color-accent)/10`) and accepts both, so the sweep rewrote those
+  to the theme name by hand; new code should go straight to the theme name. Both forms compile to the same declaration
+  (`color: var(--color-…)` or the same `color-mix(…)`), verified by building the site before and after the sweep and
+  diffing the emitted CSS rule bodies: every color declaration was identical, and the only differences were the
+  collapsed utilities below (2026-09-01). Light-mode overrides in `global.css` keep applying because the utility still
+  references the variable.
+- **Rules on** (all as errors, all but two autofixable, so `pnpm lint:fix` does the work): `enforce-canonical-classes`
+  (the ESLint twin of IntelliSense's `suggestCanonicalClasses`; also collapses `h-6 w-6` into `size-6` and
+  `[grid-auto-flow:dense]` into `grid-flow-dense`), `enforce-consistent-class-order` (Tailwind's official order),
+  `no-conflicting-classes`, `no-deprecated-classes`, `no-duplicate-classes`, `no-unnecessary-whitespace`.
+- **Rules deliberately off.** `enforce-shorthand-classes`, `enforce-consistent-important-position`, and
+  `enforce-consistent-variable-syntax` are subsumed by `enforce-canonical-classes` and would double-report.
+  `no-unknown-classes` can't work here: the templates mix Tailwind with BEM classes (`split-btn__label`, `hero-frame`,
+  `link-muted`) styled in scoped `<style>` blocks or plain CSS in `global.css`, which the plugin can't see (it only
+  detects `@utility` and `@layer components` classes in the entry CSS). `enforce-consistent-line-wrapping` would fight
+  oxfmt.
+- **Where it looks.** The plugin's default selectors cover `class` and Astro's `class:list` (its string literals and
+  object keys, so the arrays and conditionals in `src/pages/features.astro` and `StatusPill.astro` are linted; verified
+  on 4.7.0 by reading `getDefaultSelectors()`). Class strings held in a plain `const` are only linted when the variable
+  is named `className`, `classNames`, or `classes`, so name them that way. HTML inside data strings (the `answerHtml`
+  fields in `src/pages/pricing.astro`) is invisible to it; keep those canonical by hand.
+- **Editor**: set `"tailwindCSS.lint.suggestCanonicalClasses": "ignore"` in your `.vscode/settings.json` (gitignored) so
+  IntelliSense stops reporting what ESLint now owns.
+- **Cost**: the canonical rule boots Tailwind, about one second per lint run.
+
+The analytics dashboard runs the same rule set from its `eslint.config.js` with `src/app.css` as the entry point; its
+sweep was class order plus a few collapses (`h-2 w-2` to `size-2`, `text-xs leading-relaxed` to `text-xs/relaxed`). The
+desktop app writes plain CSS and has no Tailwind.
 
 ## Analytics
 

--- a/apps/website/eslint.config.js
+++ b/apps/website/eslint.config.js
@@ -7,6 +7,7 @@ import js from '@eslint/js'
 import prettierConfig from 'eslint-config-prettier'
 import tseslint from 'typescript-eslint'
 import astro from 'eslint-plugin-astro'
+import betterTailwindcss from 'eslint-plugin-better-tailwindcss'
 import globals from 'globals'
 import noConfusableCallbackParams from '../../eslint-plugins/no-confusable-callback-params.js'
 
@@ -118,6 +119,26 @@ export default tseslint.config(
     rules: {
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': 'error',
+    },
+  },
+  {
+    // Tailwind class hygiene. `enforce-canonical-classes` is the ESLint twin of Tailwind IntelliSense's
+    // `suggestCanonicalClasses` (set `"tailwindCSS.lint.suggestCanonicalClasses": "ignore"` in your editor so
+    // it isn't reported twice). It subsumes `enforce-shorthand-classes`, `enforce-consistent-important-position`,
+    // and `enforce-consistent-variable-syntax`, so those stay off. `no-unknown-classes` stays off too: the site
+    // mixes Tailwind with BEM classes styled in scoped `<style>` blocks, which the plugin can't see. Boots
+    // Tailwind itself, so it adds ~1s of startup. Rationale and the canonical-form contract: `DETAILS.md`.
+    files: ['src/**/*.astro', 'src/**/*.ts'],
+    plugins: { 'better-tailwindcss': betterTailwindcss },
+    // The plugin's default selectors already cover Astro's `class:list` (strings and object keys).
+    settings: { 'better-tailwindcss': { entryPoint: 'src/styles/global.css' } },
+    rules: {
+      'better-tailwindcss/enforce-canonical-classes': 'error',
+      'better-tailwindcss/enforce-consistent-class-order': 'error',
+      'better-tailwindcss/no-conflicting-classes': 'error',
+      'better-tailwindcss/no-deprecated-classes': 'error',
+      'better-tailwindcss/no-duplicate-classes': 'error',
+      'better-tailwindcss/no-unnecessary-whitespace': 'error',
     },
   },
   {

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -42,6 +42,7 @@
     "eslint": "^10.7.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-astro": "^1.7.0",
+    "eslint-plugin-better-tailwindcss": "4.7.0",
     "globals": "^17.7.0",
     "html-validate": "^10.17.0",
     "prettier": "^3.9.5",

--- a/apps/website/src/components/Download.astro
+++ b/apps/website/src/components/Download.astro
@@ -13,24 +13,24 @@ import NewsletterInlineWrapper from './NewsletterInlineWrapper.astro'
 
     <div class="relative mx-auto max-w-4xl text-center">
         <h2 class="mb-4 text-3xl font-bold md:text-4xl lg:text-5xl">Get Cmdr now!</h2>
-        <p class="mb-3 text-lg text-[var(--color-text-secondary)]">
+        <p class="mb-3 text-lg text-text-secondary">
             Free forever for personal use. No signup, no account needed.
         </p>
-        <p class="mb-10 text-sm text-[var(--color-text-tertiary)]">
+        <p class="mb-10 text-sm text-text-tertiary">
             Cmdr is in open beta: solid for daily use, and your feedback shapes what's next. See the <a
                 href="/features"
-                class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+                class="text-accent-text underline underline-offset-2 hover:text-accent-hover"
                 >feature status</a
             >.
         </p>
 
         <!-- Download card -->
         <div
-            class="mx-auto max-w-md rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8 transition-all duration-300 hover:border-[var(--color-accent)]/30"
+            class="mx-auto max-w-md rounded-2xl border border-border bg-surface p-8 transition-all duration-300 hover:border-accent/30"
         >
             <div class="mb-6 flex items-center justify-center gap-4">
                 <svg
-                    class="h-12 w-12 text-[var(--color-text-secondary)]"
+                    class="size-12 text-text-secondary"
                     fill="currentColor"
                     viewBox="0 0 24 24"
                     aria-hidden="true"
@@ -46,11 +46,11 @@ import NewsletterInlineWrapper from './NewsletterInlineWrapper.astro'
 
             <HomebrewInstall />
 
-            <div class="mt-6 space-y-2 text-sm text-[var(--color-text-tertiary)]">
+            <div class="mt-6 space-y-2 text-sm text-text-tertiary">
                 <p>
                     Free for personal use · <a
                         href="/pricing"
-                        class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+                        class="text-accent-text underline underline-offset-2 hover:text-accent-hover"
                         >Commercial from $59/yr</a
                     >
                 </p>

--- a/apps/website/src/components/Features.astro
+++ b/apps/website/src/components/Features.astro
@@ -68,7 +68,7 @@ const upcoming = [
             <h2 class="mb-4 text-3xl font-bold md:text-4xl lg:text-5xl">
                 Built for <span class="gradient-text">power users</span>
             </h2>
-            <p class="mx-auto max-w-2xl text-lg text-[var(--color-text-secondary)]">
+            <p class="mx-auto max-w-2xl text-lg text-text-secondary">
                 Unimaginably fast, keyboard-driven, and gets smarter every week.
             </p>
         </div>
@@ -79,18 +79,18 @@ const upcoming = [
                 shipped.map((feature) => (
                     <a
                         href={`/features#${feature.slug}`}
-                        class="group relative block rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8 no-underline transition-all duration-300 hover:border-[var(--color-accent)]/30 hover:bg-[var(--color-surface-elevated)]"
+                        class="group relative block rounded-2xl border border-border bg-surface p-8 no-underline transition-all duration-300 hover:border-accent/30 hover:bg-surface-elevated"
                     >
                         <Icon name={feature.icon} size={40} class="mb-4" />
                         <h3 class="mb-2 text-xl font-semibold">{feature.title}</h3>
-                        <p class="text-[var(--color-text-secondary)]" set:html={feature.description} />
+                        <p class="text-text-secondary" set:html={feature.description} />
                     </a>
                 ))
             }
         </div>
 
         <!-- AI features separator -->
-        <p class="my-10 text-center text-sm font-medium tracking-wide text-[var(--color-text-tertiary)] uppercase">
+        <p class="my-10 text-center text-sm font-medium tracking-wide text-text-tertiary uppercase">
             Fresh and upcoming
         </p>
 
@@ -100,7 +100,7 @@ const upcoming = [
                 upcoming.map((feature) => (
                     <a
                         href={`/features#${feature.slug}`}
-                        class="group relative block rounded-2xl border border-[var(--color-accent)]/30 bg-gradient-to-br from-[var(--color-surface)] to-[var(--color-accent)]/5 p-8 no-underline transition-all duration-300 hover:border-[var(--color-accent)]/50"
+                        class="group relative block rounded-2xl border border-accent/30 bg-linear-to-br from-surface to-accent/5 p-8 no-underline transition-all duration-300 hover:border-accent/50"
                     >
                         {feature.status && (
                             <span class="absolute top-4 right-4">
@@ -109,7 +109,7 @@ const upcoming = [
                         )}
                         <Icon name={feature.icon} size={40} class="mb-4" />
                         <h3 class="mb-2 text-xl font-semibold">{feature.title}</h3>
-                        <p class="text-[var(--color-text-secondary)]" set:html={feature.description} />
+                        <p class="text-text-secondary" set:html={feature.description} />
                     </a>
                 ))
             }

--- a/apps/website/src/components/Footer.astro
+++ b/apps/website/src/components/Footer.astro
@@ -4,7 +4,7 @@ import NewsletterForm from './NewsletterForm.astro'
 const currentYear = new Date().getFullYear()
 ---
 
-<footer class="border-t border-[var(--color-border-subtle)] px-6 py-12">
+<footer class="border-t border-border-subtle px-6 py-12">
     <div class="mx-auto max-w-6xl">
         <div class="mb-8 grid grid-cols-2 gap-8 md:grid-cols-4">
             <!-- Logo -->
@@ -16,21 +16,21 @@ const currentYear = new Date().getFullYear()
                         alt=""
                         width="32"
                         height="32"
-                        class="h-6 w-6"
+                        class="size-6"
                     />
                     <span class="font-semibold">Cmdr</span>
                 </a>
-                <p class="mt-2 text-sm text-[var(--color-text-tertiary)]">Fast, keyboard-driven file manager</p>
+                <p class="mt-2 text-sm text-text-tertiary">Fast, keyboard-driven file manager</p>
             </div>
 
             <!-- Product -->
             <div>
-                <p class="mb-3 text-sm font-semibold text-[var(--color-text-primary)]">Product</p>
+                <p class="mb-3 text-sm font-semibold text-text-primary">Product</p>
                 <ul class="space-y-2 text-sm">
                     <li>
                         <a
                             href="/features"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Features
                         </a>
@@ -38,7 +38,7 @@ const currentYear = new Date().getFullYear()
                     <li>
                         <a
                             href="/pricing"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Pricing
                         </a>
@@ -46,7 +46,7 @@ const currentYear = new Date().getFullYear()
                     <li>
                         <a
                             href="/#download"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Download
                         </a>
@@ -56,12 +56,12 @@ const currentYear = new Date().getFullYear()
 
             <!-- Resources -->
             <div>
-                <p class="mb-3 text-sm font-semibold text-[var(--color-text-primary)]">Resources</p>
+                <p class="mb-3 text-sm font-semibold text-text-primary">Resources</p>
                 <ul class="space-y-2 text-sm">
                     <li>
                         <a
                             href="/blog"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Blog
                         </a>
@@ -69,7 +69,7 @@ const currentYear = new Date().getFullYear()
                     <li>
                         <a
                             href="/blog/total-commander-for-macos"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Total Commander for Mac
                         </a>
@@ -77,7 +77,7 @@ const currentYear = new Date().getFullYear()
                     <li>
                         <a
                             href="https://github.com/vdavid/cmdr"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             GitHub
                         </a>
@@ -85,7 +85,7 @@ const currentYear = new Date().getFullYear()
                     <li>
                         <a
                             href="https://discord.gg/4BVafBneKJ"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Discord
                         </a>
@@ -93,7 +93,7 @@ const currentYear = new Date().getFullYear()
                     <li>
                         <a
                             href="https://github.com/vdavid/cmdr/issues"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Report an issue
                         </a>
@@ -101,7 +101,7 @@ const currentYear = new Date().getFullYear()
                     <li>
                         <a
                             href="https://github.com/vdavid/cmdr/blob/main/LICENSE"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Source license
                         </a>
@@ -111,12 +111,12 @@ const currentYear = new Date().getFullYear()
 
             <!-- Legal -->
             <div>
-                <p class="mb-3 text-sm font-semibold text-[var(--color-text-primary)]">Legal</p>
+                <p class="mb-3 text-sm font-semibold text-text-primary">Legal</p>
                 <ul class="space-y-2 text-sm">
                     <li>
                         <a
                             href="/terms-and-conditions"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Terms of service
                         </a>
@@ -124,7 +124,7 @@ const currentYear = new Date().getFullYear()
                     <li>
                         <a
                             href="/privacy-policy"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Privacy policy
                         </a>
@@ -132,7 +132,7 @@ const currentYear = new Date().getFullYear()
                     <li>
                         <a
                             href="/refund"
-                            class="text-[var(--color-text-secondary)] link-muted hover:text-[var(--color-text-primary)]"
+                            class="link-muted text-text-secondary hover:text-text-primary"
                         >
                             Refund policy
                         </a>
@@ -143,11 +143,11 @@ const currentYear = new Date().getFullYear()
 
         <!-- Newsletter -->
         <div
-            class="mb-8 flex flex-col items-start gap-4 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 md:flex-row md:items-center md:justify-between"
+            class="mb-8 flex flex-col items-start gap-4 rounded-xl border border-border bg-surface p-6 md:flex-row md:items-center md:justify-between"
         >
             <div>
-                <p class="font-semibold text-[var(--color-text-primary)]">Stay in the loop</p>
-                <p class="text-sm text-[var(--color-text-secondary)]">Product updates and news. No spam, ever.</p>
+                <p class="font-semibold text-text-primary">Stay in the loop</p>
+                <p class="text-sm text-text-secondary">Product updates and news. No spam, ever.</p>
             </div>
             <div class="w-full md:w-auto md:min-w-[320px]">
                 <NewsletterForm variant="inline" />
@@ -156,14 +156,14 @@ const currentYear = new Date().getFullYear()
 
         <!-- Bottom bar -->
         <div
-            class="flex flex-wrap items-center justify-center gap-x-1 border-t border-[var(--color-border-subtle)] pt-8 text-sm text-[var(--color-text-tertiary)]"
+            class="flex flex-wrap items-center justify-center gap-x-1 border-t border-border-subtle pt-8 text-sm text-text-tertiary"
         >
             <span>© {currentYear} David Veszelovszki ·</span>
             <a
                 href="https://veszelovszki.com"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="link-muted -mx-1 -my-1 inline-block px-2 py-1 hover:text-[var(--color-text-primary)]"
+                class="link-muted -m-1 inline-block px-2 py-1 hover:text-text-primary"
                 >veszelovszki.com</a
             >
             <span>·</span>
@@ -171,7 +171,7 @@ const currentYear = new Date().getFullYear()
                 href="https://github.com/vdavid"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="link-muted -mx-1 -my-1 inline-block px-2 py-1 hover:text-[var(--color-text-primary)]"
+                class="link-muted -m-1 inline-block px-2 py-1 hover:text-text-primary"
                 >GitHub</a
             >
             <span>·</span>
@@ -179,7 +179,7 @@ const currentYear = new Date().getFullYear()
                 href="https://x.com/vdavid"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="link-muted -mx-1 -my-1 inline-block px-2 py-1 hover:text-[var(--color-text-primary)]"
+                class="link-muted -m-1 inline-block px-2 py-1 hover:text-text-primary"
                 >X</a
             >
             <span>·</span>
@@ -187,14 +187,14 @@ const currentYear = new Date().getFullYear()
                 href="https://www.linkedin.com/in/veszelovszki/"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="link-muted -mx-1 -my-1 inline-block px-2 py-1 hover:text-[var(--color-text-primary)]"
+                class="link-muted -m-1 inline-block px-2 py-1 hover:text-text-primary"
                 >LinkedIn</a
             >
         </div>
 
         <!-- Company identifiers. Required on the website by lagen (2002:562) om elektronisk handel 8 § and
              aktiebolagslagen 28 kap. 5 §, which want the org number reachable from anywhere, not just the terms page. -->
-        <p class="mt-4 text-center text-xs text-[var(--color-text-tertiary)]">
+        <p class="mt-4 text-center text-xs text-text-tertiary">
             Cmdr is made by Rymdskottkärra AB, Järfälla, Sweden · Org. nr 559471-0401 · VAT SE559471040101
         </p>
     </div>

--- a/apps/website/src/components/Header.astro
+++ b/apps/website/src/components/Header.astro
@@ -14,7 +14,7 @@ const navLinks = [
 ---
 
 <header
-    class="fixed top-0 left-0 right-0 z-50 border-b border-[var(--color-border-subtle)] bg-[var(--color-background)]/80 backdrop-blur-xl"
+    class="fixed inset-x-0 top-0 z-50 border-b border-border-subtle bg-background/80 backdrop-blur-xl"
     transition:persist
 >
     <nav class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
@@ -31,13 +31,13 @@ const navLinks = [
                     alt=""
                     width="32"
                     height="32"
-                    class="h-6 w-6"
+                    class="size-6"
                 />
                 <span>Cmdr</span>
             </a>
             <a
                 href="/features"
-                class="rounded-full bg-[var(--color-accent)]/15 px-2 py-0.5 text-xs font-medium text-[var(--color-accent-text)] transition-colors hover:bg-[var(--color-accent)]/25"
+                class="rounded-full bg-accent/15 px-2 py-0.5 text-xs font-medium text-accent-text transition-colors hover:bg-accent/25"
                 title="Cmdr is in open beta. See what's solid and what's rough."
             >
                 Beta
@@ -52,7 +52,7 @@ const navLinks = [
                         href={link.href}
                         target={link.external ? '_blank' : undefined}
                         rel={link.external ? 'noopener noreferrer' : undefined}
-                        class="text-sm text-[var(--color-text-secondary)] transition-colors duration-200 hover:text-[var(--color-text-primary)]"
+                        class="text-sm text-text-secondary transition-colors duration-200 hover:text-text-primary"
                     >
                         {link.label}
                         {link.external && (
@@ -67,7 +67,7 @@ const navLinks = [
             <!-- Newsletter toggle (desktop) -->
             <button
                 type="button"
-                class="newsletter-toggle cursor-pointer text-[var(--color-text-secondary)] transition-colors duration-200 hover:text-[var(--color-text-primary)]"
+                class="newsletter-toggle cursor-pointer text-text-secondary transition-colors duration-200 hover:text-text-primary"
                 aria-expanded="false"
                 aria-controls="newsletter-panel"
                 aria-label="Newsletter"
@@ -76,7 +76,7 @@ const navLinks = [
                 data-newsletter-nav
             >
                 <svg
-                    class="h-4 w-4"
+                    class="size-4"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -168,7 +168,7 @@ const navLinks = [
     <!-- Newsletter slide-open panel (desktop) -->
     <div id="newsletter-panel" class="newsletter-panel hidden md:block" aria-hidden="true">
         <div class="mx-auto flex max-w-2xl flex-col items-center gap-3 px-6 py-5">
-            <p class="text-sm text-[var(--color-text-secondary)]">
+            <p class="text-sm text-text-secondary">
                 How cool that you want to hear about Cmdr news! No spam, promise. ❤️
             </p>
             <div class="w-full max-w-md">

--- a/apps/website/src/components/Hero.astro
+++ b/apps/website/src/components/Hero.astro
@@ -13,7 +13,7 @@ const currentYear = new Date().getFullYear()
 
     <!-- Grid pattern overlay -->
     <div
-        class="pointer-events-none absolute inset-0 bg-[linear-gradient(var(--color-border-subtle)_1px,transparent_1px),linear-gradient(90deg,var(--color-border-subtle)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_60%_60%_at_50%_50%,black,transparent)]"
+        class="pointer-events-none absolute inset-0 bg-[linear-gradient(var(--color-border-subtle)_1px,transparent_1px),linear-gradient(90deg,var(--color-border-subtle)_1px,transparent_1px)] mask-[radial-gradient(ellipse_60%_60%_at_50%_50%,black,transparent)] bg-size-[4rem_4rem]"
     >
     </div>
 
@@ -21,21 +21,21 @@ const currentYear = new Date().getFullYear()
         <!-- Open-beta eyebrow - Step 1 -->
         <a
             href="/features"
-            class="animate-blur-in stagger-1 mb-5 inline-flex items-center gap-2 rounded-full border border-[var(--color-accent)]/30 bg-[var(--color-accent)]/10 px-3 py-1 text-sm font-medium text-[var(--color-accent-text)] transition-colors hover:bg-[var(--color-accent)]/20"
+            class="animate-blur-in stagger-1 mb-5 inline-flex items-center gap-2 rounded-full border border-accent/30 bg-accent/10 px-3 py-1 text-sm font-medium text-accent-text transition-colors hover:bg-accent/20"
         >
             Now in open beta
             <span aria-hidden="true">&rarr;</span>
         </a>
 
         <!-- Headline - Steps 2 & 3 -->
-        <h1 class="mb-6 text-3xl font-bold leading-tight tracking-tight md:text-4xl lg:text-6xl">
+        <h1 class="mb-6 text-3xl/tight font-bold tracking-tight md:text-4xl lg:text-6xl">
             <span class="animate-blur-in stagger-2 inline-block">Finally, a file manager</span>
-            <span class="animate-blur-in stagger-3 inline-block gradient-text">from {currentYear}!</span>
+            <span class="animate-blur-in stagger-3 gradient-text inline-block">from {currentYear}!</span>
         </h1>
 
         <!-- Subheadline - Step 4 -->
         <p
-            class="animate-blur-in stagger-4 mb-10 max-w-xl text-lg leading-relaxed text-[var(--color-text-secondary)] md:text-xl"
+            class="animate-blur-in stagger-4 mb-10 max-w-xl text-lg/relaxed text-text-secondary md:text-xl"
         >
             Indexes your whole drive in minutes. Instant search, visible folder sizes, keyboard-driven everything.
             Built in Rust, free for personal use.
@@ -48,11 +48,11 @@ const currentYear = new Date().getFullYear()
             <a
                 href="#homebrew"
                 data-brew-jump
-                class="animate-blur-in stagger-6 inline-flex items-center gap-1.5 self-center text-sm text-[var(--color-text-tertiary)] underline decoration-[var(--color-border)] underline-offset-4 transition-colors hover:text-[var(--color-accent-text)] hover:decoration-[var(--color-accent)] sm:self-auto"
+                class="animate-blur-in stagger-6 inline-flex items-center gap-1.5 self-center text-sm text-text-tertiary underline decoration-border underline-offset-4 transition-colors hover:text-accent-text hover:decoration-accent sm:self-auto"
             >
                 or Homebrew
                 <svg
-                    class="h-3.5 w-3.5"
+                    class="size-3.5"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -67,7 +67,7 @@ const currentYear = new Date().getFullYear()
         </div>
 
         <!-- Pricing hint - Step 7 -->
-        <p class="animate-blur-in stagger-7 mt-8 text-sm text-[var(--color-text-tertiary)]">
+        <p class="animate-blur-in stagger-7 mt-8 text-sm text-text-tertiary">
             Source-available · Free forever for personal use · Commercial from $59/year
         </p>
     </div>

--- a/apps/website/src/components/StatusPill.astro
+++ b/apps/website/src/components/StatusPill.astro
@@ -19,10 +19,10 @@ const classes = [
     // Cyan = stability signal (the yellow accent stays for brand/category). Alpha is the
     // solid, loudest pill; beta is the tinted sibling; stable is quiet; planned is an
     // outline (not filled yet). Light-mode token values keep all four at >= 4.5:1.
-    status === 'alpha' && 'bg-[var(--color-accent2)] text-[var(--color-accent2-contrast)]',
-    status === 'beta' && 'bg-[var(--color-accent2)]/15 text-[var(--color-accent2-text)]',
-    status === 'stable' && 'bg-[var(--color-surface-elevated)] text-[var(--color-text-secondary)]',
-    status === 'planned' && 'border border-[var(--color-border)] text-[var(--color-text-secondary)]',
+    status === 'alpha' && 'bg-accent2 text-accent2-contrast',
+    status === 'beta' && 'bg-accent2/15 text-accent2-text',
+    status === 'stable' && 'bg-surface-elevated text-text-secondary',
+    status === 'planned' && 'border border-border text-text-secondary',
 ]
 ---
 

--- a/apps/website/src/components/Story.astro
+++ b/apps/website/src/components/Story.astro
@@ -1,5 +1,5 @@
 <section class="relative px-6 py-16">
-    <p class="mx-auto max-w-2xl text-center text-lg text-[var(--color-text-secondary)]">
+    <p class="mx-auto max-w-2xl text-center text-lg text-text-secondary">
         Built by <a
             href="https://github.com/vdavid"
             target="_blank"

--- a/apps/website/src/components/Testimonials.astro
+++ b/apps/website/src/components/Testimonials.astro
@@ -21,16 +21,16 @@ const testimonials = [
         <div class="grid gap-6 md:grid-cols-3">
             {
                 testimonials.map((t) => (
-                    <div class="flex flex-col rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8 transition-all duration-300 hover:border-[var(--color-accent)]/30">
-                        <span class="mb-2 text-4xl leading-none text-[var(--color-accent-text)]" aria-hidden="true">
+                    <div class="flex flex-col rounded-2xl border border-border bg-surface p-8 transition-all duration-300 hover:border-accent/30">
+                        <span class="mb-2 text-4xl leading-none text-accent-text" aria-hidden="true">
                             &ldquo;
                         </span>
                         <blockquote
-                            class="mb-8 flex-1 text-lg italic leading-relaxed text-[var(--color-text-secondary)]"
+                            class="mb-8 flex-1 text-lg/relaxed text-text-secondary italic"
                             set:html={`${t.quote}`}
                         />
                         <div class="flex items-center gap-3">
-                            <div class="rounded-full bg-gradient-to-br from-[var(--color-accent)] to-[var(--color-accent)]/40 p-[2px]">
+                            <div class="rounded-full bg-linear-to-br from-accent to-accent/40 p-[2px]">
                                 <img
                                     src="/images/david-88x88.jpg"
                                     srcset="/images/david-44x44.jpg 44w, /images/david-88x88.jpg 88w, /images/david-132x132.jpg 132w, /images/david.jpg 400w"
@@ -42,8 +42,8 @@ const testimonials = [
                                 />
                             </div>
                             <div>
-                                <p class="font-semibold text-[var(--color-text-primary)]">David</p>
-                                <p class="text-sm text-[var(--color-text-tertiary)]">software eng</p>
+                                <p class="font-semibold text-text-primary">David</p>
+                                <p class="text-sm text-text-tertiary">software eng</p>
                             </div>
                         </div>
                     </div>

--- a/apps/website/src/layouts/BlogLayout.astro
+++ b/apps/website/src/layouts/BlogLayout.astro
@@ -52,13 +52,13 @@ if (ogImage) {
     <main class="mx-auto max-w-3xl px-6 pt-32 pb-24">
         <script type="application/ld+json" set:html={JSON.stringify(blogPostingSchema)} />
         <header class="mb-12">
-            <time class="text-sm text-[var(--color-text-tertiary)]" datetime={date}>
+            <time class="text-sm text-text-tertiary" datetime={date}>
                 {formattedDate}
             </time>
-            <h1 class="mt-2 mb-4 text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
+            <h1 class="mt-2 mb-4 text-4xl font-bold tracking-tight text-text-primary">
                 {title}
             </h1>
-            <p class="text-lg text-[var(--color-text-secondary)]">
+            <p class="text-lg text-text-secondary">
                 {description}
             </p>
         </header>

--- a/apps/website/src/layouts/LegalLayout.astro
+++ b/apps/website/src/layouts/LegalLayout.astro
@@ -16,10 +16,10 @@ const { title, description, lastUpdated } = Astro.props
     <Header />
     <main class="mx-auto max-w-3xl px-6 pt-32 pb-24">
         <header class="mb-12">
-            <h1 class="mb-4 text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
+            <h1 class="mb-4 text-4xl font-bold tracking-tight text-text-primary">
                 {title}
             </h1>
-            <p class="text-sm text-[var(--color-text-tertiary)]">
+            <p class="text-sm text-text-tertiary">
                 Last updated: {lastUpdated}
             </p>
         </header>

--- a/apps/website/src/pages/blog/index.astro
+++ b/apps/website/src/pages/blog/index.astro
@@ -34,7 +34,7 @@ const postsWithExcerpts = await Promise.all(
 <Layout title="Blog | Cmdr" description="Product updates, behind-the-scenes stories, and tips.">
     <Header />
     <main class="mx-auto max-w-3xl px-6 pt-32 pb-24">
-        <h1 class="mb-12 text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">Blog</h1>
+        <h1 class="mb-12 text-4xl font-bold tracking-tight text-text-primary">Blog</h1>
 
         {
             postsWithExcerpts.map(({ post, excerptHtml, formattedDate }, index) => {
@@ -43,7 +43,7 @@ const postsWithExcerpts = await Promise.all(
                         <article class="mb-16">
                             <header class="mb-6">
                                 <time
-                                    class="text-sm text-[var(--color-text-tertiary)]"
+                                    class="text-sm text-text-tertiary"
                                     datetime={post.data.date.toISOString().slice(0, 10)}
                                 >
                                     {formattedDate}
@@ -51,7 +51,7 @@ const postsWithExcerpts = await Promise.all(
                                 <h2 class="mt-1 text-2xl font-bold tracking-tight">
                                     <a
                                         href={`/blog/${post.id}`}
-                                        class="text-[var(--color-text-primary)] no-underline transition-colors hover:text-[var(--color-accent-text)]"
+                                        class="text-text-primary no-underline transition-colors hover:text-accent-text"
                                     >
                                         {post.data.title}
                                     </a>

--- a/apps/website/src/pages/changelog.astro
+++ b/apps/website/src/pages/changelog.astro
@@ -23,14 +23,14 @@ const htmlContent = await marked.parse(linkifyCommitHashes(releasesOnly))
     <Header />
     <main class="mx-auto max-w-4xl px-6 pt-32 pb-24">
         <header class="mb-12">
-            <h1 class="mb-4 text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">Changelog</h1>
-            <p class="text-[var(--color-text-secondary)]">
+            <h1 class="mb-4 text-4xl font-bold tracking-tight text-text-primary">Changelog</h1>
+            <p class="text-text-secondary">
                 All notable changes to Cmdr are documented here. The format is based on
                 <a
                     href="https://keepachangelog.com/en/1.1.0/"
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+                    class="text-accent-text underline underline-offset-2 hover:text-accent-hover"
                     >keep a changelog</a
                 >.
             </p>

--- a/apps/website/src/pages/features.astro
+++ b/apps/website/src/pages/features.astro
@@ -111,46 +111,46 @@ const resolved = cards.map((card) => {
     <main class="mx-auto max-w-6xl px-6 pt-32 pb-24">
         <!-- Hero -->
         <header class="mb-14 text-center">
-            <h1 class="mb-4 text-3xl font-bold tracking-tight text-[var(--color-text-primary)] md:text-4xl lg:text-5xl">
+            <h1 class="mb-4 text-3xl font-bold tracking-tight text-text-primary md:text-4xl lg:text-5xl">
                 What Cmdr can do
             </h1>
-            <p class="mx-auto max-w-2xl text-lg text-[var(--color-text-secondary)]">
+            <p class="mx-auto max-w-2xl text-lg text-text-secondary">
                 Built in Rust, designed around your keyboard. Cmdr is in open beta: every feature carries an honest
                 status pill, and hovering a pill explains what the status means.
             </p>
         </header>
 
         <!-- Total Commander switcher callout -->
-        <p class="mb-10 text-center text-sm text-[var(--color-text-tertiary)]">
+        <p class="mb-10 text-center text-sm text-text-tertiary">
             Switching from Total Commander? See <a href="/blog/total-commander-for-macos" class="link-muted"
                 >how Cmdr compares</a
             >.
         </p>
 
         <!-- One bento: every feature, one card each -->
-        <div class="grid grid-cols-1 gap-4 [grid-auto-flow:dense] md:grid-cols-2 lg:grid-cols-3">
+        <div class="grid grid-flow-dense grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {
                 resolved.map((card) => (
                     <section
                         id={card.id}
                         class:list={[
-                            'flex scroll-mt-24 flex-col gap-2 rounded-2xl border bg-[var(--color-surface)] p-5',
+                            'flex scroll-mt-24 flex-col gap-2 rounded-2xl border bg-surface p-5',
                             card.flagship && 'md:col-span-2',
                             card.feature.status === 'planned'
-                                ? 'border-dashed border-[var(--color-border)]'
-                                : 'border-[var(--color-border)]',
+                                ? 'border-dashed border-border'
+                                : 'border-border',
                         ]}
                     >
                         <div class="flex items-center gap-2.5">
                             <Icon name={card.icon} size={24} />
-                            <h2 class="text-base font-semibold text-[var(--color-text-primary)]">{card.title}</h2>
+                            <h2 class="text-base font-semibold text-text-primary">{card.title}</h2>
                         </div>
-                        <p class="flex-1 text-sm text-[var(--color-text-secondary)]">
+                        <p class="flex-1 text-sm text-text-secondary">
                             {card.flagship ? card.blurb : card.feature.note}
                         </p>
                         <div class="mt-1 flex flex-wrap items-center gap-2">
                             <span
-                                class="rounded-full bg-[var(--color-accent)]/10 px-2.5 py-1 text-xs font-medium whitespace-nowrap text-[var(--color-accent-text)]"
+                                class="rounded-full bg-accent/10 px-2.5 py-1 text-xs font-medium whitespace-nowrap text-accent-text"
                             >
                                 {card.category}
                             </span>
@@ -160,7 +160,7 @@ const resolved = cards.map((card) => {
                                     href={card.feature.issueUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    class="text-xs text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+                                    class="text-xs text-accent-text underline underline-offset-2 hover:text-accent-hover"
                                 >
                                     Track on GitHub
                                 </a>
@@ -171,32 +171,32 @@ const resolved = cards.map((card) => {
             }
         </div>
 
-        <p class="mt-10 text-center text-sm text-[var(--color-text-tertiary)]">
+        <p class="mt-10 text-center text-sm text-text-tertiary">
             Found something rough that's not listed? <a
                 href="https://github.com/vdavid/cmdr/issues"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+                class="text-accent-text underline underline-offset-2 hover:text-accent-hover"
                 >Report an issue</a
             > and it gets fixed faster. For timing, see the <a
                 href="/roadmap"
-                class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+                class="text-accent-text underline underline-offset-2 hover:text-accent-hover"
                 >roadmap</a
             >.
         </p>
 
         <!-- Download CTA -->
         <div class="mt-20 text-center">
-            <h2 class="mb-4 text-2xl font-bold text-[var(--color-text-primary)]">
+            <h2 class="mb-4 text-2xl font-bold text-text-primary">
                 Wanna see it for yourself? Get Cmdr now.
             </h2>
-            <p class="mb-8 text-[var(--color-text-secondary)]">
+            <p class="mb-8 text-text-secondary">
                 Free forever for personal use. No signup, no trial period.
             </p>
             <div class="mx-auto max-w-xs">
                 <DownloadButton variant="card" class="w-full" />
             </div>
-            <p class="mt-3 text-sm text-[var(--color-text-tertiary)]">macOS only · Source-available (BSL 1.1)</p>
+            <p class="mt-3 text-sm text-text-tertiary">macOS only · Source-available (BSL 1.1)</p>
         </div>
 
         <!-- Newsletter -->

--- a/apps/website/src/pages/pricing.astro
+++ b/apps/website/src/pages/pricing.astro
@@ -59,17 +59,17 @@ const faq = [
     {
         question: 'Can I see the source code?',
         answer: "Yes! Cmdr is source-available. You can view the code, learn from it, verify that there are no nasty backdoors or any other weird stuff going on. You just can't reuse or republish the code or the app. The BSL 1.1 license converts to AGPL-3.0 after 3 years, meaning that if the dev gets hit by a bus, you won't end up without updates forever.",
-        answerHtml: 'Yes! Cmdr is <a href="https://github.com/vdavid/cmdr" target="_blank" rel="noopener noreferrer" class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]">source-available</a>. You can view the code, learn from it, verify that there are no nasty backdoors or any other weird stuff going on. Just you can\'t reuse/republish the code or the app. The BSL 1.1 license converts to AGPL-3.0 after 3 years, meaning that if the dev gets hit by a bus, you won\'t end up without updates forever.',
+        answerHtml: 'Yes! Cmdr is <a href="https://github.com/vdavid/cmdr" target="_blank" rel="noopener noreferrer" class="text-accent-text underline underline-offset-2 hover:text-accent-hover">source-available</a>. You can view the code, learn from it, verify that there are no nasty backdoors or any other weird stuff going on. Just you can\'t reuse/republish the code or the app. The BSL 1.1 license converts to AGPL-3.0 after 3 years, meaning that if the dev gets hit by a bus, you won\'t end up without updates forever.',
     },
     {
         question: 'What if I regret the purchase?',
         answer: "30-day, no-questions-asked refund. Send an email and you'll get your money back.",
-        answerHtml: '<a href="/refund" class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]">30-day, no-questions-asked refund</a>. Send an email and you\'ll get your money back.',
+        answerHtml: '<a href="/refund" class="text-accent-text underline underline-offset-2 hover:text-accent-hover">30-day, no-questions-asked refund</a>. Send an email and you\'ll get your money back.',
     },
     {
         question: 'Do you offer team licenses?',
         answer: 'Each person needs their own license. For teams of 10+ people, email legal@getcmdr.com for volume pricing.',
-        answerHtml: 'Each person needs their own license. For teams of 10+ people, email <a href="mailto:legal@getcmdr.com" class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]">legal@getcmdr.com</a> for volume pricing.',
+        answerHtml: 'Each person needs their own license. For teams of 10+ people, email <a href="mailto:legal@getcmdr.com" class="text-accent-text underline underline-offset-2 hover:text-accent-hover">legal@getcmdr.com</a> for volume pricing.',
     },
 ]
 ---
@@ -79,10 +79,10 @@ const faq = [
     <main class="mx-auto max-w-5xl px-6 pt-32 pb-24">
         <!-- Hero -->
         <header class="mb-16 text-center">
-            <h1 class="mb-4 text-3xl font-bold tracking-tight text-[var(--color-text-primary)] md:text-4xl lg:text-5xl">
+            <h1 class="mb-4 text-3xl font-bold tracking-tight text-text-primary md:text-4xl lg:text-5xl">
                 Free forever for personal use
             </h1>
-            <p class="text-lg text-[var(--color-text-secondary)]">
+            <p class="text-lg text-text-secondary">
                 Use Cmdr at home without paying a cent. Less than a coffee a month for work.
             </p>
         </header>
@@ -90,76 +90,76 @@ const faq = [
         <!-- Download Button -->
         <div class="mb-16 text-center">
             <DownloadButton variant="pricing" />
-            <p class="mt-3 text-sm text-[var(--color-text-tertiary)]">macOS only · Source-available (BSL 1.1)</p>
+            <p class="mt-3 text-sm text-text-tertiary">macOS only · Source-available (BSL 1.1)</p>
         </div>
 
         <!-- Pricing Cards -->
         <div class="mb-16 grid gap-6 md:grid-cols-3">
             <!-- Personal (Free) -->
-            <div class="flex flex-col rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
+            <div class="flex flex-col rounded-2xl border border-border bg-surface p-6">
                 <div class="mb-4">
-                    <h2 class="text-lg font-semibold text-[var(--color-text-primary)]">Personal</h2>
-                    <p class="text-sm text-[var(--color-text-tertiary)]">For hobbyists and side projects</p>
+                    <h2 class="text-lg font-semibold text-text-primary">Personal</h2>
+                    <p class="text-sm text-text-tertiary">For hobbyists and side projects</p>
                 </div>
                 <div class="mb-6">
-                    <span class="text-3xl font-bold text-[var(--color-text-primary)]">Free</span>
-                    <span class="text-[var(--color-text-tertiary)]"> forever</span>
+                    <span class="text-3xl font-bold text-text-primary">Free</span>
+                    <span class="text-text-tertiary"> forever</span>
                 </div>
-                <ul class="mb-6 space-y-2 text-sm text-[var(--color-text-secondary)]">
+                <ul class="mb-6 space-y-2 text-sm text-text-secondary">
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
+                        <span class="text-accent-text">✓</span>
                         All features
                     </li>
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
+                        <span class="text-accent-text">✓</span>
                         Unlimited machines
                     </li>
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
+                        <span class="text-accent-text">✓</span>
                         Automatic updates
                     </li>
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-text-tertiary)]">✗</span>
-                        <span class="text-[var(--color-text-tertiary)]">Commercial use</span>
+                        <span class="text-text-tertiary">✗</span>
+                        <span class="text-text-tertiary">Commercial use</span>
                     </li>
                 </ul>
-                <div class="mt-auto py-2 text-center text-sm text-[var(--color-text-tertiary)]">Just download and use it</div>
+                <div class="mt-auto py-2 text-center text-sm text-text-tertiary">Just download and use it</div>
             </div>
 
             <!-- Commercial Subscription -->
             <div
-                class="relative mt-4 flex flex-col rounded-2xl border-2 border-[var(--color-accent)] bg-[var(--color-surface)] p-6 shadow-lg md:mt-0"
+                class="relative mt-4 flex flex-col rounded-2xl border-2 border-accent bg-surface p-6 shadow-lg md:mt-0"
             >
                 <div
-                    class="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-[var(--color-accent)] px-3 py-1 text-xs font-medium text-[var(--color-accent-contrast)]"
+                    class="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-accent px-3 py-1 text-xs font-medium text-accent-contrast"
                 >
                     Most popular
                 </div>
                 <div class="mb-4">
-                    <h2 class="text-lg font-semibold text-[var(--color-text-primary)]">Commercial</h2>
-                    <p class="text-sm text-[var(--color-text-tertiary)]">For work use</p>
+                    <h2 class="text-lg font-semibold text-text-primary">Commercial</h2>
+                    <p class="text-sm text-text-tertiary">For work use</p>
                 </div>
                 <div class="mb-6">
-                    <span class="text-lg text-[var(--color-text-tertiary)] line-through">$79</span>
-                    <span class="text-3xl font-bold text-[var(--color-text-primary)]"> $59</span>
-                    <span class="text-[var(--color-text-tertiary)]">/year</span>
-                    <div class="mt-1 text-xs text-[var(--color-accent-text)]">First 1,000 licenses</div>
+                    <span class="text-lg text-text-tertiary line-through">$79</span>
+                    <span class="text-3xl font-bold text-text-primary"> $59</span>
+                    <span class="text-text-tertiary">/year</span>
+                    <div class="mt-1 text-xs text-accent-text">First 1,000 licenses</div>
                 </div>
-                <ul class="mb-6 space-y-2 text-sm text-[var(--color-text-secondary)]">
+                <ul class="mb-6 space-y-2 text-sm text-text-secondary">
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
+                        <span class="text-accent-text">✓</span>
                         All features
                     </li>
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
-                        <strong class="text-[var(--color-text-primary)]">Commercial use</strong>
+                        <span class="text-accent-text">✓</span>
+                        <strong class="text-text-primary">Commercial use</strong>
                     </li>
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
+                        <span class="text-accent-text">✓</span>
                         Per user, your own devices
                     </li>
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
+                        <span class="text-accent-text">✓</span>
                         Auto-renews annually
                     </li>
                 </ul>
@@ -167,37 +167,37 @@ const faq = [
                     type="button"
                     data-paddle-price="commercialSubscription"
                     disabled={!isPaddleConfigured}
-                    class="mt-auto block w-full cursor-pointer rounded-lg bg-[var(--color-accent)] py-2 text-center text-sm font-medium text-[var(--color-accent-contrast)] transition-all duration-200 hover:bg-[var(--color-accent-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+                    class="mt-auto block w-full cursor-pointer rounded-lg bg-accent py-2 text-center text-sm font-medium text-accent-contrast transition-all duration-200 hover:bg-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary disabled:cursor-not-allowed disabled:opacity-50"
                 >
                     Buy commercial license
                 </button>
             </div>
 
             <!-- Commercial Perpetual -->
-            <div class="flex flex-col rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
+            <div class="flex flex-col rounded-2xl border border-border bg-surface p-6">
                 <div class="mb-4">
-                    <h2 class="text-lg font-semibold text-[var(--color-text-primary)]">Perpetual</h2>
-                    <p class="text-sm text-[var(--color-text-tertiary)]">Buy once, use forever</p>
+                    <h2 class="text-lg font-semibold text-text-primary">Perpetual</h2>
+                    <p class="text-sm text-text-tertiary">Buy once, use forever</p>
                 </div>
                 <div class="mb-6">
-                    <span class="text-3xl font-bold text-[var(--color-text-primary)]">$199</span>
-                    <span class="text-[var(--color-text-tertiary)]"> one-time</span>
+                    <span class="text-3xl font-bold text-text-primary">$199</span>
+                    <span class="text-text-tertiary"> one-time</span>
                 </div>
-                <ul class="mb-6 space-y-2 text-sm text-[var(--color-text-secondary)]">
+                <ul class="mb-6 space-y-2 text-sm text-text-secondary">
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
+                        <span class="text-accent-text">✓</span>
                         All features
                     </li>
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
-                        <strong class="text-[var(--color-text-primary)]">Commercial use</strong>
+                        <span class="text-accent-text">✓</span>
+                        <strong class="text-text-primary">Commercial use</strong>
                     </li>
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
+                        <span class="text-accent-text">✓</span>
                         Per user, your own devices
                     </li>
                     <li class="flex items-start gap-2">
-                        <span class="text-[var(--color-accent-text)]">✓</span>
+                        <span class="text-accent-text">✓</span>
                         1 year of updates
                     </li>
                 </ul>
@@ -205,7 +205,7 @@ const faq = [
                     type="button"
                     data-paddle-price="commercialPerpetual"
                     disabled={!isPaddleConfigured}
-                    class="mt-auto block w-full cursor-pointer rounded-lg border border-[var(--color-border)] py-2 text-center text-sm font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-surface-elevated)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-50"
+                    class="mt-auto block w-full cursor-pointer rounded-lg border border-border py-2 text-center text-sm font-medium text-text-primary transition-colors hover:bg-surface-elevated focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-50"
                 >
                     Buy perpetual license
                 </button>
@@ -223,15 +223,15 @@ const faq = [
             })),
         })} />
         <section>
-            <h2 class="mb-8 text-center text-2xl font-bold text-[var(--color-text-primary)]">
+            <h2 class="mb-8 text-center text-2xl font-bold text-text-primary">
                 Frequently asked questions
             </h2>
 
             <div class="grid gap-6 md:grid-cols-2">
                 {faq.map(({ question, answer, answerHtml }) => (
-                    <div class="rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-surface)] p-5">
-                        <h3 class="mb-2 font-semibold text-[var(--color-text-primary)]">{question}</h3>
-                        <p class="text-[var(--color-text-secondary)]" set:html={answerHtml ?? answer} />
+                    <div class="rounded-lg border border-border-subtle bg-surface p-5">
+                        <h3 class="mb-2 font-semibold text-text-primary">{question}</h3>
+                        <p class="text-text-secondary" set:html={answerHtml ?? answer} />
                     </div>
                 ))}
             </div>
@@ -241,61 +241,61 @@ const faq = [
 
     {/* Organization name modal for commercial checkouts */}
     <div id="org-name-modal" class="fixed inset-0 z-50 hidden items-center justify-center bg-black/60 backdrop-blur-sm" role="dialog" aria-modal="true" aria-labelledby="org-modal-title">
-        <div class="relative mx-4 w-full max-w-md rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-2xl">
+        <div class="relative mx-4 w-full max-w-md rounded-2xl border border-border bg-surface p-6 shadow-2xl">
             <button
                 type="button"
                 id="org-modal-close"
-                class="absolute right-4 top-4 rounded text-[var(--color-text-tertiary)] transition-colors hover:text-[var(--color-text-primary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+                class="absolute top-4 right-4 rounded-sm text-text-tertiary transition-colors hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                 aria-label="Close"
             >
-                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <svg class="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
             </button>
 
-            <div class="mb-1 text-xs font-medium uppercase tracking-wide text-[var(--color-accent-text)]">
+            <div class="mb-1 text-xs font-medium tracking-wide text-accent-text uppercase">
                 Step 1 of 2
             </div>
-            <h2 id="org-modal-title" class="mb-2 text-xl font-semibold text-[var(--color-text-primary)]">
+            <h2 id="org-modal-title" class="mb-2 text-xl font-semibold text-text-primary">
                 Company details
             </h2>
-            <p class="mb-6 text-sm text-[var(--color-text-secondary)]">
+            <p class="mb-6 text-sm text-text-secondary">
                 Enter your company name as you'd like it to appear on your invoice.
             </p>
 
             <div class="mb-4">
-                <label for="org-name-input" class="mb-2 block text-sm font-medium text-[var(--color-text-primary)]">
+                <label for="org-name-input" class="mb-2 block text-sm font-medium text-text-primary">
                     Company name
                 </label>
                 <input
                     type="text"
                     id="org-name-input"
                     placeholder="Example: Acme Inc."
-                    class="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-background)] px-4 py-3 text-[var(--color-text-primary)] placeholder-[var(--color-text-tertiary)] transition-colors focus:border-[var(--color-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+                    class="w-full rounded-lg border border-border bg-background px-4 py-3 text-text-primary placeholder-text-tertiary transition-colors focus:border-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                 />
             </div>
 
             <div class="mb-6">
-                <label for="org-email-input" class="mb-2 block text-sm font-medium text-[var(--color-text-primary)]">
+                <label for="org-email-input" class="mb-2 block text-sm font-medium text-text-primary">
                     Email
                 </label>
                 <input
                     type="email"
                     id="org-email-input"
                     placeholder="Example: you@acme.com"
-                    class="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-background)] px-4 py-3 text-[var(--color-text-primary)] placeholder-[var(--color-text-tertiary)] transition-colors focus:border-[var(--color-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+                    class="w-full rounded-lg border border-border bg-background px-4 py-3 text-text-primary placeholder-text-tertiary transition-colors focus:border-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                 />
             </div>
 
             <button
                 type="button"
                 id="org-modal-continue"
-                class="w-full cursor-pointer rounded-lg bg-[var(--color-accent)] py-3 text-center font-medium text-[var(--color-accent-contrast)] transition-all duration-200 hover:bg-[var(--color-accent-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+                class="w-full cursor-pointer rounded-lg bg-accent py-3 text-center font-medium text-accent-contrast transition-all duration-200 hover:bg-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary disabled:cursor-not-allowed disabled:opacity-50"
             >
                 Continue to payment
             </button>
 
-            <p class="mt-4 text-center text-xs text-[var(--color-warning)]">
+            <p class="mt-4 text-center text-xs text-warning">
                 <strong>Need your company address on the invoice?<br /> Click "Add VAT number" before entering your card details.</strong>
             </p>
         </div>

--- a/apps/website/src/pages/renew.astro
+++ b/apps/website/src/pages/renew.astro
@@ -8,56 +8,56 @@ import Footer from '../components/Footer.astro'
     <Header />
     <main class="mx-auto max-w-2xl px-6 pt-32 pb-24">
         <header class="mb-12 text-center">
-            <h1 class="mb-4 text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">Renew your license</h1>
-            <p class="text-lg text-[var(--color-text-secondary)]">
+            <h1 class="mb-4 text-4xl font-bold tracking-tight text-text-primary">Renew your license</h1>
+            <p class="text-lg text-text-secondary">
                 Keep using Cmdr at work with a renewed commercial license.
             </p>
         </header>
 
-        <div class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8">
-            <h2 class="mb-4 text-xl font-semibold text-[var(--color-text-primary)]">Commercial subscription</h2>
-            <p class="mb-6 text-[var(--color-text-secondary)]">
+        <div class="rounded-2xl border border-border bg-surface p-8">
+            <h2 class="mb-4 text-xl font-semibold text-text-primary">Commercial subscription</h2>
+            <p class="mb-6 text-text-secondary">
                 Your subscription auto-renews annually. If your subscription has lapsed or you'd like to renew early,
                 use the button below.
             </p>
 
-            <div class="mb-6 rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-background)] p-4">
+            <div class="mb-6 rounded-lg border border-border-subtle bg-background p-4">
                 <div class="flex items-baseline justify-between">
-                    <span class="text-[var(--color-text-secondary)]">Annual renewal</span>
-                    <span class="text-2xl font-bold text-[var(--color-text-primary)]">$59/year</span>
+                    <span class="text-text-secondary">Annual renewal</span>
+                    <span class="text-2xl font-bold text-text-primary">$59/year</span>
                 </div>
             </div>
 
             <a
                 href="#"
-                class="mb-4 block w-full rounded-lg bg-[var(--color-accent)] py-3 text-center font-medium text-[var(--color-accent-contrast)] transition-all duration-200 hover:bg-[var(--color-accent-hover)]"
+                class="mb-4 block w-full rounded-lg bg-accent py-3 text-center font-medium text-accent-contrast transition-all duration-200 hover:bg-accent-hover"
             >
                 Renew subscription
             </a>
 
-            <p class="text-center text-sm text-[var(--color-text-tertiary)]">
+            <p class="text-center text-sm text-text-tertiary">
                 You'll use the same license key, so no need to re-enter anything in the app.
             </p>
         </div>
 
         <div class="mt-8 text-center">
-            <h3 class="mb-2 font-semibold text-[var(--color-text-primary)]">Prefer a perpetual license?</h3>
-            <p class="mb-4 text-[var(--color-text-secondary)]">Pay once ($199) and never worry about renewals again.</p>
+            <h3 class="mb-2 font-semibold text-text-primary">Prefer a perpetual license?</h3>
+            <p class="mb-4 text-text-secondary">Pay once ($199) and never worry about renewals again.</p>
             <a
                 href="/pricing"
-                class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+                class="text-accent-text underline underline-offset-2 hover:text-accent-hover"
             >
                 View all pricing options →
             </a>
         </div>
 
-        <div class="mt-12 rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-surface)] p-6">
-            <h3 class="mb-2 font-semibold text-[var(--color-text-primary)]">Questions about your license?</h3>
-            <p class="text-[var(--color-text-secondary)]">
+        <div class="mt-12 rounded-lg border border-border-subtle bg-surface p-6">
+            <h3 class="mb-2 font-semibold text-text-primary">Questions about your license?</h3>
+            <p class="text-text-secondary">
                 If you're having trouble renewing or need help with your license, email
                 <a
                     href="mailto:legal@getcmdr.com"
-                    class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+                    class="text-accent-text underline underline-offset-2 hover:text-accent-hover"
                     >legal@getcmdr.com</a
                 >. Happy to help.
             </p>

--- a/apps/website/src/pages/roadmap.astro
+++ b/apps/website/src/pages/roadmap.astro
@@ -15,16 +15,16 @@ import { roadmapSections } from '../lib/roadmap'
     <Header />
     <main class="mx-auto max-w-4xl px-6 pt-32 pb-24">
         <header class="mb-10">
-            <h1 class="mb-4 text-3xl font-bold tracking-tight text-[var(--color-text-primary)] md:text-4xl">Roadmap</h1>
-            <p class="text-[var(--color-text-secondary)]">
+            <h1 class="mb-4 text-3xl font-bold tracking-tight text-text-primary md:text-4xl">Roadmap</h1>
+            <p class="text-text-secondary">
                 What's shipped, what's next. Wondering how solid each feature is? See the <a
                     href="/features"
-                    class="text-[var(--color-accent-text)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+                    class="text-accent-text underline underline-offset-2 hover:text-accent-hover"
                     >feature status</a
                 > page.
             </p>
             <p>&nbsp;</p>
-            <p class="text-[var(--color-text-secondary)]">
+            <p class="text-text-secondary">
                 I'm also pretty proud of Cmdr's history, so keeping the list of the major milestones here.
             </p>
         </header>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+      eslint-plugin-better-tailwindcss:
+        specifier: 4.7.0
+        version: 4.7.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(oxlint@1.78.0)(tailwindcss@4.3.3)(typescript@6.0.3)
       eslint-plugin-svelte:
         specifier: ^3.20.0
         version: 3.23.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(svelte@5.56.8(@typescript-eslint/types@8.68.0))
@@ -226,7 +229,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       axe-core:
         specifier: ^4.12.1
-        version: 4.12.1
+        version: 4.13.0
       eslint:
         specifier: ^10.7.0
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
@@ -369,6 +372,9 @@ importers:
       eslint-plugin-astro:
         specifier: ^1.7.0
         version: 1.7.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      eslint-plugin-better-tailwindcss:
+        specifier: 4.7.0
+        version: 4.7.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(oxlint@1.78.0)(tailwindcss@4.3.3)(typescript@6.0.3)
       globals:
         specifier: ^17.7.0
         version: 17.11.0
@@ -985,6 +991,10 @@ packages:
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@eslint/css-tree@4.0.5':
+    resolution: {integrity: sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@eslint/js@10.0.1':
     resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1437,13 +1447,6 @@ packages:
 
   '@logtape/logtape@2.3.0':
     resolution: {integrity: sha512-s/pxCgf9Gg75ypTV/bRUq355Dy/JP/zUJWfgJQPO5pTkXC23X2AXBcmBBgFiWH+bSi4yiX/G06qGV8CdAWD3SA==}
-
-  '@napi-rs/wasm-runtime@1.2.1':
-    resolution: {integrity: sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
-      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
@@ -2601,10 +2604,6 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/scope-manager@8.66.0':
-    resolution: {integrity: sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/scope-manager@8.68.0':
     resolution: {integrity: sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2621,10 +2620,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/types@8.66.0':
-    resolution: {integrity: sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.68.0':
     resolution: {integrity: sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==}
@@ -2643,16 +2638,17 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.66.0':
-    resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/visitor-keys@8.68.0':
     resolution: {integrity: sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
@@ -3129,10 +3125,6 @@ packages:
 
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
-
-  axe-core@4.12.1:
-    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
-    engines: {node: '>=4'}
 
   axe-core@4.13.0:
     resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
@@ -3756,6 +3748,19 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.57.0'
+
+  eslint-plugin-better-tailwindcss@4.7.0:
+    resolution: {integrity: sha512-lrdlVW4pzLPj/zX5HRqMhKPesGijDfRhnSRJMlNcsrCyJHsndmHCLKTiRNa1eREUZ6G3D3QjdLc+G4tlfGrmkw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+      oxlint: ^1.35.0
+      tailwindcss: ^3.3.0 || ^4.1.17
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      oxlint:
+        optional: true
 
   eslint-plugin-svelte@3.23.0:
     resolution: {integrity: sha512-n9jRklDqy0+W834568a4ZIZTK7DHXxvvHHxxGP8nNq7N//pOZMubttskHOquyGgfTR4Z05q2NdGNlsTpIEA48w==}
@@ -4458,6 +4463,11 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   jsonc-parser@2.3.1:
     resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
 
@@ -4799,6 +4809,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdn-data@2.29.0:
+    resolution: {integrity: sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -5810,6 +5823,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
@@ -5916,6 +5933,15 @@ packages:
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
+
+  tailwind-csstree@0.3.3:
+    resolution: {integrity: sha512-je9J5UYRsTJqAjYrIBMMlge8T/rreRd44pJxgG5Zx/zeo4kAC/liUKqzztRZrGlYRJLvIf2Cb1DVJMTXSzEShA==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      '@eslint/css': '>=1.0.0'
+    peerDependenciesMeta:
+      '@eslint/css':
+        optional: true
 
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
@@ -6026,6 +6052,14 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tsconfig-paths-webpack-plugin@4.2.0:
+    resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
+    engines: {node: '>=10.13.0'}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -6258,6 +6292,14 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -7313,6 +7355,11 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/css-tree@4.0.5':
+    dependencies:
+      mdn-data: 2.29.0
+      source-map-js: 1.2.1
+
   '@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))':
     optionalDependencies:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
@@ -7574,7 +7621,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 1.11.3
     optional: true
 
   '@img/sharp-wasm32@0.35.4':
@@ -7691,20 +7738,6 @@ snapshots:
 
   '@logtape/logtape@2.3.0': {}
 
-  '@napi-rs/wasm-runtime@1.2.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.2.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
-    dependencies:
-      '@emnapi/core': 2.0.0-alpha.3
-      '@emnapi/runtime': 2.0.0-alpha.3
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -7712,10 +7745,24 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -7789,7 +7836,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.140.0':
@@ -7857,7 +7904,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
@@ -8111,7 +8158,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 2.0.0-alpha.3
       '@emnapi/runtime': 2.0.0-alpha.3
-      '@napi-rs/wasm-runtime': 1.2.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.2.1':
@@ -8547,11 +8594,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.66.0':
-    dependencies:
-      '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/visitor-keys': 8.66.0
-
   '@typescript-eslint/scope-manager@8.68.0':
     dependencies:
       '@typescript-eslint/types': 8.68.0
@@ -8572,8 +8614,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/types@8.66.0': {}
 
   '@typescript-eslint/types@8.68.0': {}
 
@@ -8603,17 +8643,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.66.0':
-    dependencies:
-      '@typescript-eslint/types': 8.66.0
-      eslint-visitor-keys: 5.0.1
-
   '@typescript-eslint/visitor-keys@8.68.0':
     dependencies:
       '@typescript-eslint/types': 8.68.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.3': {}
+
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.2(typescript@6.0.3)
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -9413,8 +9452,8 @@ snapshots:
   astro-eslint-parser@1.4.0(supports-color@10.2.2):
     dependencies:
       '@astrojs/compiler': 3.0.1
-      '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/scope-manager': 8.68.0
+      '@typescript-eslint/types': 8.68.0
       astrojs-compiler-sync: 1.1.1(@astrojs/compiler@3.0.1)
       debug: 4.4.3(supports-color@10.2.2)
       entities: 7.0.1
@@ -9525,8 +9564,6 @@ snapshots:
       synckit: 0.11.13
 
   aws4fetch@1.0.20: {}
-
-  axe-core@4.12.1: {}
 
   axe-core@4.13.0: {}
 
@@ -10111,7 +10148,7 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/types': 8.68.0
       astro-eslint-parser: 1.4.0(supports-color@10.2.2)
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.6.5(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
@@ -10120,6 +10157,24 @@ snapshots:
       postcss-selector-parser: 7.1.5
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-better-tailwindcss@4.7.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(oxlint@1.78.0)(tailwindcss@4.3.3)(typescript@6.0.3):
+    dependencies:
+      '@eslint/css-tree': 4.0.5
+      '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@6.0.3))
+      enhanced-resolve: 5.24.2
+      jiti: 2.7.0
+      synckit: 0.11.13
+      tailwind-csstree: 0.3.3
+      tailwindcss: 4.3.3
+      tsconfig-paths-webpack-plugin: 4.2.0
+      valibot: 1.4.2(typescript@6.0.3)
+    optionalDependencies:
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
+      oxlint: 1.78.0
+    transitivePeerDependencies:
+      - '@eslint/css'
+      - typescript
 
   eslint-plugin-svelte@3.23.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(svelte@5.56.8(@typescript-eslint/types@8.68.0)):
     dependencies:
@@ -10948,6 +11003,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json5@2.2.3: {}
+
   jsonc-parser@2.3.1: {}
 
   jsonc-parser@3.3.1: {}
@@ -11022,7 +11079,7 @@ snapshots:
     dependencies:
       '@paulirish/trace_engine': 0.0.53
       '@sentry/node': 7.120.4
-      axe-core: 4.12.1
+      axe-core: 4.13.0
       chrome-launcher: 1.2.1(supports-color@10.2.2)
       configstore: 5.0.1
       csp_evaluator: 1.1.5
@@ -11354,6 +11411,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
+
+  mdn-data@2.29.0: {}
 
   media-typer@0.3.0: {}
 
@@ -12672,6 +12731,8 @@ snapshots:
     dependencies:
       ansi-regex: 6.3.0
 
+  strip-bom@3.0.0: {}
+
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@2.0.1: {}
@@ -12835,6 +12896,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tailwind-csstree@0.3.3: {}
+
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
@@ -12939,6 +13002,19 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  tsconfig-paths-webpack-plugin@4.2.0:
+    dependencies:
+      chalk: 4.1.2
+      enhanced-resolve: 5.24.2
+      tapable: 2.3.3
+      tsconfig-paths: 4.2.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@1.14.1: {}
 
@@ -13125,6 +13201,10 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@8.3.2: {}
+
+  valibot@1.4.2(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
Closes #62.

Two commits, as the issue asked: the mechanical sweep first, then the rules.

## 1. The sweep (`refactor(website)`)

All 255 `text-[var(--color-…)]`-style utilities on the website now use their `@theme` names (`text-text-secondary`, `bg-accent/10`, `border-border`), plus the other canonical forms Tailwind suggests: `[grid-auto-flow:dense]` → `grid-flow-dense`, `h-6 w-6` → `size-6`, `left-0 right-0` → `inset-x-0`, `-mx-1 -my-1` → `-m-1`, `text-3xl leading-tight` → `text-3xl/tight`, `rounded` → `rounded-sm`, `bg-gradient-to-br` → `bg-linear-to-br`, and Tailwind's official class order. The three `answerHtml` strings in `pricing.astro` (HTML inside JS strings, invisible to any linter) were rewritten by hand.

The analytics dashboard got the same pass: class order plus a few collapses (`h-2 w-2` → `size-2`, `text-xs leading-relaxed` → `text-xs/relaxed`).

**Rendering is unchanged.** I built the site before and after and diffed the emitted CSS rule bodies: every color declaration is identical, and the only deltas are the collapsed utilities listed above, which resolve to the same values. Light-mode overrides keep applying because the short utilities reference the same variables. I could not do a visual pass in both themes in this environment (no Docker for the Playwright baselines), so a quick look at the deployed preview in light mode is still worth a minute.

## 2. The rules (`feat(website)`)

`eslint-plugin-better-tailwindcss` 4.7.0 (released 2026-07-19, well past the 3-day window) wired into both `eslint.config.js` files, all as errors:

- On: `enforce-canonical-classes`, `enforce-consistent-class-order`, `no-conflicting-classes`, `no-deprecated-classes`, `no-duplicate-classes`, `no-unnecessary-whitespace`.
- Off, on purpose: `enforce-shorthand-classes` / `enforce-consistent-important-position` / `enforce-consistent-variable-syntax` (subsumed by the canonical rule), `no-unknown-classes` (the site mixes Tailwind with BEM classes styled in scoped `<style>`, which the plugin can't see), `enforce-consistent-line-wrapping` (would fight oxfmt).

Findings from wiring it up, recorded in `apps/website/DETAILS.md` § Tailwind class hygiene:

- The plugin's defaults already cover Astro's `class:list` (strings and object keys), so `features.astro`'s arrays and conditionals are linted without extra config. Verified by reading `getDefaultSelectors()` on 4.7.0.
- Tailwind's canonicalizer sometimes stops at the variable shorthand (`border-(--color-border)`) and accepts the theme name too; the house style is the theme name.
- The plugin's optional peer dep on `oxlint` made the dashboard's knip `ignoreDependencies` entry a config hint; it's removed.
- `.vscode/` is gitignored, so `"tailwindCSS.lint.suggestCanonicalClasses": "ignore"` is documented rather than shipped. Set it locally.

## Checks

`pnpm check website dashboard` passes (eslint, typecheck, build, knip, tests, svelte-check, stylelint, analytics-injection) plus the doc checks (`claude-md-length`, `dead-links`, `docs-reachable`, `resident-budget`, `file-length`, `oxfmt`). Only `website-docker-build` didn't run here (no Docker daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZhjrpwBR8TrJdMvBS6tts

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZhjrpwBR8TrJdMvBS6tts)_