### PR TITLE
fix(viewer): transparent image pixels now show a visible checkerboard instead of reading as solid white

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -22,6 +22,12 @@
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f5f5f5;
   --color-bg-tertiary: #e8e8e8;
+  /* Checkerboard behind transparent image pixels (file viewer's image stage). A
+     dedicated pair, NOT primary/tertiary: those sit ~1.2:1 apart, which on 10px
+     cells reads as a flat surface, so transparency looked like solid white. Tile
+     vs base is ~1.6:1 here, the Preview.app / Photoshop "light" checker range. */
+  --color-checkerboard-base: #ffffff;
+  --color-checkerboard-tile: #cccccc;
   /* Inactive tab surface — slightly darker than `--color-bg-secondary` in
      light mode, slightly lighter in dark mode. The contrast against the
      active tab (which uses `bg-secondary`) is what conveys "this tab
@@ -659,6 +665,10 @@
     --color-bg-primary: #1e1e1e;
     --color-bg-secondary: #2a2a2a;
     --color-bg-tertiary: #333333;
+    /* Checkerboard pair for dark mode: lifted off `--color-bg-primary` so the stage
+       reads as a distinct surface, tile ~1.7:1 against base. */
+    --color-checkerboard-base: #262626;
+    --color-checkerboard-tile: #404040;
     /* Inactive tab surface: darker than secondary so unselected tabs read
        as recessed against the active tab. Tab-bar uses this too. */
     --color-bg-tab-inactive: #1e1e1e;

--- a/apps/desktop/src/routes/viewer/DETAILS.md
+++ b/apps/desktop/src/routes/viewer/DETAILS.md
@@ -66,6 +66,10 @@ source for the origin form). `openViewerSession` hands the result to `media.setF
   `viewer_open_as_text` (text) or `viewer_open` (re-classifies → media), swaps to it, and closes the old session
   EXPLICITLY (different id). The page tears down per-session listeners first because `openViewerSession` re-attaches
   them. No backend change: `viewer_open` re-classification is what re-derives the media kind.
+- **The image stage's checkerboard uses the dedicated `--color-checkerboard-base` / `--color-checkerboard-tile` tokens
+  (`app.css`), not the general surface tokens.** `--color-bg-primary` vs `--color-bg-tertiary` is ~1.2:1 (light) and
+  ~1.5:1 (dark), which on 10px cells rendered as a flat surface: the checker was "there" but invisible, so transparent
+  PNGs looked opaque. Keep the pair at roughly 1.6:1 or more per theme (Preview.app / Photoshop "light" checker range).
 - CSP: the `cmdr-media:` token is in `img-src` + `object-src` (`tauri.conf.json`); `viewer-media.spec.ts` locks "no
   `cmdr-media`/`img-src`/`object-src` violation". WKWebView applies EXIF orientation by default (phone photos upright).
 

--- a/apps/desktop/src/routes/viewer/MediaImageView.svelte
+++ b/apps/desktop/src/routes/viewer/MediaImageView.svelte
@@ -215,14 +215,17 @@
     overflow: hidden;
     outline: none;
     /* Checkerboard behind transparency, fixed in screen space (background-attachment
-       isn't needed since the stage itself doesn't scroll). Two layered gradients make
-       the classic 2-tone checker using design tokens. */
-    background-color: var(--color-bg-primary);
+       isn't needed since the stage itself doesn't scroll). Four layered hard-stop
+       gradients make the classic 2-tone checker. The colors are the dedicated
+       `--color-checkerboard-*` pair from `app.css`, never `--color-bg-primary` /
+       `--color-bg-tertiary`: that pair is ~1.2:1 apart and rendered as a flat white
+       surface, so transparent pixels looked opaque. */
+    background-color: var(--color-checkerboard-base);
     background-image:
-      linear-gradient(45deg, var(--color-bg-tertiary) 25%, transparent 25%),
-      linear-gradient(-45deg, var(--color-bg-tertiary) 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, var(--color-bg-tertiary) 75%),
-      linear-gradient(-45deg, transparent 75%, var(--color-bg-tertiary) 75%);
+      linear-gradient(45deg, var(--color-checkerboard-tile) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--color-checkerboard-tile) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--color-checkerboard-tile) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--color-checkerboard-tile) 75%);
     background-size: 20px 20px;
     background-position:
       0 0,


### PR DESCRIPTION
## What

The file viewer's image stage (`MediaImageView.svelte`) has always painted a checkerboard behind the `<img>`, but it never showed up. The stage used `--color-bg-tertiary` tiles on a `--color-bg-primary` base:

| Theme | Base | Tile | Contrast |
|---|---|---|---|
| Light | `#ffffff` | `#e8e8e8` | ~1.2:1 |
| Dark | `#1e1e1e` | `#333333` | ~1.5:1 |

On 10px cells that renders as a flat surface, so transparent PNGs looked opaque white (or opaque dark).

## Root cause

Not the gradient math and not the build pipeline. I ruled both out:

- Rendered the exact stage rule standalone in headless Chromium: the checker draws, but is almost imperceptible with the old pair.
- Ran the rule through Lightning CSS (Vite 8's CSS transformer, minified and plain, Safari 16 target): output is intact.
- The `cmdr-media://` handler serves raw file bytes, so alpha survives to the webview.

The checker was present in the DOM but invisible: a token-contrast bug, not a rendering bug.

## Fix

- `app.css`: dedicated `--color-checkerboard-base` / `--color-checkerboard-tile` tokens per theme (`#ffffff` / `#cccccc` light, `#262626` / `#404040` dark), roughly the Preview.app / Photoshop "light" checker contrast.
- `MediaImageView.svelte`: the stage draws with those tokens; the comment records why the general surface tokens are the wrong pair.
- `routes/viewer/DETAILS.md`: guardrail under "Media rendering" so the pair isn't swapped back to surface tokens.

## Not done

Not verified in the running macOS app (no macOS here), and `pnpm check` wasn't run locally. CI and a follow-up review should cover it. The exact color values are a human-taste call; adjust freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXDcFie9WG76LiRNEUQvWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXDcFie9WG76LiRNEUQvWX)_