### PR TITLE
feat(android): browse a phone's real filesystem over ADB, and let any device backend put itself in the volume list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           df -h /
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install
@@ -293,7 +293,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install
@@ -545,7 +545,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install
@@ -616,7 +616,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install
@@ -660,7 +660,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install
@@ -728,7 +728,7 @@ jobs:
           fetch-depth: 0 # full history so changelog-commit-links can resolve historical SHAs
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install
@@ -808,7 +808,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install

--- a/.github/workflows/deploy-api-server.yml
+++ b/.github/workflows/deploy-api-server.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         # Caching left at the action's default (on). A hosted runner is ephemeral, so there's no
         # local ~/.local/share/mise to persist and the cache is what keeps `mise install` cheap.
         # ❌ Don't set `cache: false` here without also moving back to the self-hosted runner;

--- a/.github/workflows/slow-checks.yml
+++ b/.github/workflows/slow-checks.yml
@@ -38,7 +38,7 @@ jobs:
           df -h /
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install
@@ -185,7 +185,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install tools with mise
         run: mise install

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
 node = "26"
-pnpm = "11.22.0"
+pnpm = "11.25.0"
 go = "1.27.0"
 # Rust is managed by rustup via rust-toolchain.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,8 @@ Rules for writing them:
 - `apps/desktop/`: `src/` (Svelte frontend), `src-tauri/` (Rust backend), `test/` (Vitest, Playwright, Linux Docker E2E,
   SMB fixtures), `scripts/`. The other three apps are listed above.
 - `crates/`: `cmdr-fs` (filesystem vocabulary + host primitives), `cmdr-index` (file index, media index, folder
-  importance), `cmdr-archive` (the zip/tar/7z backend, and the model a new backend crate copies), and `cmdr-smb` (the
-  SMB backend and its protocol layer) carry no `tauri`, enforced by `index-crate-isolation`; plus two dev CLIs and a
+  importance), `cmdr-archive` (the zip/tar/7z backend, and the model a new backend crate copies), `cmdr-smb` (the SMB
+  backend and its protocol layer), and `cmdr-adb` (Android over ADB) carry no `tauri`, enforced by `index-crate-isolation`; plus two dev CLIs and a
   vendored `fsevent-stream` fork. Details: `docs/architecture.md`.
 - `brand/`: tracked brand and press-kit assets.
 - `docs/`: `docs/architecture.md` (the map), `docs/guides/` (how-tos), `tooling/` (service and workflow references),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cmdr",
+ "cmdr-adb",
  "cmdr-archive",
  "cmdr-fs",
  "cmdr-index",
@@ -1447,6 +1448,19 @@ dependencies = [
  "zbus",
  "zbus-secret-service-keyring-store",
  "zip 8.6.0",
+]
+
+[[package]]
+name = "cmdr-adb"
+version = "0.0.0"
+dependencies = [
+ "cmdr-adb",
+ "cmdr-fs",
+ "log",
+ "serde",
+ "specta",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6077,9 +6091,9 @@ dependencies = [
 
 [[package]]
 name = "mtp-rs"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "101fdd60ac8bf39f698f257555f3920ec3ee0971e6fd05f73ec5d8d44d0f3b60"
+checksum = "5512a899d3ad31f804bd0f85108ad7256e6f5414030ee3c247c4ba2dffa116b0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "apps/desktop/src-tauri",
+  "crates/cmdr-adb",
   "crates/cmdr-archive",
   "crates/cmdr-fs",
   "crates/cmdr-index",

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,7 +8,7 @@ by hand; edit the generator at `scripts/check/checks/desktop-third-party-notices
 
 - Rust crates: 730
 - npm packages: 125
-- Distinct license texts: 321
+- Distinct license texts: 322
 
 ## Rust crates
 
@@ -386,7 +386,7 @@ by hand; edit the generator at `scripts/check/checks/desktop-third-party-notices
 - **ml-kem** 0.3.2, Apache-2.0 OR MIT, <https://github.com/RustCrypto/KEMs>
 - **module-lattice** 0.2.3, Apache-2.0 OR MIT, <https://github.com/RustCrypto/KEMs>
 - **moxcms** 0.8.1, BSD-3-Clause OR Apache-2.0, <https://github.com/awxkee/moxcms.git>
-- **mtp-rs** 0.30.0, MIT OR Apache-2.0, <https://github.com/vdavid/mtp-rs>
+- **mtp-rs** 0.32.0, MIT OR Apache-2.0, <https://github.com/vdavid/mtp-rs>
 - **muda** 0.19.3, Apache-2.0 OR MIT, <https://github.com/tauri-apps/muda>
 - **new_debug_unreachable** 1.0.6, MIT, <https://github.com/mbrubeck/rust-debug-unreachable>
 - **nix** 0.31.3, MIT, <https://github.com/nix-rust/nix>
@@ -774,7 +774,7 @@ by hand; edit the generator at `scripts/check/checks/desktop-third-party-notices
 - **@tauri-apps/plugin-updater** 2.10.1, MIT OR Apache-2.0, <https://github.com/tauri-apps/plugins-workspace#readme>
 - **@types/estree** 1.0.9, MIT, <https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/estree>
 - **@types/trusted-types** 2.0.7, MIT, <https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/trusted-types>
-- **@typescript-eslint/types** 8.67.0, MIT, <https://typescript-eslint.io>
+- **@typescript-eslint/types** 8.68.0, MIT, <https://typescript-eslint.io>
 - **@zag-js/accordion** 1.41.2, MIT, <https://github.com/chakra-ui/zag#readme>
 - **@zag-js/anatomy** 1.41.2, MIT, <https://github.com/chakra-ui/zag#readme>
 - **@zag-js/angle-slider** 1.41.2, MIT, <https://github.com/chakra-ui/zag#readme>
@@ -4167,7 +4167,7 @@ SOFTWARE.
 
 ### MIT
 
-Covers: awaitable-error 0.1.0, block2 0.5.1, block2 0.6.2, brotli-decompressor 5.0.3, cargo_toml 0.22.3, chrono 0.4.45, delegate 0.13.5, dispatch2 0.3.1, dpi 0.1.2, eventsource-stream 0.2.3, file_icon_provider 1.0.2, instant-clip-tokenizer 0.1.0, mac-notification-sys 0.6.15, md5 0.8.1, minisign-verify 0.2.5, mtp-rs 0.30.0, objc-sys 0.3.5, objc2 0.5.2, objc2 0.6.4, objc2-app-kit 0.2.2, objc2-app-kit 0.3.2, objc2-av-foundation 0.3.2, objc2-cloud-kit 0.3.2, objc2-core-data 0.3.2, objc2-core-foundation 0.3.2, objc2-core-graphics 0.3.2, objc2-core-image 0.3.2, objc2-core-media 0.3.2, objc2-core-ml 0.3.2, objc2-core-text 0.3.2, objc2-core-video 0.3.2, objc2-encode 4.1.0, objc2-exception-helper 0.1.1, objc2-foundation 0.2.2, objc2-foundation 0.3.2, objc2-image-io 0.3.2, objc2-io-kit 0.3.2, objc2-metal 0.3.2, objc2-osa-kit 0.3.2, objc2-pdf-kit 0.3.2, objc2-quartz-core 0.3.2, objc2-quick-look-ui 0.3.2, objc2-uniform-type-identifiers 0.3.2, objc2-vision 0.3.2, objc2-web-kit 0.2.2, objc2-web-kit 0.3.2, openssh-sftp-protocol-error 0.1.1, profiling 1.0.18, profiling-procmacros 1.0.18, rc-zip 5.4.1, simd_helpers 0.1.0, siphasher 1.0.3, specta 2.0.0-rc.24, specta-macros 2.0.0-rc.24, specta-serde 0.0.11, specta-tags 0.0.0, specta-typescript 0.0.11, tauri 2.11.5, tauri-build 2.6.3, tauri-codegen 2.6.3, tauri-macros 2.6.3, tauri-plugin 2.6.3, tauri-plugin-clipboard-manager 2.3.2, tauri-plugin-dialog 2.7.2, tauri-plugin-fs 2.5.1, tauri-plugin-global-shortcut 2.3.2, tauri-plugin-notification 2.3.3, tauri-plugin-opener 2.5.4, tauri-plugin-process 2.3.1, tauri-plugin-store 2.4.4, tauri-plugin-updater 2.10.1, tauri-runtime 2.11.3, tauri-runtime-wry 2.11.4, tauri-specta 2.0.0-rc.24, tauri-specta-macros 2.0.0-rc.24, tauri-utils 2.9.3, unic-char-property 0.9.0, unic-char-range 0.9.0, unic-common 0.9.0, unic-ucd-ident 0.9.0, unic-ucd-version 0.9.0, zune-inflate 0.2.54
+Covers: awaitable-error 0.1.0, block2 0.5.1, block2 0.6.2, brotli-decompressor 5.0.3, cargo_toml 0.22.3, chrono 0.4.45, delegate 0.13.5, dispatch2 0.3.1, dpi 0.1.2, eventsource-stream 0.2.3, file_icon_provider 1.0.2, instant-clip-tokenizer 0.1.0, mac-notification-sys 0.6.15, md5 0.8.1, minisign-verify 0.2.5, objc-sys 0.3.5, objc2 0.5.2, objc2 0.6.4, objc2-app-kit 0.2.2, objc2-app-kit 0.3.2, objc2-av-foundation 0.3.2, objc2-cloud-kit 0.3.2, objc2-core-data 0.3.2, objc2-core-foundation 0.3.2, objc2-core-graphics 0.3.2, objc2-core-image 0.3.2, objc2-core-media 0.3.2, objc2-core-ml 0.3.2, objc2-core-text 0.3.2, objc2-core-video 0.3.2, objc2-encode 4.1.0, objc2-exception-helper 0.1.1, objc2-foundation 0.2.2, objc2-foundation 0.3.2, objc2-image-io 0.3.2, objc2-io-kit 0.3.2, objc2-metal 0.3.2, objc2-osa-kit 0.3.2, objc2-pdf-kit 0.3.2, objc2-quartz-core 0.3.2, objc2-quick-look-ui 0.3.2, objc2-uniform-type-identifiers 0.3.2, objc2-vision 0.3.2, objc2-web-kit 0.2.2, objc2-web-kit 0.3.2, openssh-sftp-protocol-error 0.1.1, profiling 1.0.18, profiling-procmacros 1.0.18, rc-zip 5.4.1, simd_helpers 0.1.0, siphasher 1.0.3, specta 2.0.0-rc.24, specta-macros 2.0.0-rc.24, specta-serde 0.0.11, specta-tags 0.0.0, specta-typescript 0.0.11, tauri 2.11.5, tauri-build 2.6.3, tauri-codegen 2.6.3, tauri-macros 2.6.3, tauri-plugin 2.6.3, tauri-plugin-clipboard-manager 2.3.2, tauri-plugin-dialog 2.7.2, tauri-plugin-fs 2.5.1, tauri-plugin-global-shortcut 2.3.2, tauri-plugin-notification 2.3.3, tauri-plugin-opener 2.5.4, tauri-plugin-process 2.3.1, tauri-plugin-store 2.4.4, tauri-plugin-updater 2.10.1, tauri-runtime 2.11.3, tauri-runtime-wry 2.11.4, tauri-specta 2.0.0-rc.24, tauri-specta-macros 2.0.0-rc.24, tauri-utils 2.9.3, unic-char-property 0.9.0, unic-char-range 0.9.0, unic-common 0.9.0, unic-ucd-ident 0.9.0, unic-ucd-version 0.9.0, zune-inflate 0.2.54
 
 ```text
 MIT License
@@ -8838,6 +8838,36 @@ Text from: `LICENSE-MIT`
 
 ```text
 Copyright (c) 2024-2026 RustCrypto Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### MIT
+
+Covers: mtp-rs 0.32.0
+
+Text from: `LICENSE-MIT`
+
+```text
+MIT License
+
+Copyright (c) 2026 David Veszelovszki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ testing = [
   "cmdr-index/testing",
   "cmdr-smb/testing",
   "cmdr-sftp/testing",
+  "cmdr-adb/testing",
 ]
 
 [[bin]]
@@ -83,6 +84,9 @@ cmdr-smb = { path = "../../../crates/cmdr-smb" }
 # `cargo check -p cmdr-sftp` verifies it without building the app. The trusted-key
 # store, the secret store, the server list, and every command stay here.
 cmdr-sftp = { path = "../../../crates/cmdr-sftp" }
+# The Android-over-ADB backend: a real-filesystem `Volume` per device behind the
+# ADB server, beside MTP. No `tauri`, no user-facing words; `docs/specs/android-adb-backend.md`.
+cmdr-adb = { path = "../../../crates/cmdr-adb" }
 # The index: the file index, the media index, and folder importance, behind one
 # `Index` handle. Tauri-free by design and enforced — the app is its host, which
 # is why every seam it needs is answered in `src/index_host.rs` and nowhere else.
@@ -234,7 +238,7 @@ mime_guess = "2"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 # MTP (Android device) support via pure Rust implementation.
-mtp-rs = "0.30.0"
+mtp-rs = "0.32.0"
 bytes = "1"
 # mDNS discovery for network host browsing (pure Rust, cross-platform)
 mdns-sd = { version = "0.20", features = ["logging"] }

--- a/apps/desktop/src-tauri/src/adb/CLAUDE.md
+++ b/apps/desktop/src-tauri/src/adb/CLAUDE.md
@@ -1,0 +1,40 @@
+# ADB (app side)
+
+The app half of the Android-over-ADB backend: the cached `host:track-devices` list, the `DeviceVolumeProvider` that
+puts a device in the sidebar, lazy connect on the first `adb://` navigation, eject, and the IPC commands. The wire and
+the `Volume` are `crates/cmdr-adb/` (read its `CLAUDE.md`). Same split as `mtp/volume_wiring.rs` and
+`network/sftp_volume_wiring.rs`: the wiring knows the backend and the registry, neither knows the wiring.
+
+## Module map
+
+- `device_provider.rs`: `AdbDevices` (the list the tracker last pushed + connected volumes by serial, one process-wide
+  `RwLock`) and `AdbDeviceProvider`, ADB's `device_volumes::DeviceVolumeProvider`.
+- `volume_wiring.rs`: `install_device_provider` and `start_adb_tracker` (once each, from `lib.rs` setup),
+  `connect_adb_device` (dial, `register_if_absent`, remember), `volume_id_for_path` (what
+  `commands/volumes.rs::resolve_path_to_volume` calls for an `adb://` path).
+- `commands.rs`: `list_adb_devices`, `connect_adb_device`, and `AdbConnectOutcomeError`, the typed IPC mirror of
+  `AdbConnectError`.
+
+## Must-knows
+
+- **❗ Path scheme is `adb://<serial>[/device path]`; volume id `adb:<serial>`** (`cmdr_fs::volume::adb_volume_id`).
+  ❌ Never build or split either by hand: `device_path` / `serial_of_path` here, `adb-path-utils.ts` on the frontend.
+- **❗ A device is listed before it's connected.** `entries()` lists every `Ready` device from the cache; the volume is
+  dialed on the first `adb://<serial>` navigation. ❌ Never dial from `entries()`: the listing runs on every
+  `volumes-changed`.
+- **❗ The tracker callback (`apply_device_list`) is synchronous and unregisters inline.** It runs on the runtime
+  inside `cmdr_adb::track_devices`; a serial that left the list gets `note_device_gone` + `unregister`, which retires
+  its volume. ❌ Never spawn from it, or a pane keeps a dead volume until the task gets scheduled.
+- **❗ Eject retires, never detaches.** `adb` has no per-client detach; `AdbDeviceProvider::eject` forgets and
+  unregisters the volume, the device stays in the cached list, and the next navigation re-dials it.
+- **❗ Hotplug and connect both ride `volumes-changed`** through `device_volumes::notify_devices_changed("adb")`.
+  ❌ No ADB-named event; the channel is backend-neutral on purpose.
+- **❗ Connect errors cross IPC as `AdbConnectOutcomeError`**, a typed mirror the frontend words
+  (`adb-connect-errors.ts`). ❌ Never a sentence.
+- **❗ `"adb"` has a row in `MAX_CONCURRENT_OPERATIONS_SOURCES`** (`file_system/backend_settings.rs`) answering the
+  constant 1; a namespace without one silently gets 2.
+- **❗ No `adb` binary means the tracker idles at `debug`**; nothing reaches the user at startup.
+- **❗ Suites here run against the crate's fake server** (`cmdr_adb::testing::FakeAdbServer`, behind the `testing`
+  feature), ❌ never a real `adb`. Which side a cell lives on: `crates/cmdr-adb/DETAILS.md`.
+
+Flows, the provider's answers, what's not wired yet: `DETAILS.md`.

--- a/apps/desktop/src-tauri/src/adb/DETAILS.md
+++ b/apps/desktop/src-tauri/src/adb/DETAILS.md
@@ -1,0 +1,88 @@
+# ADB (app side): details
+
+The app side of `crates/cmdr-adb/`: how a device reaches the sidebar, when a volume is dialed, what an eject does,
+what the frontend calls, and what is not wired yet. The wire contract, the `Volume` answers, and the error policy are
+the crate's (`crates/cmdr-adb/DETAILS.md`); the design that started this is `docs/specs/android-adb-backend.md`. The
+seam both device backends register through is `device_volumes.rs`, whose module doc is canonical for the trait.
+
+## Where each thing lives
+
+- **The crate** owns the protocol, the `Volume`, and the `track_devices` subscription with its reconnect backoff. It
+  never names the registry, the listing, or `tauri`.
+- **This module** owns the cached device state, the provider, the connect wiring, eject, and the commands. It is the
+  only place that knows both the crate and the app.
+- **`device_volumes.rs`** owns the provider registry, `append_device_volumes` (what `volume_listing::complete` folds
+  over), `provider_for_volume_id` (what `eject.rs` asks before answering `EjectAction::DeviceDisconnect`),
+  `device_volume_for_path` (what path resolution asks), and `notify_devices_changed`, the one push channel (it emits
+  `volumes-changed`).
+- **`commands/volumes.rs::resolve_path_to_volume`** is where an `adb://` path turns into a dial: it calls
+  `volume_wiring::volume_id_for_path` before the generic device-provider lookup.
+
+## Flows
+
+**Startup** (`lib.rs` setup): `install_device_provider` registers `AdbDeviceProvider` beside `MtpDeviceProvider`,
+then `start_adb_tracker` starts the one `host:track-devices` subscription for the process (a `OnceLock`; a second call
+is a no-op). The tracker talks only to the local server socket, never to USB. With no `adb` installed it logs at
+`debug` and idles, so a machine without the platform tools sees nothing and pays nothing.
+
+**Hotplug**: every push from `cmdr_adb::track_devices` (the full `host:devices-l` list, refetched by the crate on each
+short-format push) lands in `device_provider::apply_device_list`, synchronously on the runtime. It stores the list,
+and for every serial that left and had a volume, calls the volume's `note_device_gone` (the crate emits the
+`Disconnected` transition once) and `VolumeManager::unregister` (which retires it). Then
+`notify_devices_changed("adb")` → `volumes-changed` → the frontend refetches the list. When the server goes away the
+crate reconnects with backoff (1 s doubling to 15 s) and redelivers the list, so a change missed while it was down is
+caught up.
+
+**Connect**: `connect_adb_device(serial)` answers an already-dialed volume's id without a second dial; otherwise
+`cmdr_adb::connect_adb_volume(params, host, cancel)` runs the crate's four phases, the volume goes in through
+`VolumeManager::register_if_absent` (never `register`: no OS mount can pre-register the id, and a repeated connect
+must not retire a volume a pane is using), is remembered by serial, and `notify_devices_changed("adb")` lets
+`volume_listing::complete` enrich the entry with its capabilities. Errors cross IPC as `AdbConnectOutcomeError`, a
+typed mirror of `AdbConnectError` (`AdbNotInstalled`, `ServerUnreachable`, `DeviceGone`, `Unauthorized`,
+`DeviceTooOld`, `TimedOut`, `Cancelled`, `Transport`); the frontend words each one in `adb-connect-errors.ts`. The
+cancel token handed to the crate is a fresh one today (§ "Not wired yet").
+
+**Eject**: `eject.rs` asks `provider_for_volume_id`, gets this provider, and answers
+`EjectAction::DeviceDisconnect { provider: "adb", volume_id }`. `AdbDeviceProvider::eject` forgets the volume and
+unregisters it; nothing is sent to the phone (`adb` has no per-client detach). The device stays in the cached list, so
+it is listed again on the next `volumes-changed` and re-dialed on the next navigation. A device the user wants gone
+for good is unplugged, or revoked on the phone.
+
+## The provider's answers
+
+`AdbDeviceProvider` answers from the cache, never the wire:
+
+- `id`: `"adb"`.
+- `entries()`: one entry per device in state `Ready` (`device` on the wire), dialed or not: id `adb:<serial>`, path
+  `adb://<serial>`, `fs_type: "adb"`, name = `AdbDevice::display_name()` (the model, falling back to the serial),
+  `mount_is_read_only: false`, `usb_speed: None`. `unauthorized`, `offline`, `recovery`, and the rest are not listed;
+  `list_adb_devices` still returns them with their typed state, so a device switcher can say "tap Allow on the phone".
+- `owns_volume_id`: any cached serial's id matches.
+- `space_for_path`: the connected volume's `get_space_info` (`df -k` on the device), `None` until it is dialed.
+- `eject`: above.
+
+## IPC and frontend
+
+- `list_adb_devices() -> Vec<AdbDevice>`: the cached list, typed states included.
+- `connect_adb_device(serial) -> Result<volume_id, AdbConnectOutcomeError>`.
+- Frontend: `src/lib/adb/` (`adb-path-utils.ts` for the `adb://` scheme beside `mtp://`, `adb-volume-label.ts`,
+  `adb-connect-errors.ts`) and `tauri-commands/adb.ts`. The frontend is a passive consumer of `volumes-changed`, the
+  posture `src/lib/mtp/CLAUDE.md` describes for MTP; its one active step is the connect a navigation triggers.
+
+## Testing
+
+Suites here drive `cmdr_adb::testing::FakeAdbServer` (the crate's `testing` feature is on for the app's dev targets):
+the tracker's diff and inline retirement, the provider's listing answers, eject, `resolve_path_to_volume` on an
+`adb://` path, and the transfer engine through the registry. A cell asserting on the protocol belongs in the crate:
+`crates/cmdr-adb/DETAILS.md` § "Which side a test lives on".
+
+## Not wired yet
+
+- An " (ADB)" name suffix when the same phone is also listed over MTP (`entries()` names the model alone).
+- Index routing for `adb:` volume ids, `go_to_path`, and the MCP `select_volume` tool don't answer for an `adb://`
+  path.
+- A settings toggle (the MTP twin is `fileOperations.mtpEnabled`) and the `adb` binary path setting.
+- The connect isn't cancelable from the pane: `connect_adb_device` hands the crate a fresh `CancellationToken`. The
+  crate honors one; the four lines that wire a cancel button are SFTP's (`crates/cmdr-sftp/DETAILS.md` § "Wiring the
+  cancel button").
+- The real-device pass and the crate's own deferrals: `crates/cmdr-adb/DETAILS.md` § "Known gaps and follow-ups".

--- a/apps/desktop/src-tauri/src/adb/commands.rs
+++ b/apps/desktop/src-tauri/src/adb/commands.rs
@@ -1,0 +1,77 @@
+//! IPC pass-throughs for ADB devices.
+
+use serde::{Deserialize, Serialize};
+
+use cmdr_adb::{AdbConnectError, AdbDevice};
+
+/// Why a connect didn't produce a volume, as the frontend branches on it.
+///
+/// A typed mirror of `cmdr_adb::AdbConnectError`, ❌ never prose: the
+/// frontend's own copy is what a person reads. The backend's diagnostic string
+/// goes to the log.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(tag = "type", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum AdbConnectOutcomeError {
+    /// No `adb` binary on this machine, so no server could be started.
+    AdbNotInstalled,
+    /// The server socket couldn't be reached.
+    ServerUnreachable,
+    /// The device isn't attached (or vanished mid-connect).
+    DeviceGone {
+        /// The serial asked for.
+        serial: String,
+    },
+    /// The phone hasn't accepted this computer's key; "Allow" on the device.
+    Unauthorized {
+        /// The serial asked for.
+        serial: String,
+    },
+    /// The device's ADB predates `shell_v2` (Android 7).
+    DeviceTooOld {
+        /// The serial asked for.
+        serial: String,
+    },
+    /// The connect ran past its budget.
+    TimedOut,
+    /// The user called it off.
+    Cancelled,
+    /// The transport refused or broke in a way none of the above names.
+    Transport,
+}
+
+impl From<AdbConnectError> for AdbConnectOutcomeError {
+    fn from(error: AdbConnectError) -> Self {
+        match error {
+            AdbConnectError::AdbNotInstalled => Self::AdbNotInstalled,
+            AdbConnectError::ServerUnreachable(what) => {
+                log::info!(target: "volume", "adb server unreachable: {what}");
+                Self::ServerUnreachable
+            }
+            AdbConnectError::DeviceGone(serial) => Self::DeviceGone { serial },
+            AdbConnectError::Unauthorized(serial) => Self::Unauthorized { serial },
+            AdbConnectError::DeviceTooOld { serial } => Self::DeviceTooOld { serial },
+            AdbConnectError::TimedOut => Self::TimedOut,
+            AdbConnectError::Cancelled => Self::Cancelled,
+            AdbConnectError::Transport(what) => {
+                log::info!(target: "volume", "adb connect didn't come up: {what}");
+                Self::Transport
+            }
+        }
+    }
+}
+
+/// The ADB devices the server last reported, from the cache the tracker keeps.
+#[tauri::command]
+#[specta::specta]
+pub async fn list_adb_devices() -> Vec<AdbDevice> {
+    super::device_provider::cached_devices()
+}
+
+/// Dials the device with `serial` and answers its volume id.
+#[tauri::command]
+#[specta::specta]
+pub async fn connect_adb_device(serial: String) -> Result<String, AdbConnectOutcomeError> {
+    super::volume_wiring::connect_adb_device(&serial)
+        .await
+        .map_err(AdbConnectOutcomeError::from)
+}

--- a/apps/desktop/src-tauri/src/adb/device_provider.rs
+++ b/apps/desktop/src-tauri/src/adb/device_provider.rs
@@ -1,0 +1,165 @@
+//! The cached ADB device state and the `DeviceVolumeProvider` built on it.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, LazyLock, RwLock};
+
+use cmdr_adb::{AdbDevice, AdbVolume};
+use cmdr_fs::ignore_poison::RwLockIgnorePoison;
+use cmdr_fs::volume::Volume;
+
+use crate::device_volumes::{DeviceVolumeEntry, DeviceVolumeProvider, notify_devices_changed};
+use crate::file_system::volume::manager::get_volume_manager;
+
+/// What the app knows about ADB devices without asking the server: the list
+/// the tracker last pushed, and the volumes that have been dialed.
+#[derive(Default)]
+pub(crate) struct AdbDevices {
+    /// The device list as `host:track-devices` last delivered it.
+    devices: Vec<AdbDevice>,
+    /// The connected volumes, by serial.
+    volumes: HashMap<String, Arc<AdbVolume>>,
+}
+
+static STATE: LazyLock<RwLock<AdbDevices>> = LazyLock::new(|| RwLock::new(AdbDevices::default()));
+
+/// The cached device list.
+pub(crate) fn cached_devices() -> Vec<AdbDevice> {
+    STATE.read_ignore_poison().devices.clone()
+}
+
+/// The connected volume for `serial`, if it has been dialed.
+pub(crate) fn connected_volume(serial: &str) -> Option<Arc<AdbVolume>> {
+    STATE.read_ignore_poison().volumes.get(serial).cloned()
+}
+
+/// Files a freshly dialed volume under its serial.
+pub(crate) fn remember_volume(serial: &str, volume: Arc<AdbVolume>) {
+    STATE.write_ignore_poison().volumes.insert(serial.to_string(), volume);
+}
+
+/// Forgets the volume for `serial`, handing it back so the caller can retire it.
+pub(crate) fn forget_volume(serial: &str) -> Option<Arc<AdbVolume>> {
+    STATE.write_ignore_poison().volumes.remove(serial)
+}
+
+/// Stores a tracker push and retires the volume of every serial that left.
+///
+/// ❗ Synchronous on purpose: it runs inside the tracker's callback, and the
+/// registry is sync. A volume that lost its device is told so
+/// (`note_device_gone`) and unregistered, which is what retires it.
+pub(crate) fn apply_device_list(devices: Vec<AdbDevice>) {
+    let gone: Vec<(String, Arc<AdbVolume>)> = {
+        let mut state = STATE.write_ignore_poison();
+        state.devices = devices;
+        let still_here: Vec<&str> = state.devices.iter().map(|d| d.serial.as_str()).collect();
+        let gone_serials: Vec<String> = state
+            .volumes
+            .keys()
+            .filter(|serial| !still_here.contains(&serial.as_str()))
+            .cloned()
+            .collect();
+        gone_serials
+            .into_iter()
+            .filter_map(|serial| state.volumes.remove(&serial).map(|v| (serial, v)))
+            .collect()
+    };
+    for (serial, volume) in gone {
+        log::info!(target: "volume", "adb device {serial} left; retiring its volume");
+        volume.note_device_gone();
+        get_volume_manager().unregister(volume.volume_id());
+    }
+    notify_devices_changed("adb");
+}
+
+/// The `adb://<serial>` root a pane navigates to.
+pub(crate) fn device_path(serial: &str) -> String {
+    format!("adb://{serial}")
+}
+
+/// The serial an `adb://<serial>[/…]` path names.
+pub(crate) fn serial_of_path(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("adb://")?;
+    let serial = rest.split('/').next()?;
+    (!serial.is_empty()).then_some(serial)
+}
+
+/// ADB's answer to `device_volumes::DeviceVolumeProvider`.
+pub(crate) struct AdbDeviceProvider;
+
+impl DeviceVolumeProvider for AdbDeviceProvider {
+    fn id(&self) -> &'static str {
+        "adb"
+    }
+
+    /// One entry per `Ready` device, dialed or not: a device with no volume yet
+    /// is listed so the user can click it, and the first `adb://` navigation
+    /// connects it (`commands/volumes.rs`).
+    ///
+    /// Follow-up: an " (ADB)" suffix when an MTP entry shares the name.
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<DeviceVolumeEntry>> + Send + '_>> {
+        Box::pin(async {
+            cached_devices()
+                .iter()
+                .filter(|d| d.is_ready())
+                .map(|d| DeviceVolumeEntry {
+                    id: cmdr_fs::volume::adb_volume_id(&d.serial),
+                    name: d.display_name(),
+                    path: device_path(&d.serial),
+                    fs_type: "adb",
+                    mount_is_read_only: false,
+                    usb_speed: None,
+                })
+                .collect()
+        })
+    }
+
+    fn owns_volume_id<'a>(&'a self, volume_id: &'a str) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+        Box::pin(async move {
+            cached_devices()
+                .iter()
+                .any(|d| cmdr_fs::volume::adb_volume_id(&d.serial) == volume_id)
+        })
+    }
+
+    /// Live space from the connected volume; `None` until it's dialed.
+    fn space_for_path<'a>(&'a self, path: &'a str) -> Pin<Box<dyn Future<Output = Option<(u64, u64)>> + Send + 'a>> {
+        Box::pin(async move {
+            let volume = connected_volume(serial_of_path(path)?)?;
+            let space = volume.get_space_info().await.ok()?;
+            Some((space.total_bytes, space.available_bytes))
+        })
+    }
+
+    /// Retires the volume. ❗ Nothing is detached: `adb` has no per-client
+    /// detach, so the device stays in the server's list and is listed again on
+    /// the next `volumes-changed`.
+    fn eject<'a>(&'a self, volume_id: &'a str) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+        Box::pin(async move {
+            let serial = cached_devices()
+                .into_iter()
+                .find(|d| cmdr_fs::volume::adb_volume_id(&d.serial) == volume_id)
+                .map(|d| d.serial)
+                .ok_or_else(|| format!("no adb device owns volume {volume_id}"))?;
+            if forget_volume(&serial).is_some() {
+                get_volume_manager().unregister(volume_id);
+            }
+            notify_devices_changed("adb");
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serial_of_path_reads_the_host_segment_only() {
+        assert_eq!(serial_of_path("adb://ZY22ABC"), Some("ZY22ABC"));
+        assert_eq!(serial_of_path("adb://ZY22ABC/sdcard/DCIM"), Some("ZY22ABC"));
+        assert_eq!(serial_of_path("adb://"), None);
+        assert_eq!(serial_of_path("mtp://dev/1"), None);
+    }
+}

--- a/apps/desktop/src-tauri/src/adb/mod.rs
+++ b/apps/desktop/src-tauri/src/adb/mod.rs
@@ -1,0 +1,17 @@
+//! Android over ADB: the app side of `cmdr_adb`.
+//!
+//! The crate owns the wire and the `Volume`; this module owns what only the
+//! app can: the cached device list the ADB server pushes
+//! (`host:track-devices`), the connected volumes and their registration, the
+//! `DeviceVolumeProvider` the volume list folds over, and the IPC commands.
+//! Same split as `mtp/` and `network/sftp_volume_wiring.rs`.
+//!
+//! Module map: `device_provider.rs` (the provider and the cached state),
+//! `volume_wiring.rs` (connect, register, and the tracker), `commands.rs`
+//! (IPC pass-throughs). `DETAILS.md` has the flows.
+
+pub mod commands;
+pub mod device_provider;
+pub mod volume_wiring;
+
+pub use volume_wiring::start_adb_tracker;

--- a/apps/desktop/src-tauri/src/adb/volume_wiring.rs
+++ b/apps/desktop/src-tauri/src/adb/volume_wiring.rs
@@ -1,0 +1,76 @@
+//! ADB volume wiring: turns "the user opened this device" into a registered
+//! `AdbVolume`, and keeps the cached device list following the server.
+//!
+//! ❗ **A backend never registers itself.** This module knows both the backend
+//! and the volume registry, and neither of those knows this module: the same
+//! shape `mtp::volume_wiring` and `network::sftp_volume_wiring` take.
+
+use std::sync::{Arc, OnceLock};
+
+use cmdr_adb::{AdbConnectError, AdbConnectionParams, AdbEndpoint, DeviceTracker};
+use tauri::AppHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::device_provider::{self, AdbDeviceProvider};
+use crate::device_volumes::{notify_devices_changed, register_device_provider};
+use crate::file_system::volume::manager::get_volume_manager;
+
+/// The one `host:track-devices` subscription, alive for the process.
+static TRACKER: OnceLock<DeviceTracker> = OnceLock::new();
+
+/// Files ADB as a device provider. Call once at startup.
+pub(crate) fn install_device_provider() {
+    register_device_provider(Arc::new(AdbDeviceProvider));
+}
+
+/// Starts following the ADB server's device list. Once; a second call is a
+/// no-op.
+///
+/// Talks only to the local server socket, never to USB. With no `adb`
+/// installed the tracker logs at debug and idles, so nothing reaches the user
+/// at startup.
+pub fn start_adb_tracker(_app: &AppHandle) {
+    if TRACKER.get().is_some() {
+        return;
+    }
+    let tracker = cmdr_adb::track_devices(
+        AdbEndpoint::default_local(),
+        tauri::async_runtime::handle().inner().clone(),
+        Arc::new(device_provider::apply_device_list),
+    );
+    if TRACKER.set(tracker).is_err() {
+        log::debug!(target: "volume", "adb tracker already running");
+    }
+}
+
+/// Dials the device with `serial`, registers its volume, and answers the volume
+/// id. Already connected is answered without a second dial.
+///
+/// `register_if_absent`, never `register`: an ADB device has no OS mount, so
+/// nothing else can pre-register its id, and a repeated connect must not retire
+/// a volume the pane is using.
+pub async fn connect_adb_device(serial: &str) -> Result<String, AdbConnectError> {
+    if let Some(volume) = device_provider::connected_volume(serial) {
+        return Ok(volume.volume_id().to_string());
+    }
+    let volume = cmdr_adb::connect_adb_volume(
+        AdbConnectionParams::new(serial),
+        crate::volume_host::host(),
+        CancellationToken::new(),
+    )
+    .await?;
+    let volume_id = volume.volume_id().to_string();
+    let volume = Arc::new(volume);
+    get_volume_manager().register_if_absent(&volume_id, Arc::clone(&volume) as Arc<dyn cmdr_fs::volume::Volume>);
+    device_provider::remember_volume(serial, volume);
+    log::info!(target: "volume", "registered ADB volume {volume_id}");
+    notify_devices_changed("adb");
+    Ok(volume_id)
+}
+
+/// The volume id for an `adb://<serial>[/…]` path, dialing the device on first
+/// use. `None` for a path that isn't `adb://` at all.
+pub async fn volume_id_for_path(path: &str) -> Option<Result<String, AdbConnectError>> {
+    let serial = device_provider::serial_of_path(path)?;
+    Some(connect_adb_device(serial).await)
+}

--- a/apps/desktop/src-tauri/src/commands/volumes.rs
+++ b/apps/desktop/src-tauri/src/commands/volumes.rs
@@ -57,12 +57,12 @@ pub fn get_default_volume_id() -> String {
 
 /// Gets space information for a volume at the given path.
 /// Returns total and available bytes for the volume.
-/// For MTP paths (`mtp://`), fetches from the MTP connection manager instead of
-/// asking the filesystem.
+/// For device paths (`mtp://`, `adb://`), asks the device provider instead of
+/// the filesystem.
 #[tauri::command]
 #[specta::specta]
 pub async fn get_volume_space(path: String) -> TimedOut<Option<VolumeSpaceInfo>> {
-    if let Some((total_bytes, available_bytes)) = volume_listing::mtp_space_for_path(&path).await {
+    if let Some((total_bytes, available_bytes)) = crate::device_volumes::device_space_for_path(&path).await {
         return TimedOut {
             data: Some(VolumeSpaceInfo {
                 total_bytes,
@@ -116,9 +116,24 @@ async fn resolve_location_inner(path: String, fs_timeout: Duration) -> ResolveLo
 /// the mount table under `fs_timeout`. Returns the volume (if any) and whether it
 /// timed out.
 async fn resolve_path_to_volume(path: String, fs_timeout: Duration) -> (Option<VolumeInfo>, bool) {
-    // MTP protocol dispatch
-    if path.starts_with("mtp://") {
-        return (volume_listing::mtp_volume_for_path(&path).await, false);
+    // Device protocol dispatch (`mtp://`, `adb://`): whichever provider's
+    // storage the path falls under. An ADB device is listed before it's
+    // dialed, so the first navigation onto it is what connects it.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        if path.starts_with("adb://") {
+            match crate::adb::volume_wiring::volume_id_for_path(&path).await {
+                Some(Ok(_)) => {}
+                Some(Err(error)) => {
+                    log::info!(target: "volume", "adb device for {path} didn't connect: {error}");
+                    return (None, false);
+                }
+                None => return (None, false),
+            }
+        }
+    }
+    if path.starts_with("mtp://") || path.starts_with("adb://") {
+        return (crate::device_volumes::device_volume_for_path(&path).await, false);
     }
 
     // SMB/network protocol paths → return the virtual network volume

--- a/apps/desktop/src-tauri/src/device_volumes.rs
+++ b/apps/desktop/src-tauri/src/device_volumes.rs
@@ -1,0 +1,171 @@
+//! What the volume list asks a device backend, and how a device backend says
+//! "the device set changed".
+//!
+//! The generalization of the MTP-only fold `volume_listing::complete` used to
+//! hardcode. A device backend (MTP, ADB) registers one [`DeviceVolumeProvider`]
+//! at startup; the listing folds over every provider, eject asks which provider
+//! owns a volume id, and path resolution asks which provider's entry a
+//! `scheme://` path falls under. On hotplug a provider calls
+//! [`notify_devices_changed`], which is the one push channel the frontend has.
+//!
+//! ❗ [`DeviceVolumeProvider::entries`] answers from CACHED state, never the
+//! wire: the listing runs on every `volumes-changed`, and a provider that probes
+//! its devices there turns a refresh into a round of USB or socket traffic.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, LazyLock, RwLock};
+
+use cmdr_fs::ignore_poison::RwLockIgnorePoison;
+
+use crate::usb_speed::UsbSpeed;
+use crate::volume_listing::{LocationCategory, LocationInfo};
+
+/// One device storage as its provider lists it. [`append_from`] turns it into
+/// the `LocationInfo` the frontend reads, filling in everything a mobile device
+/// has in common.
+#[derive(Debug, Clone)]
+pub(crate) struct DeviceVolumeEntry {
+    /// The volume id the registry files the backend under.
+    pub id: String,
+    /// What the picker shows.
+    pub name: String,
+    /// The `scheme://…` root a pane navigates to.
+    pub path: String,
+    /// The `fs_type` the frontend branches on (`"mtp"`, `"adb"`).
+    pub fs_type: &'static str,
+    /// Whether the storage refuses writes.
+    pub mount_is_read_only: bool,
+    /// The USB link speed, when the backend can see it.
+    pub usb_speed: Option<UsbSpeed>,
+}
+
+/// A backend that turns attached devices into volumes.
+///
+/// Every method answers from the provider's own cached state. Boxed futures
+/// rather than `async fn` so the trait stays object-safe: the registry holds
+/// `Arc<dyn DeviceVolumeProvider>`.
+pub(crate) trait DeviceVolumeProvider: Send + Sync + 'static {
+    /// The provider's stable name (`"mtp"`, `"adb"`), the key the registry
+    /// dedupes on and what eject reports back.
+    fn id(&self) -> &'static str;
+
+    /// Every storage the provider currently offers. ❗ From cached state, never
+    /// the wire.
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<DeviceVolumeEntry>> + Send + '_>>;
+
+    /// Whether `volume_id` names a device this provider has live. ❌ Never an
+    /// id-shape guess: an id that LOOKS like one of ours but names a device that
+    /// left would otherwise route an eject at nothing.
+    fn owns_volume_id<'a>(&'a self, volume_id: &'a str) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>>;
+
+    /// `(total, available)` bytes for the storage `path` falls under, or `None`
+    /// when the path isn't one of this provider's.
+    fn space_for_path<'a>(&'a self, path: &'a str) -> Pin<Box<dyn Future<Output = Option<(u64, u64)>> + Send + 'a>>;
+
+    /// Retires the volume `volume_id` names. The `Err` string is the backend's
+    /// own diagnostic; it reaches the log and the details line, ❌ never the
+    /// message.
+    fn eject<'a>(&'a self, volume_id: &'a str) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>;
+}
+
+/// The registered providers, in registration order.
+static PROVIDERS: LazyLock<RwLock<Vec<Arc<dyn DeviceVolumeProvider>>>> = LazyLock::new(|| RwLock::new(Vec::new()));
+
+/// Files a provider under its `id()`. The first registration per id wins; a
+/// duplicate is logged and dropped, so a double `install_device_provider` can't
+/// list every device twice.
+pub(crate) fn register_device_provider(provider: Arc<dyn DeviceVolumeProvider>) {
+    let mut providers = PROVIDERS.write_ignore_poison();
+    if providers.iter().any(|p| p.id() == provider.id()) {
+        log::warn!(target: "volume", "device provider {} registered twice; keeping the first", provider.id());
+        return;
+    }
+    log::debug!(target: "volume", "registered device provider {}", provider.id());
+    providers.push(provider);
+}
+
+/// A snapshot of the registered providers.
+pub(crate) fn device_providers() -> Vec<Arc<dyn DeviceVolumeProvider>> {
+    PROVIDERS.read_ignore_poison().clone()
+}
+
+/// Appends every registered provider's storages to `volumes`.
+pub(crate) async fn append_device_volumes(volumes: &mut Vec<LocationInfo>) {
+    append_from(volumes, &device_providers()).await;
+}
+
+/// Appends `providers`' storages to `volumes`, each as a `MobileDevice` entry.
+///
+/// What every device storage has in common lives here, once: ejectable, no
+/// trash, no icon, not a disk image, no SMB state, and `capabilities: None`
+/// because enrichment fills that from the registered `Volume` afterwards.
+pub(crate) async fn append_from(volumes: &mut Vec<LocationInfo>, providers: &[Arc<dyn DeviceVolumeProvider>]) {
+    for provider in providers {
+        for entry in provider.entries().await {
+            volumes.push(location_from_entry(entry));
+        }
+    }
+}
+
+fn location_from_entry(entry: DeviceVolumeEntry) -> LocationInfo {
+    LocationInfo {
+        id: entry.id,
+        name: entry.name,
+        path: entry.path,
+        category: LocationCategory::MobileDevice,
+        icon: None,
+        is_ejectable: true,
+        mount_is_read_only: entry.mount_is_read_only,
+        is_disk_image: false,
+        fs_type: Some(entry.fs_type.to_string()),
+        supports_trash: false,
+        smb_connection_state: None,
+        usb_speed: entry.usb_speed,
+        capabilities: None,
+    }
+}
+
+/// What a provider calls when its device set changed: logs it and republishes
+/// the volume list.
+pub(crate) fn notify_devices_changed(provider_id: &str) {
+    log::debug!(target: "volume", "device provider {provider_id} reports a device change");
+    crate::volume_broadcast::emit_volumes_changed();
+}
+
+/// The provider that has `volume_id` live, if any.
+pub(crate) async fn provider_for_volume_id(volume_id: &str) -> Option<Arc<dyn DeviceVolumeProvider>> {
+    for provider in device_providers() {
+        if provider.owns_volume_id(volume_id).await {
+            return Some(provider);
+        }
+    }
+    None
+}
+
+/// Live `(total, available)` bytes for a device path, from whichever provider
+/// claims it.
+pub(crate) async fn device_space_for_path(path: &str) -> Option<(u64, u64)> {
+    for provider in device_providers() {
+        if let Some(space) = provider.space_for_path(path).await {
+            return Some(space);
+        }
+    }
+    None
+}
+
+/// The device volume `path` falls under: the entry whose `path` equals it or
+/// is a `/`-separated prefix of it.
+pub(crate) async fn device_volume_for_path(path: &str) -> Option<LocationInfo> {
+    let mut volumes = Vec::new();
+    append_device_volumes(&mut volumes).await;
+    volumes.into_iter().find(|v| path_is_under(path, &v.path))
+}
+
+/// Whether `path` is `root` itself or something inside it.
+fn path_is_under(path: &str, root: &str) -> bool {
+    path == root || path.strip_prefix(root).is_some_and(|rest| rest.starts_with('/'))
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/desktop/src-tauri/src/device_volumes/tests.rs
+++ b/apps/desktop/src-tauri/src/device_volumes/tests.rs
@@ -1,0 +1,83 @@
+//! The fold from provider entries to picker entries, and the path prefix rule,
+//! against a fake provider so no device is needed.
+
+use super::*;
+
+/// A provider with a fixed entry list.
+struct FakeProvider {
+    id: &'static str,
+    entries: Vec<DeviceVolumeEntry>,
+}
+
+impl DeviceVolumeProvider for FakeProvider {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<DeviceVolumeEntry>> + Send + '_>> {
+        Box::pin(async { self.entries.clone() })
+    }
+
+    fn owns_volume_id<'a>(&'a self, volume_id: &'a str) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+        Box::pin(async move { self.entries.iter().any(|e| e.id == volume_id) })
+    }
+
+    fn space_for_path<'a>(&'a self, _path: &'a str) -> Pin<Box<dyn Future<Output = Option<(u64, u64)>> + Send + 'a>> {
+        Box::pin(async { None })
+    }
+
+    fn eject<'a>(&'a self, _volume_id: &'a str) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+fn entry(id: &str, path: &str, fs_type: &'static str) -> DeviceVolumeEntry {
+    DeviceVolumeEntry {
+        id: id.to_string(),
+        name: format!("Device {id}"),
+        path: path.to_string(),
+        fs_type,
+        mount_is_read_only: false,
+        usb_speed: None,
+    }
+}
+
+#[tokio::test]
+async fn append_from_folds_every_provider_into_mobile_device_entries() {
+    let providers: Vec<Arc<dyn DeviceVolumeProvider>> = vec![
+        Arc::new(FakeProvider {
+            id: "mtp",
+            entries: vec![entry("mtp-1:65537", "mtp://mtp-1/65537", "mtp")],
+        }),
+        Arc::new(FakeProvider {
+            id: "adb",
+            entries: vec![entry("adb-serial", "adb://serial", "adb")],
+        }),
+    ];
+
+    let mut volumes = Vec::new();
+    append_from(&mut volumes, &providers).await;
+
+    assert_eq!(volumes.len(), 2);
+    let ids: Vec<&str> = volumes.iter().map(|v| v.id.as_str()).collect();
+    assert_eq!(ids, ["mtp-1:65537", "adb-serial"], "registration order is listing order");
+    for v in &volumes {
+        assert!(matches!(v.category, LocationCategory::MobileDevice));
+        assert!(v.is_ejectable);
+        assert!(!v.supports_trash);
+        assert!(v.capabilities.is_none(), "enrichment fills capabilities afterwards");
+        assert!(v.icon.is_none());
+        assert!(!v.is_disk_image);
+        assert!(v.smb_connection_state.is_none());
+    }
+    assert_eq!(volumes[0].fs_type.as_deref(), Some("mtp"));
+    assert_eq!(volumes[1].fs_type.as_deref(), Some("adb"));
+}
+
+#[test]
+fn a_path_is_under_its_root_or_a_slash_separated_child_of_it() {
+    assert!(path_is_under("adb://serial", "adb://serial"));
+    assert!(path_is_under("adb://serial/sdcard/DCIM", "adb://serial"));
+    assert!(!path_is_under("adb://serial2", "adb://serial"), "a sibling sharing a prefix isn't inside");
+    assert!(!path_is_under("mtp://dev/655370", "mtp://dev/65537"));
+}

--- a/apps/desktop/src-tauri/src/file_system/backend_settings.rs
+++ b/apps/desktop/src-tauri/src/file_system/backend_settings.rs
@@ -25,7 +25,7 @@ type ConcurrencySource = (BackendName, fn() -> usize);
 /// Where each backend's concurrency setting comes from, keyed by its namespace.
 ///
 /// ❗ **A row is where a backend's number comes from, not a promise that a user
-/// can change it.** Two rows today, and only one of them is a slider:
+/// can change it.** Three rows today, and only one of them is a slider:
 ///
 /// - `"smb"` reads `network.smbConcurrency` (Settings > Advanced, default 10,
 ///   clamped to `1..=32` by `set_smb_concurrency`), whose label and help text
@@ -39,11 +39,29 @@ type ConcurrencySource = (BackendName, fn() -> usize);
 ///   the design rather than something to tune. It still needs a row, because a
 ///   namespace without one silently gets
 ///   [`UNREGISTERED_MAX_CONCURRENT_OPERATIONS`].
+/// - `"adb"` reads the constant 1: the device's `adbd` serializes I/O, so more
+///   sockets buy nothing.
 ///
 /// Adding a backend means adding its row here next to its own accessor, whether
 /// or not the number is ever exposed.
 const MAX_CONCURRENT_OPERATIONS_SOURCES: &[ConcurrencySource] =
-    &[("smb", super::smb_concurrency), ("sftp", sftp_concurrency)];
+    &[
+    ("smb", super::smb_concurrency),
+    ("sftp", sftp_concurrency),
+    ("adb", adb_concurrency),
+];
+
+/// How many operations an ADB volume runs at once.
+///
+/// One, and not a knob: a phone's `adbd` serializes sync-socket I/O anyway, so
+/// a second socket only queues behind the first while holding a transport open.
+/// The row exists so the namespace doesn't silently get
+/// [`UNREGISTERED_MAX_CONCURRENT_OPERATIONS`], which is higher.
+const ADB_MAX_CONCURRENT_OPERATIONS: usize = 1;
+
+fn adb_concurrency() -> usize {
+    ADB_MAX_CONCURRENT_OPERATIONS
+}
 
 /// How many operations an SFTP volume runs at once.
 ///
@@ -137,6 +155,27 @@ mod tests {
         );
         assert_ne!(
             AppBackendSettings.max_concurrent_operations("sftp"),
+            UNREGISTERED_MAX_CONCURRENT_OPERATIONS,
+            "a missing row is invisible at runtime, so this is what says the row is there"
+        );
+
+        set_smb_concurrency(previous);
+    }
+
+    /// ADB's row is a constant of 1: the cautious default would let a second
+    /// socket queue behind the first on a phone whose `adbd` serializes I/O.
+    #[test]
+    fn adb_reads_its_own_constant_and_not_the_smb_slider() {
+        let _turn = one_writer_at_a_time();
+        let previous = smb_concurrency();
+
+        set_smb_concurrency(32);
+        assert_eq!(
+            AppBackendSettings.max_concurrent_operations("adb"),
+            ADB_MAX_CONCURRENT_OPERATIONS
+        );
+        assert_ne!(
+            AppBackendSettings.max_concurrent_operations("adb"),
             UNREGISTERED_MAX_CONCURRENT_OPERATIONS,
             "a missing row is invisible at runtime, so this is what says the row is there"
         );

--- a/apps/desktop/src-tauri/src/file_system/volume/DETAILS.md
+++ b/apps/desktop/src-tauri/src/file_system/volume/DETAILS.md
@@ -194,6 +194,7 @@ Everything below is optional per the trait (methods default to `Err(NotSupported
 - [ ] If your backend holds a session that can drop (FTP, S3, SFTP, anything network-bound), emit `volume-connection-changed` (`network::VolumeConnectionChanged` + the `VolumeConnection` enum) on every transition and you inherit the whole frontend recovery story for free: the unreachable banner, the per-volume backoff cycle, and the "Sign in" prompt when saved credentials go stale. ❌ Don't add a backend-named connection event alongside it; the channel is backend-neutral on purpose. Map your internal state machine onto the wire enum the way `From<ConnectionState> for VolumeConnection` does in `crates/cmdr-smb/src/volume/state.rs`, and emit `NeedsCredentials` straight from your reconnect give-up path (no backend rests in it). Flow: `crates/cmdr-smb/DETAILS.md` § "SMB live-reconnect lifecycle".
 - [ ] If the volume needs async teardown (session close, handle drop), implement `on_unmount`. The default is a no-op.
 - [ ] If tearing that state down mid-flight would break a caller still holding an `Arc`, also implement `on_superseded` (it defaults to `on_unmount`).
+- [ ] If the volume is a DEVICE (a phone or a camera: something that appears and leaves on its own rather than being mounted or signed into), register a `device_volumes::DeviceVolumeProvider` at startup and call `device_volumes::notify_devices_changed(id)` on every hotplug edge. `volume_listing::complete` folds over every provider, and eject and path resolution ask the registry which provider owns an id or a path, so nothing outside `device_volumes.rs` names your backend. Answer `entries()` from cached state, ❌ never from the wire: the listing runs on every `volumes-changed`. `MtpDeviceProvider` (`mtp/volume_wiring.rs`) and `AdbDeviceProvider` (`adb/`) are the two; a network volume is not a device and stays out of it (the sidebar arm for one is its own design question, `docs/specs/later/sftp-follow-ups.md`).
 - [ ] Add a branch to `detect_provider` / `provider_suggestion` in `friendly_error/provider.rs` (see `friendly_error/CLAUDE.md`) if there's a recognizable path shape or fs type worth calling out in friendly errors.
 - [ ] Add a capability-matrix row below and update the `docs/architecture.md` volume line if the shape changes meaningfully.
 
@@ -336,19 +337,20 @@ trait it dispatches over. `commands::eject::eject_volume` is a thin delegate; th
 1. **Busy gate**: refuse (`EjectError::Busy`) if a write op is touching the volume (`file_system::busy_volume_ids`), so
    a transfer can't be truncated. The picker already disables Eject for busy volumes; this defends against a race or an
    MCP/automation caller.
-2. **Classify**: MTP (id shaped `{device_id}:{storage_id}`, confirmed against the live device list) → disconnect the
-   session; a registered `SmbVolume` (`smb_connection_state().is_some()`) → `diskutil unmount` (FSEvents drives smb2
+2. **Classify**: a device volume (a `device_volumes::DeviceVolumeProvider` answers `owns_volume_id` from live state;
+   MTP, ADB) → that provider's `eject`; a registered `SmbVolume` (`smb_connection_state().is_some()`) → `diskutil unmount` (FSEvents drives smb2
    teardown via `on_unmount`); otherwise NSURL/`/sys/block` ejectability → `diskutil eject` (powers down USB, detaches
    DMGs). The pure `decide_eject_action` makes this choice and is unit-tested without touching the FS.
-3. **Execute**: MTP disconnect, or a `diskutil`/`umount` subprocess under a 15 s timeout.
+3. **Execute**: the provider's eject (MTP closes the session; ADB only retires the volume, since `adb` has no
+   per-client detach), or a `diskutil`/`umount` subprocess under a 15 s timeout.
 
 The MCP `eject` tool wraps `eject::eject` directly (not the command), surfacing `Busy` / non-ejectable as honest tool errors; see `mcp/DETAILS.md`.
 
-Errors are the typed `EjectError` (`Busy`, `VolumeNotFound`, `MtpIdMissingDevicePrefix`, `NotEjectable`,
-`NotAnSmbVolume`, `MtpDisconnectRefused`, `UnmountRefused`, `TimedOut`, `Unexpected`), and it IS the wire type:
+Errors are the typed `EjectError` (`Busy`, `VolumeNotFound`, `NotEjectable`,
+`NotAnSmbVolume`, `DeviceDisconnectRefused`, `UnmountRefused`, `TimedOut`, `Unexpected`), and it IS the wire type:
 `commands::eject` passes it straight through, so nothing is flattened on the way out and the frontend words each
 variant from `errors.eject.*` (`src/lib/file-explorer/navigation/DETAILS.md` § "Eject button + row context menu").
-`diskutil`'s own stderr rides in the `detail` field of `UnmountRefused` / `MtpDisconnectRefused` and goes to the LOG,
+`diskutil`'s own stderr rides in the `detail` field of `UnmountRefused` / `DeviceDisconnectRefused` and goes to the LOG,
 never into the toast.
 Returns once teardown is *initiated* — `volume-unmounted` / `mtp-device-disconnected` fire
 shortly after and panes rooted at the volume redirect to root. `disconnect_smb_volume` (in `commands::network`) is the

--- a/apps/desktop/src-tauri/src/file_system/volume/backends/CLAUDE.md
+++ b/apps/desktop/src-tauri/src/file_system/volume/backends/CLAUDE.md
@@ -10,6 +10,8 @@ Per-backend `Volume` impls. Trait shape, capabilities, streaming patterns, "Buil
   with the trait in `cmdr-fs`. MTP splits by concern the way both remote backends do: `volume_impl` is the whole
   `impl Volume`, with `streams`, `mapping`, and `scan` beside it (SMB carries the pattern further; see
   `crates/cmdr-smb/CLAUDE.md`).
+- The Android-over-ADB backend is `crates/cmdr-adb/` (its `CLAUDE.md` has the must-knows); the app-side tracker,
+  provider, and connect wiring live in `src-tauri/src/adb/`, not here.
 
 ## SMB is a crate now
 

--- a/apps/desktop/src-tauri/src/file_system/volume/eject.rs
+++ b/apps/desktop/src-tauri/src/file_system/volume/eject.rs
@@ -1,9 +1,11 @@
-//! Volume eject: unmounts ejectable volumes (USB, SD, DMG, SMB, MTP).
+//! Volume eject: unmounts ejectable volumes (USB, SD, DMG, SMB, MTP, ADB).
 //!
 //! Dispatches by volume kind:
-//! - **MTP device** (volume ID shaped `{device_id}:{storage_id}`): closes the
-//!   MTP session via `mtp::connection_manager().disconnect`. The
-//!   `mtp-device-disconnected` event removes the volume from the picker.
+//! - **Device volume** (a `device_volumes::DeviceVolumeProvider` owns the id):
+//!   hands the eject to that provider. MTP closes the device session and the
+//!   `mtp-device-disconnected` event removes its storages from the picker; ADB
+//!   has nothing to detach (`adb` has no per-client detach), so it retires the
+//!   volume and hides the device until it re-enumerates.
 //! - **SMB volume** (registered `SmbVolume` in `VolumeManager`): runs `diskutil
 //!   unmount`. FSEvents fires `NSWorkspaceDidUnmount`, which calls
 //!   `Volume::on_unmount` (drops the smb2 session, stops the watcher) and the
@@ -28,8 +30,8 @@ pub enum EjectAction {
     DiskutilEject,
     /// Run `diskutil unmount <mount_path>`. SMB: FSEvents handles smb2 teardown.
     DiskutilUnmount,
-    /// Close the MTP session for this device.
-    MtpDisconnect { device_id: String },
+    /// Hand the eject to the device provider that owns the volume.
+    DeviceDisconnect { provider: &'static str, volume_id: String },
 }
 
 /// Reasons `decide_eject_action` can't pick an action. Kept as a typed enum so
@@ -37,10 +39,7 @@ pub enum EjectAction {
 /// matching a free-form message.
 #[derive(Debug, PartialEq, Eq)]
 pub enum EjectDecisionError {
-    /// MTP volume id is shaped wrong: missing the `{device_id}:{storage_id}`
-    /// separator. Carries the bad id verbatim for diagnostics / UI rendering.
-    MtpIdMissingDevicePrefix { volume_id: String },
-    /// Volume can't be ejected (not SMB, not MTP, and NSURL/`/sys/block`
+    /// Volume can't be ejected (not SMB, not a device, and NSURL/`/sys/block`
     /// reports `is_ejectable = false`). Typical for the boot volume or other
     /// internal disks.
     NotEjectable { volume_id: String },
@@ -49,9 +48,6 @@ pub enum EjectDecisionError {
 impl std::fmt::Display for EjectDecisionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::MtpIdMissingDevicePrefix { volume_id } => {
-                write!(f, "MTP volume id {} is missing a device prefix", volume_id)
-            }
             Self::NotEjectable { volume_id } => {
                 write!(f, "Volume {} isn't ejectable", volume_id)
             }
@@ -67,27 +63,23 @@ impl std::error::Error for EjectDecisionError {}
 pub struct EjectContext<'a> {
     pub volume_id: &'a str,
     /// NSURL-derived ejectability for physical/DMG volumes. Always `false` for
-    /// SMB and MTP (those route via their own branches).
+    /// SMB and device volumes (those route via their own branches).
     pub is_ejectable: bool,
     /// True if this is an SMB volume (any state: Direct, OsMount, Disconnected).
     pub is_smb: bool,
-    /// True if this is an MTP/mobile-device volume.
-    pub is_mtp: bool,
+    /// The device provider (`"mtp"`, `"adb"`) that owns this volume, if one does.
+    pub device_provider: Option<&'static str>,
 }
 
 /// Decides what to do for a given volume. Pure function; the impure parts
-/// (looking up the volume, running `diskutil`, calling MTP disconnect) live
-/// in [`eject`].
+/// (looking up the volume, running `diskutil`, calling the provider's eject)
+/// live in [`eject`].
 pub fn decide_eject_action(ctx: &EjectContext) -> Result<EjectAction, EjectDecisionError> {
-    if ctx.is_mtp {
-        // rsplit-based parse (identity) so a `:` inside a serial-based device id
-        // doesn't truncate it: the storage id is the trailing numeric component.
-        let device_id = cmdr_fs::volume::mtp_ids::device_id_of_volume(ctx.volume_id)
-            .map(str::to_string)
-            .ok_or_else(|| EjectDecisionError::MtpIdMissingDevicePrefix {
-                volume_id: ctx.volume_id.to_string(),
-            })?;
-        return Ok(EjectAction::MtpDisconnect { device_id });
+    if let Some(provider) = ctx.device_provider {
+        return Ok(EjectAction::DeviceDisconnect {
+            provider,
+            volume_id: ctx.volume_id.to_string(),
+        });
     }
     if ctx.is_smb {
         return Ok(EjectAction::DiskutilUnmount);
@@ -123,13 +115,7 @@ pub enum EjectError {
         /// The id that no longer resolves.
         volume_id: String,
     },
-    /// The MTP volume id is shaped wrong: missing the `{device_id}:{storage_id}`
-    /// separator.
-    MtpIdMissingDevicePrefix {
-        /// The malformed id, verbatim.
-        volume_id: String,
-    },
-    /// The volume can't be ejected at all: not SMB, not MTP, and the OS reports
+    /// The volume can't be ejected at all: not SMB, not a device, and the OS reports
     /// it as fixed. Typical for the boot volume and other internal disks.
     NotEjectable {
         /// The volume asked about.
@@ -142,9 +128,12 @@ pub enum EjectError {
         /// The volume asked about.
         volume_id: String,
     },
-    /// The device wouldn't close its MTP session.
-    MtpDisconnectRefused {
-        /// What the MTP layer reported, for the log and the details line.
+    /// The device provider wouldn't retire the volume (MTP: the device wouldn't
+    /// close its session).
+    DeviceDisconnectRefused {
+        /// Which provider refused (`"mtp"`, `"adb"`).
+        provider: String,
+        /// What the provider reported, for the log and the details line.
         detail: String,
     },
     /// `diskutil` / `umount` turned the unmount down. The overwhelmingly common
@@ -171,12 +160,11 @@ impl std::fmt::Display for EjectError {
         match self {
             Self::Busy => f.write_str("operations are in progress on this device"),
             Self::VolumeNotFound { volume_id } => write!(f, "volume not found: {volume_id}"),
-            Self::MtpIdMissingDevicePrefix { volume_id } => {
-                write!(f, "MTP volume id {volume_id} is missing a device prefix")
-            }
             Self::NotEjectable { volume_id } => write!(f, "volume {volume_id} isn't ejectable"),
             Self::NotAnSmbVolume { volume_id } => write!(f, "volume {volume_id} isn't an SMB volume"),
-            Self::MtpDisconnectRefused { detail } => write!(f, "MTP disconnect refused: {detail}"),
+            Self::DeviceDisconnectRefused { provider, detail } => {
+                write!(f, "{provider} disconnect refused: {detail}")
+            }
             Self::UnmountRefused { detail } => write!(f, "unmount refused: {detail}"),
             Self::TimedOut => f.write_str("timed out"),
             Self::Unexpected { detail } => write!(f, "unexpected: {detail}"),
@@ -189,7 +177,6 @@ impl std::error::Error for EjectError {}
 impl From<EjectDecisionError> for EjectError {
     fn from(error: EjectDecisionError) -> Self {
         match error {
-            EjectDecisionError::MtpIdMissingDevicePrefix { volume_id } => Self::MtpIdMissingDevicePrefix { volume_id },
             EjectDecisionError::NotEjectable { volume_id } => Self::NotEjectable { volume_id },
         }
     }
@@ -213,11 +200,12 @@ pub async fn eject(volume_id: &str) -> Result<(), EjectError> {
         return Err(EjectError::Busy);
     }
 
-    // MTP volumes use ID format `{device_id}:{storage_id}` and aren't
-    // registered in VolumeManager; check the live MTP device list first.
-    let is_mtp = is_mtp_volume_id(volume_id).await;
+    // A device provider answers for its own volumes from live state, so an id
+    // that merely looks device-shaped can't route an eject at nothing. Asked
+    // first: MTP storages aren't registered under a mount path at all.
+    let provider = crate::device_volumes::provider_for_volume_id(volume_id).await;
 
-    let (mount_path, is_smb) = if is_mtp {
+    let (mount_path, is_smb) = if provider.is_some() {
         (String::new(), false)
     } else {
         let volume = get_volume_manager()
@@ -233,7 +221,7 @@ pub async fn eject(volume_id: &str) -> Result<(), EjectError> {
     // For physical volumes, ejectability comes from NSURL (macOS) /
     // `/sys/block/*/removable` (Linux). Look it up via the fast statfs-based
     // resolver instead of enumerating all volumes.
-    let is_ejectable = if is_mtp || is_smb {
+    let is_ejectable = if provider.is_some() || is_smb {
         false
     } else {
         resolve_is_ejectable(&mount_path).await
@@ -243,15 +231,26 @@ pub async fn eject(volume_id: &str) -> Result<(), EjectError> {
         volume_id,
         is_ejectable,
         is_smb,
-        is_mtp,
+        device_provider: provider.as_ref().map(|p| p.id()),
     })
     .map_err(EjectError::from)?;
 
     match action {
-        EjectAction::MtpDisconnect { device_id } => mtp_disconnect(&device_id).await,
+        EjectAction::DeviceDisconnect { provider: id, volume_id } => {
+            let provider = provider.ok_or_else(|| EjectError::VolumeNotFound {
+                volume_id: volume_id.clone(),
+            })?;
+            provider
+                .eject(&volume_id)
+                .await
+                .map_err(|detail| EjectError::DeviceDisconnectRefused {
+                    provider: id.to_string(),
+                    detail,
+                })
+        }
         // For disk volumes, stop the index BEFORE the unmount (the wedge-safe point).
-        // MTP tears its index down through the disconnect hook, so it isn't stopped
-        // here.
+        // A device provider tears its index down through its own disconnect hook,
+        // so it isn't stopped here.
         EjectAction::DiskutilUnmount => {
             stop_index_then_unmount(volume_id, || diskutil_run("unmount", &mount_path)).await
         }
@@ -355,19 +354,6 @@ pub async fn disconnect_smb(volume_id: &str) -> Result<(), EjectError> {
     Ok(())
 }
 
-/// MTP volume IDs are shaped `{device_id}:{storage_id}` (see
-/// `commands/volumes.rs::append_mtp_volumes`). Confirm against the live device
-/// list so we don't false-positive on any future ID containing a colon.
-async fn is_mtp_volume_id(volume_id: &str) -> bool {
-    let Some(device_id) = cmdr_fs::volume::mtp_ids::device_id_of_volume(volume_id) else {
-        return false;
-    };
-    crate::mtp::connection_manager()
-        .get_device_info(device_id)
-        .await
-        .is_some()
-}
-
 /// Looks up `is_ejectable` for the volume at `mount_path` via the per-path
 /// statfs/NSURL fast resolver. Avoids the full volume enumeration.
 async fn resolve_is_ejectable(mount_path: &str) -> bool {
@@ -395,17 +381,6 @@ async fn resolve_is_ejectable(mount_path: &str) -> bool {
         .await
         .unwrap_or(false)
     }
-}
-
-async fn mtp_disconnect(device_id: &str) -> Result<(), EjectError> {
-    crate::mtp::connection_manager()
-        .disconnect(
-            device_id,
-            None::<&tauri::AppHandle>,
-            crate::mtp::MtpDisconnectReason::User,
-        )
-        .await
-        .map_err(|e| EjectError::MtpDisconnectRefused { detail: e.to_string() })
 }
 
 /// Runs a blocking eject subprocess with a 15 s timeout, mapping the outcome to
@@ -470,54 +445,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn mtp_volume_routes_to_mtp_disconnect() {
-        let ctx = EjectContext {
-            volume_id: "mtp-336592896:65537",
-            is_ejectable: false,
-            is_smb: false,
-            is_mtp: true,
-        };
-        assert_eq!(
-            decide_eject_action(&ctx).unwrap(),
-            EjectAction::MtpDisconnect {
-                device_id: "mtp-336592896".to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn mtp_volume_with_colon_in_serial_keeps_the_full_device_id() {
-        // Regression for the identity fix: a serial-based device id can contain a
-        // `:`. The rsplit-based parse must keep the WHOLE device id, splitting
-        // only on the trailing numeric storage id.
+    fn device_volume_routes_to_its_provider() {
+        // The id is handed over whole: the provider owns its parse (MTP splits
+        // `{device_id}:{storage_id}` on the LAST colon, so a serial with `:` in
+        // it survives).
         let ctx = EjectContext {
             volume_id: "mtp-AA:BB:CC:65537",
             is_ejectable: false,
             is_smb: false,
-            is_mtp: true,
+            device_provider: Some("mtp"),
         };
         assert_eq!(
             decide_eject_action(&ctx).unwrap(),
-            EjectAction::MtpDisconnect {
-                device_id: "mtp-AA:BB:CC".to_string()
+            EjectAction::DeviceDisconnect {
+                provider: "mtp",
+                volume_id: "mtp-AA:BB:CC:65537".to_string()
             }
         );
     }
 
     #[test]
-    fn mtp_without_colon_errors() {
+    fn device_provider_wins_over_every_other_flag() {
         let ctx = EjectContext {
-            volume_id: "no-colon-id",
-            is_ejectable: false,
-            is_smb: false,
-            is_mtp: true,
+            volume_id: "adb-serial",
+            is_ejectable: true,
+            is_smb: true,
+            device_provider: Some("adb"),
         };
-        assert_eq!(
-            decide_eject_action(&ctx).unwrap_err(),
-            EjectDecisionError::MtpIdMissingDevicePrefix {
-                volume_id: "no-colon-id".to_string(),
-            }
-        );
+        assert!(matches!(
+            decide_eject_action(&ctx).unwrap(),
+            EjectAction::DeviceDisconnect { provider: "adb", .. }
+        ));
     }
 
     #[test]
@@ -526,7 +484,7 @@ mod tests {
             volume_id: "smb-naspolya-445-public",
             is_ejectable: false,
             is_smb: true,
-            is_mtp: false,
+            device_provider: None,
         };
         assert_eq!(decide_eject_action(&ctx).unwrap(), EjectAction::DiskutilUnmount);
     }
@@ -537,7 +495,7 @@ mod tests {
             volume_id: "volumes-usb-drive",
             is_ejectable: true,
             is_smb: false,
-            is_mtp: false,
+            device_provider: None,
         };
         assert_eq!(decide_eject_action(&ctx).unwrap(), EjectAction::DiskutilEject);
     }
@@ -548,7 +506,7 @@ mod tests {
             volume_id: "root",
             is_ejectable: false,
             is_smb: false,
-            is_mtp: false,
+            device_provider: None,
         };
         assert_eq!(
             decide_eject_action(&ctx).unwrap_err(),
@@ -604,7 +562,7 @@ mod tests {
             volume_id: "smb-foo",
             is_ejectable: true,
             is_smb: true,
-            is_mtp: false,
+            device_provider: None,
         };
         assert_eq!(decide_eject_action(&ctx).unwrap(), EjectAction::DiskutilUnmount);
     }
@@ -652,10 +610,14 @@ mod wire_tests {
         .into();
         assert!(matches!(err, EjectError::NotEjectable { ref volume_id } if volume_id == "root"));
 
-        let err: EjectError = EjectDecisionError::MtpIdMissingDevicePrefix {
-            volume_id: "no-colon".to_string(),
-        }
-        .into();
-        assert!(matches!(err, EjectError::MtpIdMissingDevicePrefix { .. }));
+        let json = serde_json::to_value(EjectError::DeviceDisconnectRefused {
+            provider: "mtp".to_string(),
+            detail: "PTP CloseSession timed out".to_string(),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "type": "deviceDisconnectRefused", "provider": "mtp", "detail": "PTP CloseSession timed out" })
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/ipc.rs
+++ b/apps/desktop/src-tauri/src/ipc.rs
@@ -504,6 +504,10 @@ macro_rules! ipc_command_manifest {
                     crate::commands::mtp::rename_mtp_object,
                     crate::commands::mtp::move_mtp_object,
                     crate::commands::mtp::scan_mtp_for_copy,
+                    // Android over ADB. ❌ No stub counterpart, like SFTP: the
+                    // backend is macOS + Linux only.
+                    crate::adb::commands::list_adb_devices,
+                    crate::adb::commands::connect_adb_device,
                 ]
                 dispatch_only: []
             }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -62,6 +62,9 @@ use tauri_plugin_updater as _;
 // mtp-rs is used in mtp/ module for Android device support (macOS + Linux)
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use mtp_rs as _;
+// cmdr-adb is used in the adb/ module for Android-over-ADB support (macOS + Linux)
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+use cmdr_adb as _;
 
 // These host primitives live in `cmdr-fs` so every crate in the workspace shares
 // one copy, and are re-exported here at their original paths: poison-free
@@ -127,6 +130,9 @@ mod mcp;
 mod menu;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 mod mtp;
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+mod adb;
+mod device_volumes;
 #[cfg(target_os = "macos")]
 mod native_drag;
 mod net;
@@ -472,6 +478,12 @@ pub fn run() {
             // are the two things that can connect one.
             #[cfg(any(target_os = "macos", target_os = "linux"))]
             mtp::volume_wiring::install_volume_registrar();
+            // File MTP as a device provider, so the volume list, eject, and path
+            // resolution see its storages. `device_volumes` is the seam.
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            mtp::volume_wiring::install_device_provider();
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            adb::volume_wiring::install_device_provider();
 
             // Wire the "busy volumes" emitter so write ops can broadcast
             // `volumes-busy-changed` (drives disabling Eject while a transfer touches a
@@ -570,6 +582,12 @@ pub fn run() {
             if !fda_gate::is_fda_pending_runtime() {
                 mtp::start_mtp_watcher(app.handle());
             }
+
+            // Follow the ADB server's device list (`host:track-devices`). Talks
+            // only to the local server socket, never to USB, so no TCC prompt and
+            // no FDA gate; with no `adb` installed it logs at debug and idles.
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            adb::start_adb_tracker(app.handle());
 
             // Emit initial volume list (after watchers start so MTP devices can connect)
             volume_broadcast::emit_volumes_changed_now();

--- a/apps/desktop/src-tauri/src/mtp/DETAILS.md
+++ b/apps/desktop/src-tauri/src/mtp/DETAILS.md
@@ -207,6 +207,13 @@ wiring. Neither module could then be understood or moved alone, and MTP can't be
 app. This is the shape FTP, S3, and SFTP should copy: **the wiring knows the backend, the backend never knows the
 registry.**
 
+**The same module is also the listing's device seam.** `volume_wiring.rs` registers `MtpDeviceProvider`, MTP's
+`device_volumes::DeviceVolumeProvider`, at startup beside the registrar: `volume_listing::complete` folds over every
+registered provider rather than naming MTP, and eject and path resolution ask the registry which provider owns an id.
+`entries()` answers from `KNOWN_DEVICES`, never from USB, and `check_for_device_changes()` calls
+`device_volumes::notify_devices_changed("mtp")` on every diff. ADB (`adb/`) is the second provider; the seam's contract
+is the module doc of `device_volumes.rs`.
+
 **Gotcha: the attach must complete before the event loop starts, and the hook must not break that.** `connect()`
 attaches every storage and only then calls `start_event_loop`. Everything the loop reaches routes through the volume
 registry (open listings are looked up by volume id; the per-volume index routes by device id), so an event that arrived

--- a/apps/desktop/src-tauri/src/mtp/volume_wiring.rs
+++ b/apps/desktop/src-tauri/src/mtp/volume_wiring.rs
@@ -1,4 +1,5 @@
-//! MTP volume wiring: turns "a storage attached" into a registered `MtpVolume`.
+//! MTP volume wiring: turns "a storage attached" into a registered `MtpVolume`,
+//! and answers the volume list as a `DeviceVolumeProvider`.
 //!
 //! This is the MTP twin of `network::smb_upgrade`, which registers `SmbVolume`
 //! the same way. Both exist so a backend never registers itself: the wiring
@@ -6,11 +7,16 @@
 //! the wiring. New backends (FTP, S3, SFTP) copy this shape. The rule and its
 //! rationale: `DETAILS.md` § "Backends never register themselves".
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use log::debug;
+
+use crate::device_volumes::{DeviceVolumeEntry, DeviceVolumeProvider, register_device_provider};
 use crate::file_system::volume::MtpVolume;
 use crate::file_system::volume::manager::get_volume_manager;
 use crate::mtp::connection::{MtpVolumeRegistrar, set_volume_registrar};
-use log::debug;
-use std::sync::Arc;
 
 /// Teaches the MTP session layer how a storage becomes a volume.
 ///
@@ -38,4 +44,107 @@ pub(crate) fn install_volume_registrar() {
             debug!("Unregistered MTP volume: {volume_id}");
         },
     });
+}
+
+// ============================================================================
+// The device provider
+// ============================================================================
+
+/// MTP's answer to `device_volumes::DeviceVolumeProvider`: the connected
+/// devices' storages, from the connection manager's cached device list.
+struct MtpDeviceProvider;
+
+impl DeviceVolumeProvider for MtpDeviceProvider {
+    fn id(&self) -> &'static str {
+        "mtp"
+    }
+
+    /// Each storage becomes its own entry. One device with several storages
+    /// spells each `"<device> - <storage>"`; a single-storage device is just
+    /// the device name, because the storage name is noise the user didn't ask
+    /// for ("Internal shared storage").
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<DeviceVolumeEntry>> + Send + '_>> {
+        Box::pin(async {
+            let devices = crate::mtp::connection_manager().get_all_connected_devices().await;
+            let mut entries = Vec::new();
+            for device in devices {
+                let multi = device.storages.len() > 1;
+                let device_name = device
+                    .device
+                    .product
+                    .as_deref()
+                    .or(device.device.manufacturer.as_deref())
+                    .unwrap_or("Mobile device");
+                for storage in &device.storages {
+                    let name = if multi {
+                        format!("{} - {}", device_name, storage.name)
+                    } else {
+                        device_name.to_string()
+                    };
+                    entries.push(DeviceVolumeEntry {
+                        id: format!("{}:{}", device.device.id, storage.id),
+                        name,
+                        path: format!("mtp://{}/{}", device.device.id, storage.id),
+                        fs_type: "mtp",
+                        mount_is_read_only: storage.is_read_only,
+                        usb_speed: device.device.usb_speed,
+                    });
+                }
+            }
+            entries
+        })
+    }
+
+    /// MTP volume ids are shaped `{device_id}:{storage_id}`. Confirmed against
+    /// the live device list so a future id containing a colon can't
+    /// false-positive.
+    fn owns_volume_id<'a>(&'a self, volume_id: &'a str) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+        Box::pin(async move {
+            let Some(device_id) = cmdr_fs::volume::mtp_ids::device_id_of_volume(volume_id) else {
+                return false;
+            };
+            crate::mtp::connection_manager()
+                .get_device_info(device_id)
+                .await
+                .is_some()
+        })
+    }
+
+    /// Live space from an `mtp://{device_id}/{storage_id}/...` path.
+    fn space_for_path<'a>(&'a self, path: &'a str) -> Pin<Box<dyn Future<Output = Option<(u64, u64)>> + Send + 'a>> {
+        Box::pin(async move {
+            let rest = path.strip_prefix("mtp://")?;
+            let mut parts = rest.splitn(3, '/');
+            let device_id = parts.next()?;
+            let storage_id: u32 = parts.next()?.parse().ok()?;
+            crate::mtp::connection_manager()
+                .get_live_storage_space(device_id, storage_id)
+                .await
+        })
+    }
+
+    /// Closes the device's MTP session. The `mtp-device-disconnected` event
+    /// then removes every one of its storages from the picker.
+    fn eject<'a>(&'a self, volume_id: &'a str) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+        Box::pin(async move {
+            // rsplit-based parse (identity) so a `:` inside a serial-based device
+            // id doesn't truncate it: the storage id is the trailing numeric part.
+            let device_id = cmdr_fs::volume::mtp_ids::device_id_of_volume(volume_id)
+                .ok_or_else(|| format!("MTP volume id {volume_id} is missing a device prefix"))?;
+            crate::mtp::connection_manager()
+                .disconnect(
+                    device_id,
+                    None::<&tauri::AppHandle>,
+                    crate::mtp::MtpDisconnectReason::User,
+                )
+                .await
+                .map_err(|e| e.to_string())
+        })
+    }
+}
+
+/// Files MTP as a device provider, so the volume list, eject, and path
+/// resolution see its storages. Call once at startup.
+pub(crate) fn install_device_provider() {
+    register_device_provider(Arc::new(MtpDeviceProvider));
 }

--- a/apps/desktop/src-tauri/src/volume_listing.rs
+++ b/apps/desktop/src-tauri/src/volume_listing.rs
@@ -5,7 +5,9 @@
 //! `list_volumes` IPC call and the `volumes-changed` push publish the same list
 //! to the same frontend, so they have to assemble it the same way. This module
 //! owns the platform aliases and the assembly, and every consumer goes through
-//! [`complete`] rather than re-deriving the steps.
+//! [`complete`] rather than re-deriving the steps. Device-backed volumes (MTP,
+//! ADB) come from `device_volumes`, which also answers the per-path questions
+//! (`device_volume_for_path`, `device_space_for_path`).
 
 use std::time::Duration;
 
@@ -72,12 +74,13 @@ pub(crate) async fn discover_local(timeout: Duration) -> ListingOutcome {
     }
 }
 
-/// Completes a local listing into the list every consumer publishes: appends the
-/// connected MTP storages, then enriches every entry from the volume registry.
+/// Completes a local listing into the list every consumer publishes: appends
+/// every device provider's storages (`device_volumes`), then enriches every
+/// entry from the volume registry.
 ///
 /// **The order is the reason this function exists.** Enrichment copies across
 /// what only the registered `Volume` knows (its capability surface, and on macOS
-/// its SMB connection state), and MTP storages are registered volumes too — so
+/// its SMB connection state), and device storages are registered volumes too, so
 /// appending them after enrichment ships mobile devices to the frontend with
 /// `capabilities: None`, and the pane falls back to per-kind defaults instead of
 /// what the backend actually offers. Callers hand over a local listing and get
@@ -85,8 +88,7 @@ pub(crate) async fn discover_local(timeout: Duration) -> ListingOutcome {
 pub(crate) async fn complete(local: Vec<LocationInfo>) -> Vec<LocationInfo> {
     let mut volumes = local;
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    append_mtp_volumes(&mut volumes).await;
+    crate::device_volumes::append_device_volumes(&mut volumes).await;
 
     #[cfg(target_os = "macos")]
     crate::volumes::enrich_from_volume_registry(&mut volumes);
@@ -108,81 +110,4 @@ pub(crate) async fn list_with_timeout(timeout: Duration) -> (Vec<LocationInfo>, 
         ListingOutcome::TimedOut | ListingOutcome::Panicked => (Vec::new(), true),
     };
     (complete(local).await, timed_out)
-}
-
-// ============================================================================
-// MTP
-// ============================================================================
-
-/// Appends the connected MTP device storages to the volume list. Each storage
-/// becomes its own entry under `MobileDevice`.
-///
-/// One device with several storages spells each entry `"<device> - <storage>"`;
-/// a single-storage device is just the device name, because the storage name is
-/// noise the user didn't ask for ("Internal shared storage").
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-async fn append_mtp_volumes(volumes: &mut Vec<LocationInfo>) {
-    let devices = crate::mtp::connection_manager().get_all_connected_devices().await;
-    for device in devices {
-        let multi = device.storages.len() > 1;
-        let device_name = device
-            .device
-            .product
-            .as_deref()
-            .or(device.device.manufacturer.as_deref())
-            .unwrap_or("Mobile device");
-        for storage in &device.storages {
-            let name = if multi {
-                format!("{} - {}", device_name, storage.name)
-            } else {
-                device_name.to_string()
-            };
-            volumes.push(LocationInfo {
-                id: format!("{}:{}", device.device.id, storage.id),
-                name,
-                path: format!("mtp://{}/{}", device.device.id, storage.id),
-                category: LocationCategory::MobileDevice,
-                icon: None,
-                is_ejectable: true,
-                mount_is_read_only: storage.is_read_only,
-                is_disk_image: false,
-                fs_type: Some("mtp".to_string()),
-                supports_trash: false,
-                smb_connection_state: None,
-                usb_speed: device.device.usb_speed,
-                capabilities: None,
-            });
-        }
-    }
-}
-
-/// Finds the MTP volume matching an `mtp://device_id/storage_id/...` path, so
-/// path resolution can answer for a device without enumerating local mounts.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-pub(crate) async fn mtp_volume_for_path(path: &str) -> Option<LocationInfo> {
-    let rest = path.strip_prefix("mtp://")?;
-    let mut parts = rest.splitn(3, '/');
-    let device_id = parts.next()?;
-    let storage_id_str = parts.next()?;
-    // Parsed, not used: a non-numeric storage segment isn't an MTP path at all,
-    // and matching the prefix below would otherwise accept it.
-    let _storage_id: u32 = storage_id_str.parse().ok()?;
-
-    let mut volumes = Vec::new();
-    append_mtp_volumes(&mut volumes).await;
-    let prefix = format!("mtp://{}/{}", device_id, storage_id_str);
-    volumes.into_iter().find(|v| v.path == prefix)
-}
-
-/// Queries live MTP space from an `mtp://{device_id}/{storage_id}/...` path.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-pub(crate) async fn mtp_space_for_path(path: &str) -> Option<(u64, u64)> {
-    let rest = path.strip_prefix("mtp://")?;
-    let mut parts = rest.splitn(3, '/');
-    let device_id = parts.next()?;
-    let storage_id: u32 = parts.next()?.parse().ok()?;
-
-    crate::mtp::connection_manager()
-        .get_live_storage_space(device_id, storage_id)
-        .await
 }

--- a/apps/desktop/src-tauri/src/volumes/CLAUDE.md
+++ b/apps/desktop/src-tauri/src/volumes/CLAUDE.md
@@ -40,8 +40,9 @@ Everything re-exports from `mod.rs` (`LocationInfo` / `LocationCategory`, consts
 - **`LocationInfo` enrichment from `VolumeManager` lives only in `enrich_from_volume_registry`**; new enrichment fields
   go there once. It fills `capabilities` and `smb_connection_state`. ❌ Never fill `capabilities` from a discovery
   constructor: discovery knows the mount, the registry knows the backend.
-- **Assemble a published volume list through `volume_listing::complete`**: it holds the order (MTP storages appended,
-  then enrichment, or mobile devices publish with no capabilities) and owns the only `append_mtp_volumes`.
+- **Assemble a published volume list through `volume_listing::complete`**: it holds the order (device volumes
+  appended from every `device_volumes::DeviceVolumeProvider`, MTP and ADB, then enrichment, or mobile devices publish
+  with no capabilities) and owns the only `device_volumes::append_device_volumes` call.
 - **`get_main_volume` / `get_attached_volumes` / `get_volume_space` wrap their bodies in
   `objc2::rc::autoreleasepool`** (they run in `spawn_blocking`, so the per-call objc objects would leak), and
   `start_volume_watcher`'s observer block runs on the main thread: keep it cheap, no blocking I/O.

--- a/apps/desktop/src/lib/adb/adb-connect-errors.ts
+++ b/apps/desktop/src/lib/adb/adb-connect-errors.ts
@@ -1,0 +1,31 @@
+/**
+ * The words for a typed `AdbConnectError`: what connecting a device over ADB
+ * says when it doesn't produce a volume. Classification is the backend's
+ * (`crates/cmdr-adb/src/errors.rs`); the words all live in the `adb.connect.*`
+ * catalog so every locale gets its own.
+ */
+import { tString } from '$lib/intl/messages.svelte'
+import type { AdbConnectError } from '$lib/tauri-commands'
+
+/**
+ * One sentence for a connect refusal, or `null` when there is nothing to say
+ * (the person cancelled it themselves).
+ */
+export function adbConnectErrorMessage(error: AdbConnectError): string | null {
+  switch (error.type) {
+    case 'adbNotInstalled':
+      return tString('adb.connect.adbNotInstalled')
+    case 'unauthorized':
+      return tString('adb.connect.unauthorized')
+    case 'deviceTooOld':
+      return tString('adb.connect.deviceTooOld')
+    case 'deviceGone':
+      return tString('adb.connect.deviceGone')
+    case 'serverUnreachable':
+      return tString('adb.connect.serverUnreachable')
+    case 'timedOut':
+      return tString('adb.connect.timedOut')
+    case 'cancelled':
+      return null
+  }
+}

--- a/apps/desktop/src/lib/adb/adb-path-utils.test.ts
+++ b/apps/desktop/src/lib/adb/adb-path-utils.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import {
+  constructAdbPath,
+  getAdbDisplayPath,
+  getAdbParentPath,
+  getDeviceDisplayPath,
+  isAdbPath,
+  isAdbVolumeId,
+  isDeviceScheme,
+  isDeviceVolumeId,
+  joinAdbPath,
+  parseAdbPath,
+} from './adb-path-utils'
+
+describe('parseAdbPath', () => {
+  it('parses the device root', () => {
+    expect(parseAdbPath('adb://R58M12345')).toEqual({ serial: 'R58M12345', path: '' })
+    expect(parseAdbPath('adb://R58M12345/')).toEqual({ serial: 'R58M12345', path: '' })
+  })
+
+  it('parses a folder on the device', () => {
+    expect(parseAdbPath('adb://R58M12345/sdcard/DCIM')).toEqual({ serial: 'R58M12345', path: 'sdcard/DCIM' })
+  })
+
+  it('keeps a TCP serial (host:port) intact', () => {
+    expect(parseAdbPath('adb://192.168.1.5:5555/sdcard')).toEqual({ serial: '192.168.1.5:5555', path: 'sdcard' })
+  })
+
+  it('returns null for a non-ADB path or a missing serial', () => {
+    expect(parseAdbPath('/Users/me')).toBeNull()
+    expect(parseAdbPath('mtp://0-5/65537')).toBeNull()
+    expect(parseAdbPath('adb://')).toBeNull()
+  })
+})
+
+describe('constructAdbPath', () => {
+  it('builds the root without a trailing slash', () => {
+    expect(constructAdbPath('R58M12345')).toBe('adb://R58M12345')
+    expect(constructAdbPath('R58M12345', '/')).toBe('adb://R58M12345')
+  })
+
+  it('accepts absolute and relative device paths alike (root-anchored is idempotent)', () => {
+    expect(constructAdbPath('R58M12345', '/sdcard/DCIM')).toBe('adb://R58M12345/sdcard/DCIM')
+    expect(constructAdbPath('R58M12345', 'sdcard/DCIM')).toBe('adb://R58M12345/sdcard/DCIM')
+  })
+
+  it('round-trips through parseAdbPath', () => {
+    const parsed = parseAdbPath('adb://R58M12345/data/local/tmp')
+    if (!parsed) throw new Error('expected an ADB path to parse')
+    expect(constructAdbPath(parsed.serial, parsed.path)).toBe('adb://R58M12345/data/local/tmp')
+  })
+})
+
+describe('getAdbParentPath', () => {
+  it('walks up one level and stops at the device root', () => {
+    expect(getAdbParentPath('adb://R58M12345/sdcard/DCIM')).toBe('adb://R58M12345/sdcard')
+    expect(getAdbParentPath('adb://R58M12345/sdcard')).toBe('adb://R58M12345')
+    expect(getAdbParentPath('adb://R58M12345')).toBeNull()
+  })
+
+  it('returns null for a non-ADB path', () => {
+    expect(getAdbParentPath('/Users/me')).toBeNull()
+  })
+})
+
+describe('joinAdbPath', () => {
+  it('appends a child at the root and below it', () => {
+    expect(joinAdbPath('adb://R58M12345', 'sdcard')).toBe('adb://R58M12345/sdcard')
+    expect(joinAdbPath('adb://R58M12345/sdcard', 'DCIM')).toBe('adb://R58M12345/sdcard/DCIM')
+  })
+
+  it('leaves a non-ADB base untouched', () => {
+    expect(joinAdbPath('/Users/me', 'x')).toBe('/Users/me')
+  })
+})
+
+describe('getAdbDisplayPath', () => {
+  it('shows the absolute device path, "/" at the root', () => {
+    expect(getAdbDisplayPath('adb://R58M12345')).toBe('/')
+    expect(getAdbDisplayPath('adb://R58M12345/sdcard/DCIM')).toBe('/sdcard/DCIM')
+  })
+
+  it('passes a non-ADB path through', () => {
+    expect(getAdbDisplayPath('/Users/me')).toBe('/Users/me')
+  })
+})
+
+describe('the device-family predicates', () => {
+  it('isAdbVolumeId matches only the adb- prefix', () => {
+    expect(isAdbVolumeId('adb-pixel-7-a1b2c3d')).toBe(true)
+    expect(isAdbVolumeId('mtp-336592896:65537')).toBe(false)
+    expect(isAdbVolumeId('root')).toBe(false)
+  })
+
+  it('isAdbPath matches only the adb:// scheme', () => {
+    expect(isAdbPath('adb://R58M12345/sdcard')).toBe(true)
+    expect(isAdbPath('mtp://0-5/65537')).toBe(false)
+  })
+
+  it('isDeviceVolumeId covers both MTP and ADB ids and nothing local', () => {
+    expect(isDeviceVolumeId('adb-pixel-7-a1b2c3d')).toBe(true)
+    expect(isDeviceVolumeId('mtp-336592896:65537')).toBe(true)
+    expect(isDeviceVolumeId('mtp-336592896')).toBe(true)
+    expect(isDeviceVolumeId('root')).toBe(false)
+    expect(isDeviceVolumeId('smb-host-share')).toBe(false)
+  })
+
+  it('isDeviceScheme covers both schemes', () => {
+    expect(isDeviceScheme('adb://R58M12345')).toBe(true)
+    expect(isDeviceScheme('mtp://0-5/65537')).toBe(true)
+    expect(isDeviceScheme('smb://host/share')).toBe(false)
+    expect(isDeviceScheme('/Volumes/USB')).toBe(false)
+  })
+
+  it('getDeviceDisplayPath dispatches per scheme and passes the rest through', () => {
+    expect(getDeviceDisplayPath('mtp://0-5/65537')).toBe('/')
+    expect(getDeviceDisplayPath('mtp://0-5/65537/DCIM/Camera')).toBe('/DCIM/Camera')
+    expect(getDeviceDisplayPath('adb://R58M12345/sdcard/DCIM')).toBe('/sdcard/DCIM')
+    expect(getDeviceDisplayPath('/Users/me')).toBe('/Users/me')
+  })
+})

--- a/apps/desktop/src/lib/adb/adb-path-utils.ts
+++ b/apps/desktop/src/lib/adb/adb-path-utils.ts
@@ -1,0 +1,107 @@
+/**
+ * Utilities for parsing and constructing ADB paths, plus the device-scheme
+ * predicates that treat MTP and ADB alike.
+ *
+ * ADB path format: adb://{serial}/{device path}
+ * Examples:
+ *   - adb://R58M12345 (the device's `/`)
+ *   - adb://R58M12345/sdcard/DCIM (a folder on the device)
+ *
+ * Volume id format: `adb-{slug}-{digest}`. No colon, so `isMtpVolumeId` stays
+ * false for it and the two families never shadow each other.
+ *
+ * Contract: `docs/specs/android-adb-backend.md` § "Volume contract".
+ */
+
+import { getMtpDisplayPath, isMtpVolumeId } from '$lib/mtp/mtp-path-utils'
+
+const ADB_SCHEME = 'adb://'
+const MTP_SCHEME = 'mtp://'
+
+/** Parsed ADB path components. */
+export interface ParsedAdbPath {
+  serial: string
+  /** Path within the device (no leading slash; empty string for the device root). */
+  path: string
+}
+
+/**
+ * Parses an ADB path into its components.
+ * @returns Parsed path, or null if not a valid ADB path.
+ */
+export function parseAdbPath(path: string): ParsedAdbPath | null {
+  if (!path.startsWith(ADB_SCHEME)) return null
+  const parts = path.slice(ADB_SCHEME.length).split('/')
+  const serial = parts[0]
+  if (!serial) return null
+  return { serial, path: parts.slice(1).join('/') }
+}
+
+/** Constructs an ADB path from a serial and a device path (absolute or relative). */
+export function constructAdbPath(serial: string, path: string = ''): string {
+  const base = `${ADB_SCHEME}${serial}`
+  if (!path || path === '/') return base
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path
+  return `${base}/${normalizedPath}`
+}
+
+/** Whether a volume id names an ADB volume (`adb-…`). */
+export function isAdbVolumeId(volumeId: string): boolean {
+  return volumeId.startsWith('adb-')
+}
+
+/** Whether a path is on the `adb://` scheme. */
+export function isAdbPath(path: string): boolean {
+  return path.startsWith(ADB_SCHEME)
+}
+
+/**
+ * Gets the parent path for an ADB path.
+ * Returns null when not an ADB path or already at the device root.
+ */
+export function getAdbParentPath(path: string): string | null {
+  const parsed = parseAdbPath(path)
+  if (!parsed || !parsed.path) return null
+  const lastSlash = parsed.path.lastIndexOf('/')
+  return constructAdbPath(parsed.serial, lastSlash > 0 ? parsed.path.slice(0, lastSlash) : '')
+}
+
+/** Joins an ADB path with a child folder name. */
+export function joinAdbPath(basePath: string, childName: string): string {
+  const parsed = parseAdbPath(basePath)
+  if (!parsed) return basePath
+  return constructAdbPath(parsed.serial, parsed.path ? `${parsed.path}/${childName}` : childName)
+}
+
+/**
+ * Gets the display path for an ADB path (the absolute path on the device).
+ * Returns "/" for the device root.
+ */
+export function getAdbDisplayPath(path: string): string {
+  const parsed = parseAdbPath(path)
+  if (!parsed) return path
+  return parsed.path ? `/${parsed.path}` : '/'
+}
+
+/**
+ * Whether a volume id names a device-anchored volume (MTP or ADB): not local,
+ * no trash, no Finder reveal, no OS-visible path, no git over the transport.
+ */
+export function isDeviceVolumeId(volumeId: string): boolean {
+  return isMtpVolumeId(volumeId) || isAdbVolumeId(volumeId)
+}
+
+/** Whether a path is on one of the device schemes (`mtp://` or `adb://`). */
+export function isDeviceScheme(path: string): boolean {
+  return path.startsWith(MTP_SCHEME) || path.startsWith(ADB_SCHEME)
+}
+
+/**
+ * The display form of a device-scheme path: the path within the MTP storage or
+ * on the ADB device, "/" at the root. Any other path passes through unchanged.
+ */
+export function getDeviceDisplayPath(path: string): string {
+  if (path.startsWith(MTP_SCHEME)) return getMtpDisplayPath(path)
+  if (path.startsWith(ADB_SCHEME)) return getAdbDisplayPath(path)
+  return path
+}

--- a/apps/desktop/src/lib/adb/adb-volume-label.ts
+++ b/apps/desktop/src/lib/adb/adb-volume-label.ts
@@ -1,0 +1,21 @@
+/**
+ * The volume switcher's label for a device volume. The same phone can be listed
+ * twice, over MTP and over ADB, under the same model name; the ADB entry gets an
+ * "ADB" suffix only then, so a phone that is only reachable one way keeps its
+ * plain name. Contract: `docs/specs/android-adb-backend.md` § "App wiring".
+ */
+import type { VolumeInfo } from '$lib/file-explorer/types'
+import { tString } from '$lib/intl/messages.svelte'
+
+/** Whether this is the ADB half of a device also listed over MTP. */
+function hasMtpTwin(volume: VolumeInfo, volumes: readonly VolumeInfo[]): boolean {
+  return volumes.some(
+    (v) => v.id !== volume.id && v.category === 'mobile_device' && v.fsType !== 'adb' && v.name === volume.name,
+  )
+}
+
+/** The switcher label: the volume's name, suffixed with "ADB" when an MTP twin shares it. */
+export function deviceVolumeLabel(volume: VolumeInfo, volumes: readonly VolumeInfo[]): string {
+  if (volume.fsType !== 'adb' || !hasMtpTwin(volume, volumes)) return volume.name
+  return tString('adb.volumeLabelWithSuffix', { deviceName: volume.name })
+}

--- a/apps/desktop/src/lib/adb/index.ts
+++ b/apps/desktop/src/lib/adb/index.ts
@@ -1,0 +1,6 @@
+// Android over ADB: path utilities, connect-refusal wording, and the switcher label.
+// Pure modules import `./adb-path-utils` directly to stay free of the intl runtime.
+
+export * from './adb-path-utils'
+export { adbConnectErrorMessage } from './adb-connect-errors'
+export { deviceVolumeLabel } from './adb-volume-label'

--- a/apps/desktop/src/lib/file-explorer/navigation/DETAILS.md
+++ b/apps/desktop/src/lib/file-explorer/navigation/DETAILS.md
@@ -238,7 +238,7 @@ through `wordEjectRefusal(e)` in `eject-error-messages.ts`, which:
 - picks the one sentence for the variant from `errors.eject.*` through `getMessage()` (a RAW catalog lookup, never ICU
   `t()`: the `ejectFailedToast` around it interpolates uncontrolled volume names, whose apostrophes and braces collide
   with ICU grammar);
-- sends `ejectTechnicalDetail(error)` to the LOG. That's the `detail` field of `unmountRefused` / `mtpDisconnectRefused`
+- sends `ejectTechnicalDetail(error)` to the LOG. That's the `detail` field of `unmountRefused` / `deviceDisconnectRefused`
   / `unexpected`, usually `diskutil`'s own stderr naming the process still holding the drive. It never reaches the
   message: it's untranslated OS text;
 - answers a value that isn't an `EjectError` at all (the IPC transport itself broke) with the same honest

--- a/apps/desktop/src/lib/file-explorer/navigation/VolumeBreadcrumb.svelte
+++ b/apps/desktop/src/lib/file-explorer/navigation/VolumeBreadcrumb.svelte
@@ -63,6 +63,7 @@
     /** Tooltip shown on a disabled Eject control while a transfer touches the volume. */
     const EJECT_BUSY_TOOLTIP = $derived(tString('fileExplorer.navigation.ejectBusyTooltip'))
     import { groupByCategory, getIconForVolume } from './volume-grouping'
+    import { deviceVolumeLabel } from '$lib/adb/adb-volume-label'
     import { createVolumeSpaceManager } from './volume-space-manager.svelte'
     import { createDriveIndexManager, isDriveRow } from './drive-index-manager.svelte'
     import DriveIndexBadge from './DriveIndexBadge.svelte'
@@ -902,7 +903,7 @@
                                 aria-label={tString('fileExplorer.navigation.renameFavoriteAriaLabel')}
                             />
                         {:else}
-                            <span class="volume-label">{volume.name}</span>
+                            <span class="volume-label">{deviceVolumeLabel(volume, volumes)}</span>
                         {/if}
                         {#if fsLabel}
                             <span class="volume-fs">{fsLabel}</span>

--- a/apps/desktop/src/lib/file-explorer/navigation/breadcrumb-navigation.test.ts
+++ b/apps/desktop/src/lib/file-explorer/navigation/breadcrumb-navigation.test.ts
@@ -76,6 +76,22 @@ describe('enrichBreadcrumbSegments', () => {
     expect(segs[2].target).toBeNull() // current folder
   })
 
+  it('reconstructs ADB paths from the parsed serial (device root is the first target)', () => {
+    const ctx: BreadcrumbNavContext = {
+      volumeId: 'adb-pixel-7-a1b2c3d',
+      volumePath: 'adb://R58M12345',
+      currentPath: 'adb://R58M12345/sdcard/DCIM/Camera',
+      userHomePath: '/Users/dave',
+      isSearchResults: false,
+    }
+    // ADB display path is the absolute device path "/sdcard/DCIM/Camera".
+    const segs = enrich('/sdcard/DCIM/Camera', ctx)
+    expect(segs[0].target).toBeNull() // the empty root marker
+    expect(segs[1].target).toBe('adb://R58M12345/sdcard')
+    expect(segs[2].target).toBe('adb://R58M12345/sdcard/DCIM')
+    expect(segs[3].target).toBeNull() // current folder
+  })
+
   it('never makes search-results panes clickable', () => {
     const ctx: BreadcrumbNavContext = {
       volumeId: 'search-results',

--- a/apps/desktop/src/lib/file-explorer/navigation/breadcrumb-navigation.ts
+++ b/apps/desktop/src/lib/file-explorer/navigation/breadcrumb-navigation.ts
@@ -9,6 +9,7 @@
  *   - `~`-rooted: the base is the home dir (`~` → `userHomePath`).
  *   - non-root volume: the base is the volume path (display is volume-relative).
  *   - MTP: rebuild the `mtp://device/storage/...` URL from the parsed current path.
+ *   - ADB: rebuild the `adb://serial/...` URL from the parsed current path.
  *   - root volume, absolute: no base; the leading `/` comes from the root marker.
  *
  * The last segment (the current folder) and the empty leading root marker are
@@ -17,10 +18,11 @@
  */
 
 import { isMtpVolumeId, parseMtpPath, constructMtpPath } from '$lib/mtp'
+import { constructAdbPath, isAdbVolumeId, parseAdbPath } from '$lib/adb/adb-path-utils'
 import type { PathSegment } from './path-segments'
 
 export interface BreadcrumbNavContext {
-  /** The pane's volume id (drives the MTP branch). */
+  /** The pane's volume id (drives the MTP and ADB branches). */
   volumeId: string
   /** The volume's root path (`/` for the root volume, `mtp://…`/`smb://…` for virtual). */
   volumePath: string
@@ -55,6 +57,12 @@ function targetFor(segments: PathSegment[], index: number, ctx: BreadcrumbNavCon
     const parsed = parseMtpPath(ctx.currentPath)
     if (!parsed) return null
     return constructMtpPath(parsed.deviceId, parsed.storageId, innerPath(segments, index))
+  }
+
+  if (isAdbVolumeId(ctx.volumeId)) {
+    const parsed = parseAdbPath(ctx.currentPath)
+    if (!parsed) return null
+    return constructAdbPath(parsed.serial, innerPath(segments, index))
   }
 
   const first = segments[0]?.text

--- a/apps/desktop/src/lib/file-explorer/navigation/eject-error-messages.test.ts
+++ b/apps/desktop/src/lib/file-explorer/navigation/eject-error-messages.test.ts
@@ -29,10 +29,9 @@ afterAll(() => {
 const EJECT_CASES: EjectError[] = [
   { type: 'busy' },
   { type: 'volumeNotFound', volumeId: 'volumes-usb-drive' },
-  { type: 'mtpIdMissingDevicePrefix', volumeId: 'no-colon-id' },
   { type: 'notEjectable', volumeId: 'root' },
   { type: 'notAnSmbVolume', volumeId: 'volumes-usb-drive' },
-  { type: 'mtpDisconnectRefused', detail: 'PTP CloseSession timed out' },
+  { type: 'deviceDisconnectRefused', provider: 'mtp', detail: 'PTP CloseSession timed out' },
   { type: 'unmountRefused', detail: 'Unmount failed for /Volumes/Trip: in use by process 1234 (mds)' },
   { type: 'timedOut' },
   { type: 'unexpected', detail: 'the eject task panicked' },

--- a/apps/desktop/src/lib/file-explorer/navigation/eject-error-messages.ts
+++ b/apps/desktop/src/lib/file-explorer/navigation/eject-error-messages.ts
@@ -39,10 +39,9 @@ function raw(key: MessageKey): string {
 const EJECT_MESSAGE: { [K in EjectError['type']]: () => string } = {
   busy: () => raw('errors.eject.busy'),
   volumeNotFound: () => raw('errors.eject.volumeNotFound'),
-  mtpIdMissingDevicePrefix: () => raw('errors.eject.mtpIdMissingDevicePrefix'),
   notEjectable: () => raw('errors.eject.notEjectable'),
   notAnSmbVolume: () => raw('errors.eject.notAnSmbVolume'),
-  mtpDisconnectRefused: () => raw('errors.eject.mtpDisconnectRefused'),
+  deviceDisconnectRefused: () => raw('errors.eject.deviceDisconnectRefused'),
   unmountRefused: () => raw('errors.eject.unmountRefused'),
   timedOut: () => raw('errors.eject.timedOut'),
   // The single honest fallback. ❌ `detail` is never the message; it goes to
@@ -56,7 +55,7 @@ export function renderEjectError(error: EjectError): string {
 }
 
 /** `EjectError` variants that carry their own free-text `detail` field. */
-const DETAIL_BEARING_VARIANTS = new Set<EjectError['type']>(['unmountRefused', 'mtpDisconnectRefused', 'unexpected'])
+const DETAIL_BEARING_VARIANTS = new Set<EjectError['type']>(['unmountRefused', 'deviceDisconnectRefused', 'unexpected'])
 
 /**
  * The backend's own words for this refusal (usually `diskutil`'s stderr, which

--- a/apps/desktop/src/lib/file-explorer/pane/breadcrumb-bar.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/breadcrumb-bar.ts
@@ -11,6 +11,7 @@
 import { showBreadcrumbContextMenu } from '$lib/tauri-commands'
 import type { VolumeInfo } from '../types'
 import { isMtpVolumeId, getMtpDisplayPath } from '$lib/mtp'
+import { getAdbDisplayPath, isAdbVolumeId } from '$lib/adb/adb-path-utils'
 import { getEffectiveShortcuts } from '$lib/shortcuts/shortcuts-store'
 import { toDisplayShortcut } from '$lib/shortcuts/key-capture'
 import { isVolumeEjectable } from '../navigation/eject-predicate'
@@ -32,7 +33,7 @@ export interface BreadcrumbDisplayPathInput {
 /**
  * The path shown after the volume name. On the root volume the home prefix
  * becomes `~`; on any other volume the path is shown relative to its mount
- * point; MTP has its own display form.
+ * point; MTP and ADB have their own display forms.
  *
  * R3 B6: the search-results pane shows the snapshot's friendly label (the AI
  * title / filename pattern / regex pattern) AS the path. The volume selector
@@ -48,6 +49,7 @@ export function breadcrumbDisplayPath(input: BreadcrumbDisplayPathInput): string
     return input.searchLabel ?? 'Search'
   }
   if (isMtpVolumeId(volumeId)) return getMtpDisplayPath(currentPath)
+  if (isAdbVolumeId(volumeId)) return getAdbDisplayPath(currentPath)
 
   // For non-root volumes, strip the volume path prefix
   if (volumePath !== '/') {

--- a/apps/desktop/src/lib/file-explorer/pane/clipboard-operations.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/clipboard-operations.ts
@@ -40,7 +40,9 @@ type DialogState = ReturnType<typeof createDialogState>
  * in `clipboard-operations.test.ts`).
  */
 function isMtpClipboardRefusal(volumeId: string): boolean {
-  return capabilitiesFor(volumeId).kind === 'mtp'
+  // `adb` rides along: an `adb://` path is as invisible to the OS clipboard as an `mtp://` one.
+  const kind = capabilitiesFor(volumeId).kind
+  return kind === 'mtp' || kind === 'adb'
 }
 
 /**

--- a/apps/desktop/src/lib/file-explorer/pane/git-browser-sync.svelte.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/git-browser-sync.svelte.ts
@@ -16,6 +16,7 @@
 import { lookupRepoInfo, subscribeToRepo, unsubscribeFromRepo, type RepoInfo } from '../git/git-store.svelte'
 import { getSetting, onSpecificSettingChange } from '$lib/settings'
 import { isMtpVolumeId } from '$lib/mtp'
+import { isAdbVolumeId } from '$lib/adb/adb-path-utils'
 import { pathInsideArchive } from './volume-capabilities'
 
 export interface GitBrowserSyncDeps {
@@ -83,6 +84,7 @@ export function createGitBrowserSync(deps: GitBrowserSyncDeps): GitBrowserSync {
     if (
       !gitFeaturesNeeded ||
       isMtpVolumeId(deps.getVolumeId()) ||
+      isAdbVolumeId(deps.getVolumeId()) || // same reason: git can't run over the ADB transport
       !deps.getHasBackendListing() ||
       pathInsideArchive(path)
     ) {

--- a/apps/desktop/src/lib/file-explorer/pane/navigate.test.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/navigate.test.ts
@@ -765,6 +765,17 @@ describe('refusal strings (L12) — byte-for-byte contract', () => {
     })
   })
 
+  it('ADB path on a pane not on that device is refused (typed kind, no volume-id derivation)', () => {
+    const result = navigate(
+      { pane: 'left', to: { goTo: { volumeId: 'root', path: 'adb://R58M12345/sdcard' } }, source: 'mcp' },
+      h.deps,
+    )
+    expect(result).toEqual({
+      status: 'refused',
+      reason: { kind: 'adb-unconnected', message: 'Pane is not on this ADB volume. Call select_volume first.' },
+    })
+  })
+
   it('on-MTP-volume pane returns the exact "on the … MTP volume" string (volumeName falls back to id)', () => {
     h = makeHarness({ left: { path: 'mtp://dev/1/DCIM', volumeId: 'mtp-dev:1' } })
     const result = navigate(

--- a/apps/desktop/src/lib/file-explorer/pane/navigate.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/navigate.ts
@@ -130,6 +130,7 @@ import {
 } from '../navigation/navigation-history'
 import { isPathOnVolume, type DetermineNavigationPathArgs } from '../navigation/path-navigation'
 import { tString } from '$lib/intl/messages.svelte'
+import { isAdbVolumeId } from '$lib/adb/adb-path-utils'
 import type { Location } from '$lib/tauri-commands'
 
 /** Where a navigation originates. Drives focus + history-push behavior, never the destination. */
@@ -171,7 +172,13 @@ export interface NavigateIntent {
 
 /** Why a synchronous navigation refused. `message` is the exact current string — contract (L12). */
 export interface NavigateRefusal {
-  kind: 'on-network-volume' | 'smb-path-unsupported' | 'mtp-unconnected' | 'pane-unavailable' | 'no-volume-resolved'
+  kind:
+    | 'on-network-volume'
+    | 'smb-path-unsupported'
+    | 'mtp-unconnected'
+    | 'adb-unconnected'
+    | 'pane-unavailable'
+    | 'no-volume-resolved'
   /** EXACT current refusal string, forwarded verbatim as the `mcp-response` error. Pinned byte-for-byte. */
   message: string
 }
@@ -314,6 +321,32 @@ function validateMtpNavigation(path: string, volumeId: string, volumeName: strin
     return {
       kind: 'mtp-unconnected',
       message: `Pane is on the ${volumeName ?? volumeId} MTP volume. Use select_volume to switch to a local volume first.`,
+    }
+  }
+  return null
+}
+
+/**
+ * ADB capability check, the MTP twin: an `adb://<serial>/…` path is navigable only
+ * while the pane sits on that device's volume. Returns a refusal or `null`.
+ */
+function validateAdbNavigation(
+  deps: NavigateDeps,
+  path: string,
+  volumeId: string,
+  volumeName: string | undefined,
+): NavigateRefusal | null {
+  if (path.startsWith('adb://')) {
+    // The volume id (`adb-<slug>-<digest>`) isn't derivable from the serial; the
+    // volume's registered root (`adb://<serial>`) is the link.
+    const serial = /^adb:\/\/([^/]+)/.exec(path)?.[1]
+    if (!serial || !isAdbVolumeId(volumeId) || deps.getVolumePathById(volumeId) !== `adb://${serial}`) {
+      return { kind: 'adb-unconnected', message: 'Pane is not on this ADB volume. Call select_volume first.' }
+    }
+  } else if (isAdbVolumeId(volumeId)) {
+    return {
+      kind: 'adb-unconnected',
+      message: `Pane is on the ${volumeName ?? volumeId} ADB volume. Use select_volume to switch to a local volume first.`,
     }
   }
   return null
@@ -628,7 +661,9 @@ function navigateInPlace(deps: NavigateDeps, intent: NavigateIntent, path: strin
   }
 
   // MTP capability refusal (synchronous).
-  const mtpRefusal = validateMtpNavigation(path, currentVolumeId, currentVolumeName)
+  const mtpRefusal =
+    validateMtpNavigation(path, currentVolumeId, currentVolumeName) ??
+    validateAdbNavigation(deps, path, currentVolumeId, currentVolumeName)
   if (mtpRefusal) return { status: 'refused', reason: mtpRefusal }
 
   const paneRef = deps.getPaneRef(pane)

--- a/apps/desktop/src/lib/file-explorer/pane/volume-capabilities.test.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/volume-capabilities.test.ts
@@ -73,6 +73,14 @@ describe('capabilitiesForKind — the frozen per-kind defaults', () => {
       hasParentRow: true,
       syncsToMcp: true,
     },
+    adb: {
+      kind: 'adb',
+      hasBackendListing: true,
+      canWrite: true,
+      canBeSource: true,
+      hasParentRow: true,
+      syncsToMcp: true,
+    },
     network: {
       kind: 'network',
       hasBackendListing: false,
@@ -146,6 +154,7 @@ describe('volumeKindOf — the unified superset classifier', () => {
     expect(volumeKindOf('some-id', 'smbfs', undefined)).toBe('smb')
     expect(volumeKindOf('mtp-336592896:65537', undefined, 'mobile_device')).toBe('mtp')
     expect(volumeKindOf('0-5:65537', undefined, undefined)).toBe('mtp')
+    expect(volumeKindOf('adb-pixel-7-a1b2c3d', 'adb', 'mobile_device')).toBe('adb')
   })
 
   it('the favorite edge resolves to its containing real volume kind (local)', () => {
@@ -170,6 +179,7 @@ describe('volumeKindOf — the unified superset classifier', () => {
       ['search-results', undefined, undefined],
       ['root', 'apfs', 'main_volume'],
       ['mtp-1:1', undefined, 'mobile_device'],
+      ['adb-pixel-7-a1b2c3d', 'adb', 'mobile_device'],
       ['x', 'smbfs', undefined],
       ['fav', undefined, 'favorite'],
       ['weird', undefined, undefined],

--- a/apps/desktop/src/lib/file-explorer/pane/volume-capabilities.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/volume-capabilities.ts
@@ -46,7 +46,7 @@
  * ## One classifier, not two
  *
  * `volume-tint.svelte.ts::volumeKindFor` classifies into
- * `'local' | 'smb' | 'mtp' | 'other'` for tinting, collapsing the two virtual
+ * `'local' | 'smb' | 'mtp' | 'adb' | 'other'` for tinting, collapsing the two virtual
  * kinds + favorites into the untinted `'other'`. `volumeKindOf` here is the
  * SUPERSET: it adds the two virtual kinds as first-class, then DELEGATES to
  * `volumeKindFor` for the real kinds, overriding only its `'other'` fall-through
@@ -76,6 +76,7 @@ export type VolumeKind =
   | 'local' // real filesystem volume (root, attached, cloud_drive, main_volume)
   | 'smb' // mounted SMB share (real backend listing, smb path scheme on the share)
   | 'mtp' // connected MTP storage (real backend listing, mtp:// scheme, no system clipboard)
+  | 'adb' // an Android device over ADB (real backend listing, adb:// scheme, no system clipboard)
   | 'network' // the synthetic SMB browser virtual volume (host/share list, smb:// namespace)
   | 'search-results' // the snapshot virtual volume (search-results:// namespace, flat result set)
   | 'archive' // a pane inside a supported archive (kind-from-path; zip is writable, see the row)
@@ -149,6 +150,16 @@ const CAPABILITY_TABLE: Readonly<Record<VolumeKind, VolumeCapabilities>> = Objec
     hasParentRow: true,
     syncsToMcp: true,
   }),
+  adb: Object.freeze({
+    // Same shape as `mtp`: a device-anchored real listing. The transport differs
+    // (`adb sync`, a real filesystem), the pane's structure doesn't.
+    kind: 'adb',
+    hasBackendListing: true,
+    canWrite: true,
+    canBeSource: true,
+    hasParentRow: true,
+    syncsToMcp: true,
+  }),
   network: Object.freeze({
     kind: 'network',
     // The strictest kind: no listing, no source ops (the host/share list isn't
@@ -211,7 +222,7 @@ export function volumeKindOf(
   if (volumeId === 'network') return 'network'
   if (volumeId === 'search-results') return 'search-results'
   const tintKind = volumeKindFor(volumeId, fsType, category)
-  // `volumeKindFor` returns 'local' | 'smb' | 'mtp' | 'other'. The first three
+  // `volumeKindFor` returns 'local' | 'smb' | 'mtp' | 'adb' | 'other'. The first four
   // are real kinds in our union; 'other' (favorites + real-but-unclassified)
   // defaults to 'local' — the only sane capability set for a listable volume.
   return tintKind === 'other' ? 'local' : tintKind

--- a/apps/desktop/src/lib/file-explorer/pane/volume-tint.svelte.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/volume-tint.svelte.ts
@@ -27,6 +27,7 @@
 
 import { getSetting, onSpecificSettingChange, type VolumeTintColor } from '$lib/settings'
 import { isMtpVolumeId } from '$lib/mtp/mtp-path-utils'
+import { isAdbVolumeId } from '$lib/adb/adb-path-utils'
 import type { LocationCategory } from '$lib/file-explorer/types'
 import { hasColorMix } from '$lib/utils/webkit-compat'
 import { mixSrgb } from '$lib/utils/srgb-mix'
@@ -84,7 +85,7 @@ export function cleanupVolumeTints(): void {
   initialized = false
 }
 
-export type VolumeKind = 'local' | 'smb' | 'mtp' | 'other'
+export type VolumeKind = 'local' | 'smb' | 'mtp' | 'adb' | 'other'
 
 /**
  * Pure classifier: pick the tint bucket for a volume.
@@ -92,12 +93,18 @@ export type VolumeKind = 'local' | 'smb' | 'mtp' | 'other'
  * `other` covers favorites and the synthetic "network" browser view, which
  * don't carry a meaningful "this is a real volume" identity. Those panes
  * stay untinted regardless of settings.
+ *
+ * `adb` is checked BEFORE `mtp`: both are `mobile_device` volumes, and the
+ * category alone can't tell the two transports apart. The two share the
+ * `tintMtp` setting (one "mobile device" tint), so the split only matters to
+ * callers that key behavior on the transport.
  */
 export function volumeKindFor(
   volumeId: string,
   fsType: string | undefined,
   category: LocationCategory | undefined,
 ): VolumeKind {
+  if (isAdbVolumeId(volumeId) || fsType === 'adb') return 'adb'
   if (isMtpVolumeId(volumeId) || category === 'mobile_device') return 'mtp'
   if (category === 'network' || fsType === 'smbfs') return 'smb'
   if (
@@ -115,7 +122,7 @@ export function volumeKindFor(
 function tintForKind(kind: VolumeKind): VolumeTintColor {
   if (kind === 'local') return tintLocal
   if (kind === 'smb') return tintSmb
-  if (kind === 'mtp') return tintMtp
+  if (kind === 'mtp' || kind === 'adb') return tintMtp
   return 'none'
 }
 

--- a/apps/desktop/src/lib/file-explorer/pane/volume-tint.test.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/volume-tint.test.ts
@@ -38,6 +38,12 @@ describe('volumeKindFor', () => {
     expect(volumeKindFor('mtp-336592896', undefined, 'mobile_device')).toBe('mtp')
   })
 
+  it('classifies an ADB volume as adb, by id or by fsType, ahead of the mobile_device category', () => {
+    expect(volumeKindFor('adb-pixel-7-a1b2c3d', 'adb', 'mobile_device')).toBe('adb')
+    expect(volumeKindFor('adb-pixel-7-a1b2c3d', undefined, undefined)).toBe('adb')
+    expect(volumeKindFor('some-id', 'adb', 'mobile_device')).toBe('adb')
+  })
+
   it('classifies favorites and synthetic browsers as other', () => {
     expect(volumeKindFor('network', undefined, 'favorite')).toBe('other')
   })

--- a/apps/desktop/src/lib/file-explorer/tabs/tab-label.test.ts
+++ b/apps/desktop/src/lib/file-explorer/tabs/tab-label.test.ts
@@ -16,6 +16,11 @@ describe('deriveTabLabel', () => {
     expect(deriveTabLabel('mtp://0-5/65537/DCIM')).toBe('DCIM')
   })
 
+  it('shows "/" at an ADB device root and the folder name below it', () => {
+    expect(deriveTabLabel('adb://R58M12345')).toBe('/')
+    expect(deriveTabLabel('adb://R58M12345/sdcard/DCIM')).toBe('DCIM')
+  })
+
   it('shows "/" for the local filesystem root (convention pinned)', () => {
     expect(deriveTabLabel('/')).toBe('/')
   })

--- a/apps/desktop/src/lib/file-explorer/tabs/tab-label.ts
+++ b/apps/desktop/src/lib/file-explorer/tabs/tab-label.ts
@@ -1,5 +1,5 @@
 import { getFolderName } from '$lib/file-operations/transfer/transfer-dialog-utils'
-import { getMtpDisplayPath } from '$lib/mtp'
+import { getDeviceDisplayPath, isDeviceScheme } from '$lib/adb/adb-path-utils'
 
 /**
  * Derives the user-facing label for a tab from its path.
@@ -12,15 +12,18 @@ import { getMtpDisplayPath } from '$lib/mtp'
  * inner (within-storage) path instead: "/" at the storage root, the inner
  * folder basename below it — matching what the breadcrumb already shows.
  *
- * We special-case ONLY the MTP scheme. Every other path (including mounted
+ * An ADB path (`adb://{serial}/inner/path`) gets the same treatment: "/" at the
+ * device root, the inner folder basename below it.
+ *
+ * We special-case ONLY the two device schemes. Every other path (including mounted
  * volume roots like `/Volumes/USB`, which keep their basename "USB") flows
  * through `getFolderName` unchanged.
  */
 export function deriveTabLabel(path: string): string {
-  if (path.startsWith('mtp://')) {
-    // `getMtpDisplayPath` returns "/" at the storage root and `/DCIM/Camera`
-    // for a subfolder; its basename is the tab label.
-    return getFolderName(getMtpDisplayPath(path))
+  if (isDeviceScheme(path)) {
+    // `getDeviceDisplayPath` returns "/" at the storage or device root and
+    // `/DCIM/Camera` for a subfolder; its basename is the tab label.
+    return getFolderName(getDeviceDisplayPath(path))
   }
   return getFolderName(path)
 }

--- a/apps/desktop/src/lib/file-operations/transfer/transfer-dialog-utils.test.ts
+++ b/apps/desktop/src/lib/file-operations/transfer/transfer-dialog-utils.test.ts
@@ -124,6 +124,7 @@ describe('containingFolder', () => {
 
   it('answers for a virtual volume, where a clash is just as ambiguous', () => {
     expect(containingFolder('mtp://device/DCIM/Camera/IMG_0001.jpg')).toBe('mtp://device/DCIM/Camera')
+    expect(containingFolder('adb://R58M12345/sdcard/DCIM/IMG_0001.jpg')).toBe('adb://R58M12345/sdcard/DCIM')
   })
 
   it('says nothing rather than guessing at a path it cannot take a parent of', () => {

--- a/apps/desktop/src/lib/intl/keys.gen.ts
+++ b/apps/desktop/src/lib/intl/keys.gen.ts
@@ -3,6 +3,13 @@
 
 /** Every key present in `messages/en/*.json`. A wrong key is a typecheck error. */
 export type MessageKey =
+  | 'adb.connect.adbNotInstalled'
+  | 'adb.connect.deviceGone'
+  | 'adb.connect.deviceTooOld'
+  | 'adb.connect.serverUnreachable'
+  | 'adb.connect.timedOut'
+  | 'adb.connect.unauthorized'
+  | 'adb.volumeLabelWithSuffix'
   | 'ai.cloud.apiKeyDescription'
   | 'ai.cloud.apiKeyLabel'
   | 'ai.cloud.apiKeyPlaceholderAnthropic'
@@ -591,8 +598,7 @@ export type MessageKey =
   | 'errorReporter.sentToast.dismiss'
   | 'errorReporter.sentToast.message'
   | 'errors.eject.busy'
-  | 'errors.eject.mtpDisconnectRefused'
-  | 'errors.eject.mtpIdMissingDevicePrefix'
+  | 'errors.eject.deviceDisconnectRefused'
   | 'errors.eject.notAnSmbVolume'
   | 'errors.eject.notEjectable'
   | 'errors.eject.timedOut'

--- a/apps/desktop/src/lib/intl/messages/de/adb.json
+++ b/apps/desktop/src/lib/intl/messages/de/adb.json
@@ -1,0 +1,31 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName} (ADB)",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20",
+    "sameAsSourceJustification": "A placeholder plus the tool acronym ADB in parentheses; nothing to translate."
+  },
+  "adb.connect.adbNotInstalled": "Cmdr konnte das adb-Tool nicht finden. Installiere die Android platform-tools oder lege den Pfad in den Einstellungen fest.",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "Bestätige die USB-Debugging-Abfrage auf dem Gerät und versuche es dann erneut.",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "Die Android-Version dieses Geräts ist zu alt für die ADB-Unterstützung von Cmdr (Android 7 oder neuer nötig).",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "Das Gerät ist nicht mehr verbunden.",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "Cmdr konnte den adb-Server nicht erreichen.",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "Das Gerät hat nicht rechtzeitig geantwortet.",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/de/errors.json
+++ b/apps/desktop/src/lib/intl/messages/de/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "Cmdr konnte nicht erkennen, welches Gerät das ist, und kann es deshalb nicht trennen.",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "Dieses Laufwerk ist kein Wechselmedium, es bleibt also verbunden.",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "Das Gerät wollte seine Verbindung nicht schließen. Zieh es ab, sobald es nicht mehr beschäftigt ist.",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "Das Gerät wollte seine Verbindung nicht schließen. Zieh es ab, sobald es nicht mehr beschäftigt ist.",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "Dieses Laufwerk ist noch in Verwendung. Schließe offene Dateien und beende laufende Apps, dann wirf es erneut aus.",

--- a/apps/desktop/src/lib/intl/messages/en/adb.json
+++ b/apps/desktop/src/lib/intl/messages/en/adb.json
@@ -1,0 +1,40 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName} (ADB)",
+  "@adb.volumeLabelWithSuffix": {
+    "description": "Volume switcher label for a phone reached over ADB when the same phone is also listed over MTP, so the two rows stay apart. ADB is the Android Debug Bridge tool name; keep it verbatim.",
+    "placeholders": {
+      "deviceName": "the device's model name, for example Pixel 7"
+    },
+    "screenshotNote": "Not captured yet: the ADB connect flow has no UI surface in the app yet."
+  },
+  "adb.connect.adbNotInstalled": "Cmdr couldn't find the adb tool. Install Android platform-tools, or set the path in Settings.",
+  "@adb.connect.adbNotInstalled": {
+    "description": "Toast when connecting an Android device over ADB and the adb command-line tool isn't on the machine. adb and platform-tools are tool names; keep them verbatim. Settings is the app's settings window.",
+    "screenshotNote": "Not captured yet: the ADB connect flow has no UI surface in the app yet."
+  },
+  "adb.connect.unauthorized": "Accept the USB debugging prompt on the device, then try again.",
+  "@adb.connect.unauthorized": {
+    "description": "Toast when the phone hasn't approved this computer for USB debugging yet; the person has to tap the prompt on the phone's screen.",
+    "screenshotNote": "Not captured yet: the ADB connect flow has no UI surface in the app yet."
+  },
+  "adb.connect.deviceTooOld": "This device's Android version is too old for Cmdr's ADB support (needs Android 7 or newer).",
+  "@adb.connect.deviceTooOld": {
+    "description": "Toast when the device runs an Android version older than 7 (2016), which Cmdr's ADB support doesn't cover. ADB is a tool name; keep it verbatim.",
+    "screenshotNote": "Not captured yet: the ADB connect flow has no UI surface in the app yet."
+  },
+  "adb.connect.deviceGone": "The device is no longer connected.",
+  "@adb.connect.deviceGone": {
+    "description": "Toast when the phone was unplugged or dropped off the ADB server between listing it and connecting to it.",
+    "screenshotNote": "Not captured yet: the ADB connect flow has no UI surface in the app yet."
+  },
+  "adb.connect.serverUnreachable": "Cmdr couldn't reach the adb server.",
+  "@adb.connect.serverUnreachable": {
+    "description": "Toast when the local adb server (the background process the adb tool starts) doesn't answer. adb is a tool name; keep it verbatim.",
+    "screenshotNote": "Not captured yet: the ADB connect flow has no UI surface in the app yet."
+  },
+  "adb.connect.timedOut": "The device didn't answer in time.",
+  "@adb.connect.timedOut": {
+    "description": "Toast when connecting a device over ADB takes longer than Cmdr waits for.",
+    "screenshotNote": "Not captured yet: the ADB connect flow has no UI surface in the app yet."
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/en/errors.json
+++ b/apps/desktop/src/lib/intl/messages/en/errors.json
@@ -2354,12 +2354,6 @@
     "screenshot": "error-message-example.png",
     "screenshotNote": "Cmdr renders every friendly error with one shared layout: a bold title, an explanation paragraph, and a suggestion below it (plus an optional action button and a collapsed \"Technical details\"). This screenshot shows a DIFFERENT error, but your string appears as the title, explanation, or suggestion text in this same panel, in the same position. errors.provider.* names (Dropbox, Google Drive, OneDrive, and so on) are brand names, so keep them as-is."
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "Cmdr couldn't tell which device this is, so it can't disconnect it.",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "description": "Shown for a phone or camera whose internal identifier came through malformed. \"Device\" here means a phone, tablet, or camera connected by cable. Surface: a brief error toast in the top-right of Cmdr's main window, shown after someone asks to eject a drive or disconnect a network share. Your string is dropped into \"Couldn't eject {volumeName}: …\" or \"Couldn't disconnect: …\", so it reads as the sentence AFTER a colon. Plain text, one or two short sentences, no markdown. Cmdr never uses the words \"error\" or \"failed\" in messages people read.",
-    "screenshot": "error-message-example.png",
-    "screenshotNote": "Cmdr renders every friendly error with one shared layout: a bold title, an explanation paragraph, and a suggestion below it (plus an optional action button and a collapsed \"Technical details\"). This screenshot shows a DIFFERENT error, but your string appears as the title, explanation, or suggestion text in this same panel, in the same position. errors.provider.* names (Dropbox, Google Drive, OneDrive, and so on) are brand names, so keep them as-is."
-  },
   "errors.eject.notEjectable": "This drive isn't removable, so it stays connected.",
   "@errors.eject.notEjectable": {
     "description": "Shown when someone asks to eject a fixed disk, such as the built-in startup drive. It isn't a fault: the drive simply can't be ejected. Surface: a brief error toast in the top-right of Cmdr's main window, shown after someone asks to eject a drive or disconnect a network share. Your string is dropped into \"Couldn't eject {volumeName}: …\" or \"Couldn't disconnect: …\", so it reads as the sentence AFTER a colon. Plain text, one or two short sentences, no markdown. Cmdr never uses the words \"error\" or \"failed\" in messages people read.",
@@ -2372,8 +2366,8 @@
     "screenshot": "error-message-example.png",
     "screenshotNote": "Cmdr renders every friendly error with one shared layout: a bold title, an explanation paragraph, and a suggestion below it (plus an optional action button and a collapsed \"Technical details\"). This screenshot shows a DIFFERENT error, but your string appears as the title, explanation, or suggestion text in this same panel, in the same position. errors.provider.* names (Dropbox, Google Drive, OneDrive, and so on) are brand names, so keep them as-is."
   },
-  "errors.eject.mtpDisconnectRefused": "The device wouldn't close its connection. Unplug it once it's idle.",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "The device wouldn't close its connection. Unplug it once it's idle.",
+  "@errors.eject.deviceDisconnectRefused": {
     "description": "Shown when a connected phone, tablet, or camera refuses to end its session. The technical reason is written to the log, not shown here. Surface: a brief error toast in the top-right of Cmdr's main window, shown after someone asks to eject a drive or disconnect a network share. Your string is dropped into \"Couldn't eject {volumeName}: …\" or \"Couldn't disconnect: …\", so it reads as the sentence AFTER a colon. Plain text, one or two short sentences, no markdown. Cmdr never uses the words \"error\" or \"failed\" in messages people read.",
     "screenshot": "error-message-example.png",
     "screenshotNote": "Cmdr renders every friendly error with one shared layout: a bold title, an explanation paragraph, and a suggestion below it (plus an optional action button and a collapsed \"Technical details\"). This screenshot shows a DIFFERENT error, but your string appears as the title, explanation, or suggestion text in this same panel, in the same position. errors.provider.* names (Dropbox, Google Drive, OneDrive, and so on) are brand names, so keep them as-is."

--- a/apps/desktop/src/lib/intl/messages/es/adb.json
+++ b/apps/desktop/src/lib/intl/messages/es/adb.json
@@ -1,0 +1,31 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName} (ADB)",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20",
+    "sameAsSourceJustification": "A placeholder plus the tool acronym ADB in parentheses; nothing to translate."
+  },
+  "adb.connect.adbNotInstalled": "Cmdr no encontró la herramienta adb. Instala las platform-tools de Android o indica la ruta en Ajustes.",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "Acepta la solicitud de depuración USB en el dispositivo y vuelve a intentarlo.",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "La versión de Android de este dispositivo es demasiado antigua para la compatibilidad ADB de Cmdr (necesita Android 7 o posterior).",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "El dispositivo ya no está conectado.",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "Cmdr no pudo conectar con el servidor adb.",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "El dispositivo no respondió a tiempo.",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/es/errors.json
+++ b/apps/desktop/src/lib/intl/messages/es/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "Cmdr no pudo saber de qué dispositivo se trata, así que no puede desconectarlo.",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "Este disco no es extraíble, así que se queda conectado.",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "El dispositivo no cerró su conexión. Desconecta el cable cuando esté inactivo.",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "El dispositivo no cerró su conexión. Desconecta el cable cuando esté inactivo.",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "Algo sigue usando este disco. Cierra los archivos y las apps que tengas abiertos y vuelve a expulsarlo.",

--- a/apps/desktop/src/lib/intl/messages/fr/adb.json
+++ b/apps/desktop/src/lib/intl/messages/fr/adb.json
@@ -1,0 +1,31 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName} (ADB)",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20",
+    "sameAsSourceJustification": "A placeholder plus the tool acronym ADB in parentheses; nothing to translate."
+  },
+  "adb.connect.adbNotInstalled": "Cmdr n''a pas trouvé l''outil adb. Installez les platform-tools Android ou indiquez le chemin dans les Réglages.",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "Acceptez la demande de débogage USB sur l''appareil, puis réessayez.",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "La version d''Android de cet appareil est trop ancienne pour la prise en charge ADB de Cmdr (Android 7 ou plus récent requis).",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "L''appareil n''est plus connecté.",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "Cmdr n''a pas pu joindre le serveur adb.",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "L''appareil n''a pas répondu à temps.",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/fr/errors.json
+++ b/apps/desktop/src/lib/intl/messages/fr/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "Cmdr n'a pas reconnu cet appareil et ne peut donc pas le déconnecter.",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "Ce disque n'est pas amovible, il reste donc connecté.",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "L'appareil a refusé de fermer sa connexion. Débranchez-le quand il n'est plus occupé.",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "L'appareil a refusé de fermer sa connexion. Débranchez-le quand il n'est plus occupé.",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "Quelque chose utilise encore ce disque. Fermez les fichiers et les apps ouverts, puis éjectez-le à nouveau.",

--- a/apps/desktop/src/lib/intl/messages/hu/adb.json
+++ b/apps/desktop/src/lib/intl/messages/hu/adb.json
@@ -1,0 +1,31 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName} (ADB)",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20",
+    "sameAsSourceJustification": "A placeholder plus the tool acronym ADB in parentheses; nothing to translate."
+  },
+  "adb.connect.adbNotInstalled": "A Cmdr nem találja az adb eszközt. Telepítsd az Android platform-tools csomagot, vagy add meg az útvonalát a Beállításokban.",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "Fogadd el az USB-hibakeresési kérést az eszközön, majd próbáld újra.",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "Az eszköz Android-verziója túl régi a Cmdr ADB-támogatásához (Android 7 vagy újabb kell).",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "Az eszköz már nincs csatlakoztatva.",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "A Cmdr nem éri el az adb-kiszolgálót.",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "Az eszköz nem válaszolt időben.",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/hu/errors.json
+++ b/apps/desktop/src/lib/intl/messages/hu/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "A Cmdr nem tudta megállapítani, melyik eszközről van szó, ezért nem tudja leválasztani.",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "Ez a meghajtó nem cserélhető, ezért csatlakoztatva marad.",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "Az eszköz nem zárta le a kapcsolatot. Húzd ki, amikor már nincs használatban.",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "Az eszköz nem zárta le a kapcsolatot. Húzd ki, amikor már nincs használatban.",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "Valami még használja ezt a meghajtót. Zárd be a nyitott fájlokat és alkalmazásokat, majd add ki újra.",

--- a/apps/desktop/src/lib/intl/messages/nl/adb.json
+++ b/apps/desktop/src/lib/intl/messages/nl/adb.json
@@ -1,0 +1,31 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName} (ADB)",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20",
+    "sameAsSourceJustification": "A placeholder plus the tool acronym ADB in parentheses; nothing to translate."
+  },
+  "adb.connect.adbNotInstalled": "Cmdr kon het adb-hulpprogramma niet vinden. Installeer de Android platform-tools of stel het pad in bij Instellingen.",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "Accepteer de USB-foutopsporingsprompt op het apparaat en probeer het opnieuw.",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "De Android-versie van dit apparaat is te oud voor de ADB-ondersteuning van Cmdr (Android 7 of nieuwer vereist).",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "Het apparaat is niet meer verbonden.",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "Cmdr kon de adb-server niet bereiken.",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "Het apparaat antwoordde niet op tijd.",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/nl/errors.json
+++ b/apps/desktop/src/lib/intl/messages/nl/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "Cmdr kan niet bepalen welk apparaat dit is en kan het daarom niet loskoppelen.",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "Deze schijf kun je niet uitwerpen, dus hij blijft aangesloten.",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "Het apparaat wilde de verbinding niet verbreken. Koppel het los zodra het niet meer bezig is.",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "Het apparaat wilde de verbinding niet verbreken. Koppel het los zodra het niet meer bezig is.",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "Deze schijf is nog in gebruik. Sluit open bestanden, stop geopende apps en werp hem daarna opnieuw uit.",

--- a/apps/desktop/src/lib/intl/messages/pt/adb.json
+++ b/apps/desktop/src/lib/intl/messages/pt/adb.json
@@ -1,0 +1,31 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName} (ADB)",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20",
+    "sameAsSourceJustification": "A placeholder plus the tool acronym ADB in parentheses; nothing to translate."
+  },
+  "adb.connect.adbNotInstalled": "O Cmdr não encontrou a ferramenta adb. Instale as platform-tools do Android ou defina o caminho em Configurações.",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "Aceite a solicitação de depuração USB no dispositivo e tente de novo.",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "A versão do Android deste dispositivo é antiga demais para o suporte a ADB do Cmdr (precisa do Android 7 ou mais recente).",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "O dispositivo não está mais conectado.",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "O Cmdr não conseguiu acessar o servidor adb.",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "O dispositivo não respondeu a tempo.",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/pt/errors.json
+++ b/apps/desktop/src/lib/intl/messages/pt/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "O Cmdr não conseguiu identificar qual é este dispositivo, então não consegue desconectá-lo.",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "Este disco não é removível, então ele continua conectado.",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "O dispositivo se recusou a encerrar a conexão. Desconecte-o assim que ele estiver ocioso.",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "O dispositivo se recusou a encerrar a conexão. Desconecte-o assim que ele estiver ocioso.",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "Algo ainda está usando este disco. Feche os arquivos e aplicativos abertos, depois ejete-o de novo.",

--- a/apps/desktop/src/lib/intl/messages/sv/adb.json
+++ b/apps/desktop/src/lib/intl/messages/sv/adb.json
@@ -1,0 +1,31 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName} (ADB)",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20",
+    "sameAsSourceJustification": "A placeholder plus the tool acronym ADB in parentheses; nothing to translate."
+  },
+  "adb.connect.adbNotInstalled": "Cmdr hittade inte verktyget adb. Installera Android platform-tools eller ange sökvägen i Inställningar.",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "Godkänn USB-felsökningsfrågan på enheten och försök sedan igen.",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "Enhetens Android-version är för gammal för Cmdrs ADB-stöd (kräver Android 7 eller senare).",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "Enheten är inte längre ansluten.",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "Cmdr kunde inte nå adb-servern.",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "Enheten svarade inte i tid.",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/sv/errors.json
+++ b/apps/desktop/src/lib/intl/messages/sv/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "Cmdr kunde inte avgöra vilken enhet det här är, så den går inte att koppla från.",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "Den här enheten är inte borttagbar, så den förblir ansluten.",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "Enheten ville inte stänga sin anslutning. Koppla ur den när den inte används.",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "Enheten ville inte stänga sin anslutning. Koppla ur den när den inte används.",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "Något använder fortfarande den här enheten. Stäng öppna filer och appar och mata sedan ut igen.",

--- a/apps/desktop/src/lib/intl/messages/vi/adb.json
+++ b/apps/desktop/src/lib/intl/messages/vi/adb.json
@@ -1,0 +1,31 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName} (ADB)",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20",
+    "sameAsSourceJustification": "A placeholder plus the tool acronym ADB in parentheses; nothing to translate."
+  },
+  "adb.connect.adbNotInstalled": "Cmdr không tìm thấy công cụ adb. Hãy cài Android platform-tools hoặc đặt đường dẫn trong Cài đặt.",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "Hãy chấp nhận lời nhắc gỡ lỗi USB trên thiết bị rồi thử lại.",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "Phiên bản Android của thiết bị này quá cũ so với hỗ trợ ADB của Cmdr (cần Android 7 trở lên).",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "Thiết bị không còn được kết nối.",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "Cmdr không kết nối được với máy chủ adb.",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "Thiết bị không phản hồi kịp thời.",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/vi/errors.json
+++ b/apps/desktop/src/lib/intl/messages/vi/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "Cmdr không nhận ra đây là thiết bị nào, nên không ngắt kết nối được.",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "Ổ đĩa này không phải loại có thể tháo, nên nó luôn kết nối.",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "Thiết bị đã từ chối đóng kết nối. Hãy rút nó ra khi không còn bận.",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "Thiết bị đã từ chối đóng kết nối. Hãy rút nó ra khi không còn bận.",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "Vẫn còn thứ gì đó đang sử dụng ổ đĩa này. Hãy đóng các tệp và ứng dụng đang mở, rồi tháo lại.",

--- a/apps/desktop/src/lib/intl/messages/zh-Hant/adb.json
+++ b/apps/desktop/src/lib/intl/messages/zh-Hant/adb.json
@@ -1,0 +1,30 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName}（ADB）",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20"
+  },
+  "adb.connect.adbNotInstalled": "Cmdr 找不到 adb 工具。請安裝 Android platform-tools，或在設定中指定路徑。",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "請在裝置上接受 USB 偵錯提示，然後再試一次。",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "此裝置的 Android 版本過舊，Cmdr 的 ADB 支援無法使用（需要 Android 7 或更新版本）。",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "裝置已中斷連線。",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "Cmdr 無法連線到 adb 伺服器。",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "裝置未及時回應。",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/zh-Hant/errors.json
+++ b/apps/desktop/src/lib/intl/messages/zh-Hant/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "Cmdr 認不出這是哪個裝置，所以沒辦法中斷它。",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "這個磁碟機不可移除，所以會一直連著。",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "裝置沒有把連線關掉。等它閒下來再拔線。",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "裝置沒有把連線關掉。等它閒下來再拔線。",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "還有東西在用這個磁碟機。請關掉開著的檔案和 App，然後再退出一次。",

--- a/apps/desktop/src/lib/intl/messages/zh/adb.json
+++ b/apps/desktop/src/lib/intl/messages/zh/adb.json
@@ -1,0 +1,30 @@
+{
+  "adb.volumeLabelWithSuffix": "{deviceName}（ADB）",
+  "@adb.volumeLabelWithSuffix": {
+    "sourceHash": "98d6c20"
+  },
+  "adb.connect.adbNotInstalled": "Cmdr 找不到 adb 工具。请安装 Android platform-tools，或在设置中指定路径。",
+  "@adb.connect.adbNotInstalled": {
+    "sourceHash": "c29eed4"
+  },
+  "adb.connect.unauthorized": "请在设备上接受 USB 调试提示，然后重试。",
+  "@adb.connect.unauthorized": {
+    "sourceHash": "a7ce70a"
+  },
+  "adb.connect.deviceTooOld": "此设备的 Android 版本过旧，Cmdr 的 ADB 支持无法使用（需要 Android 7 或更高版本）。",
+  "@adb.connect.deviceTooOld": {
+    "sourceHash": "c687896"
+  },
+  "adb.connect.deviceGone": "设备已断开连接。",
+  "@adb.connect.deviceGone": {
+    "sourceHash": "ffa8f75"
+  },
+  "adb.connect.serverUnreachable": "Cmdr 无法连接到 adb 服务器。",
+  "@adb.connect.serverUnreachable": {
+    "sourceHash": "3fa5a73"
+  },
+  "adb.connect.timedOut": "设备未及时响应。",
+  "@adb.connect.timedOut": {
+    "sourceHash": "bfa105c"
+  }
+}

--- a/apps/desktop/src/lib/intl/messages/zh/errors.json
+++ b/apps/desktop/src/lib/intl/messages/zh/errors.json
@@ -1613,10 +1613,6 @@
   "@errors.eject.volumeNotFound": {
     "sourceHash": "62a3af2"
   },
-  "errors.eject.mtpIdMissingDevicePrefix": "Cmdr 认不出这是哪台设备，所以没法断开它。",
-  "@errors.eject.mtpIdMissingDevicePrefix": {
-    "sourceHash": "d26b57b"
-  },
   "errors.eject.notEjectable": "这个驱动器不可移除，所以会一直保持连接。",
   "@errors.eject.notEjectable": {
     "sourceHash": "bb88249"
@@ -1625,8 +1621,8 @@
   "@errors.eject.notAnSmbVolume": {
     "sourceHash": "d49623e"
   },
-  "errors.eject.mtpDisconnectRefused": "设备没有关闭连接。等它空闲下来再拔下线缆。",
-  "@errors.eject.mtpDisconnectRefused": {
+  "errors.eject.deviceDisconnectRefused": "设备没有关闭连接。等它空闲下来再拔下线缆。",
+  "@errors.eject.deviceDisconnectRefused": {
     "sourceHash": "d49861f"
   },
   "errors.eject.unmountRefused": "还有东西在使用这个驱动器。请关闭打开的文件和 App，然后再次推出。",

--- a/apps/desktop/src/lib/licensing/third-party-packages.gen.json
+++ b/apps/desktop/src/lib/licensing/third-party-packages.gen.json
@@ -2247,7 +2247,7 @@
     },
     {
       "name": "mtp-rs",
-      "version": "0.30.0",
+      "version": "0.32.0",
       "license": "MIT OR Apache-2.0",
       "url": "https://github.com/vdavid/mtp-rs"
     },
@@ -4559,7 +4559,7 @@
     },
     {
       "name": "@typescript-eslint/types",
-      "version": "8.67.0",
+      "version": "8.68.0",
       "license": "MIT",
       "url": "https://typescript-eslint.io"
     },

--- a/apps/desktop/src/lib/path/canonical.test.ts
+++ b/apps/desktop/src/lib/path/canonical.test.ts
@@ -19,6 +19,7 @@ describe('toCanonical', () => {
 
   it('passes virtual-volume URLs through', () => {
     expect(toCanonical('mtp://dev/65537/Music', HOME)).toBe('mtp://dev/65537/Music')
+    expect(toCanonical('adb://R58M12345/sdcard/Music', HOME)).toBe('adb://R58M12345/sdcard/Music')
     expect(toCanonical('smb://host/share/dir', HOME)).toBe('smb://host/share/dir')
     expect(toCanonical('search-results://snap-1', HOME)).toBe('search-results://snap-1')
   })
@@ -52,6 +53,7 @@ describe('parentOf', () => {
 
   it('handles virtual-volume URLs by slash arithmetic', () => {
     expect(parentOf(toCanonical('mtp://dev/65537/Music', HOME))).toBe('mtp://dev/65537')
+    expect(parentOf(toCanonical('adb://R58M12345/sdcard', HOME))).toBe('adb://R58M12345')
   })
 })
 

--- a/apps/desktop/src/lib/path/canonical.ts
+++ b/apps/desktop/src/lib/path/canonical.ts
@@ -4,7 +4,7 @@ declare const __canonicalBrand: unique symbol
  * An absolute path safe for `dirname` / `basename` arithmetic.
  *
  * Includes local filesystem paths (start with `/`) and virtual-volume URLs
- * (`mtp://...`, `smb://...`, `search-results://...`). Excludes `~`-rooted
+ * (`mtp://...`, `adb://...`, `smb://...`, `search-results://...`). Excludes `~`-rooted
  * paths, relative paths, and anything that would silently break `lastIndexOf('/')`
  * style derivations.
  *

--- a/apps/desktop/src/lib/tauri-commands/adb.test.ts
+++ b/apps/desktop/src/lib/tauri-commands/adb.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The ADB wrappers: the device list passes through, and a connect refusal keeps
+ * its typed reason instead of collapsing into a stringified blob.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('$lib/ipc/bindings', () => ({
+  commands: {
+    listAdbDevices: vi.fn(),
+    connectAdbDevice: vi.fn(),
+  },
+}))
+
+import { commands } from '$lib/ipc/bindings'
+import { AdbConnectFailure, asAdbConnectError, connectAdbDevice, listAdbDevices, type AdbDevice } from './adb'
+
+// The shim casts `commands`; the mock carries the two ADB commands.
+const mocked = commands as unknown as {
+  listAdbDevices: ReturnType<typeof vi.fn>
+  connectAdbDevice: ReturnType<typeof vi.fn>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('listAdbDevices', () => {
+  it('passes the device list straight through, whatever the states', async () => {
+    const devices: AdbDevice[] = [
+      { serial: 'R58M12345', state: 'ready', model: 'Pixel_7' },
+      { serial: '192.168.1.5:5555', state: 'unauthorized' },
+    ]
+    mocked.listAdbDevices.mockResolvedValueOnce(devices)
+    expect(await listAdbDevices()).toEqual(devices)
+    expect(mocked.listAdbDevices).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('connectAdbDevice', () => {
+  it('hands the serial to the command and resolves to the volume id', async () => {
+    mocked.connectAdbDevice.mockResolvedValueOnce({ status: 'ok', data: 'adb-pixel-7-a1b2c3d' })
+    expect(await connectAdbDevice('R58M12345')).toBe('adb-pixel-7-a1b2c3d')
+    expect(mocked.connectAdbDevice).toHaveBeenCalledWith('R58M12345')
+  })
+
+  it('throws a typed failure that a catch site can read back', async () => {
+    mocked.connectAdbDevice.mockResolvedValueOnce({ status: 'error', error: { type: 'unauthorized' } })
+    let caught: unknown
+    try {
+      await connectAdbDevice('R58M12345')
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(AdbConnectFailure)
+    expect(asAdbConnectError(caught)).toEqual({ type: 'unauthorized' })
+  })
+
+  it('asAdbConnectError answers null for anything else', () => {
+    expect(asAdbConnectError(new Error('boom'))).toBeNull()
+    expect(asAdbConnectError(undefined)).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/tauri-commands/adb.ts
+++ b/apps/desktop/src/lib/tauri-commands/adb.ts
@@ -1,0 +1,84 @@
+// Android devices over ADB: the device list and connecting one as a volume.
+// Contract: `docs/specs/android-adb-backend.md` § "App wiring".
+
+import { commands } from '$lib/ipc/bindings'
+import { TypedFailure } from '$lib/ipc/typed-failure'
+
+// ---------------------------------------------------------------------------
+// TODO(bindings-shim): DELETE this block once `pnpm bindings:regen` (run in
+// `apps/desktop`) emits `AdbDevice`, `AdbDeviceState`, `AdbConnectError`, and the
+// two commands from Rust; then import the types from `$lib/ipc/bindings` and
+// call `commands.listAdbDevices` / `commands.connectAdbDevice` directly.
+// ---------------------------------------------------------------------------
+
+/** What the ADB server reports for a device. Only `ready` can be connected. */
+export type AdbDeviceState =
+  | 'ready'
+  | 'unauthorized'
+  | 'offline'
+  | 'noPermissions'
+  | 'connecting'
+  | 'authorizing'
+  | 'recovery'
+  | 'bootloader'
+  | 'sideload'
+  | 'unknown'
+
+/** One row of `host:devices-l`. */
+export interface AdbDevice {
+  serial: string
+  state: AdbDeviceState
+  product?: string | null
+  model?: string | null
+  device?: string | null
+  transportId?: string | null
+}
+
+/** Why a connect didn't produce a volume (`AdbConnectError` in `crates/cmdr-adb`). */
+export type AdbConnectError =
+  | { type: 'serverUnreachable' }
+  | { type: 'adbNotInstalled' }
+  | { type: 'deviceGone' }
+  | { type: 'unauthorized' }
+  | { type: 'deviceTooOld' }
+  | { type: 'timedOut' }
+  | { type: 'cancelled' }
+
+type AdbResult<T> = { status: 'ok'; data: T } | { status: 'error'; error: AdbConnectError }
+
+interface AdbCommands {
+  listAdbDevices(): Promise<AdbDevice[]>
+  connectAdbDevice(serial: string): Promise<AdbResult<string>>
+}
+
+const adbCommands = commands as unknown as AdbCommands
+
+// ------------------------------- end of shim --------------------------------
+
+/** A connect refusal, still carrying the backend's typed reason. */
+export class AdbConnectFailure extends TypedFailure<AdbConnectError> {
+  constructor(failure: AdbConnectError) {
+    super(failure, `adb connect refused: ${failure.type}`)
+    this.name = 'AdbConnectFailure'
+  }
+}
+
+/** The typed refusal behind a caught value, or `null` when it isn't one. */
+export function asAdbConnectError(error: unknown): AdbConnectError | null {
+  return error instanceof AdbConnectFailure ? error.failure : null
+}
+
+/** Every device the ADB server knows about, whatever its state. */
+export async function listAdbDevices(): Promise<AdbDevice[]> {
+  return await adbCommands.listAdbDevices()
+}
+
+/**
+ * Connects a device and registers it as a volume. Resolves to the volume id
+ * (`adb-…`); throws {@link AdbConnectFailure} with the typed reason otherwise.
+ */
+export async function connectAdbDevice(serial: string): Promise<string> {
+  const res = await adbCommands.connectAdbDevice(serial)
+  if (res.status === 'error') throw new AdbConnectFailure(res.error)
+  return res.data
+}

--- a/apps/desktop/src/lib/tauri-commands/index.ts
+++ b/apps/desktop/src/lib/tauri-commands/index.ts
@@ -557,6 +557,10 @@ export {
   scanVolumeForCopy,
   scanVolumeForConflicts,
 } from './mtp'
+// Android devices over ADB (device list, connect)
+export { listAdbDevices, connectAdbDevice, AdbConnectFailure, asAdbConnectError } from './adb'
+export type { AdbDevice, AdbDeviceState, AdbConnectError } from './adb'
+
 // Archive-password commands (encrypted-archive unlock)
 export {
   setArchivePassword,

--- a/crates/cmdr-adb/CLAUDE.md
+++ b/crates/cmdr-adb/CLAUDE.md
@@ -1,0 +1,46 @@
+# `cmdr-adb`
+
+Everything Cmdr says to an Android device over ADB: one `Volume` per attached device, rooted at the device's real `/`,
+spoken to the ADB **server** on loopback (never USB itself). The device-side twin of `cmdr-sftp`. No `tauri`, no
+user-facing words.
+
+## Module map
+
+- `server.rs` (endpoint + the one `start-server` attempt), `transport.rs` (the ONLY module that knows the wire
+  framing), `devices.rs` (`host:devices-l` + the `host:track-devices` hotplug stream), `features.rs` (read once per
+  session), `sync.rs` (`STAT`/`LIST`/`RECV`/`SEND`), `shell.rs` (`mkdir`/`rm`/`mv`/`cp`/`df`), `errors.rs`, `params.rs`,
+  `testing.rs` (the fake ADB server).
+- `volume/`: the `Volume` impl by job: `paths`, `query`, `streams`, `writes`, `scan`, `mutation`, `mapping`, `state`,
+  `volume_impl`, `testing`.
+
+## Must-knows
+
+- **❗ Keep the framing in `transport.rs`.** Hex-length requests, `OKAY`/`FAIL`, sync packets: one module, so a protocol
+  change stays one file's problem.
+- **❗ The peer is the server, not the phone.** `adb` owns USB and pairing; a refused loopback connect earns exactly
+  one `adb start-server` per process, ❌ never a retry loop that spawns processes.
+- **❗ `shell_v2` is required; a device without it is `AdbConnectError::DeviceTooOld`.** Legacy `shell:` has no exit
+  code, and inferring one from output would be string-matching control flow.
+- **❗ A shell failure is classified by a follow-up stat of the path and its parent, ❌ never by stderr.** The exit
+  code says "no"; the sync service says why. `DETAILS.md` § "The error policy".
+- **❗ `NotFound` / `PermissionDenied` carry the PATH**, ❌ never the device's wording: the frontend renders it as the
+  missing file's name. `errors::volume_error_from_errno` takes the path for that reason.
+- **❌ Never anchor an out-of-root path; refuse it.** `root_anchored` is idempotent; a pane's `adb://<serial>/sdcard`
+  and a dest box's `/sdcard` are the same file.
+- **❌ Never collect a file into a `Vec<u8>`.** `RECV` and `SEND` are one socket per file, chunk by chunk.
+- **❗ Every write lands under a staging name (`<name>.cmdr-tmp-<pid>-<n>`) and is `mv -f`ed into place.** `SEND`
+  truncates on open, so a direct write is a torn file the moment the cable pulls.
+- **❗ Every mutation calls `notify_mutation`.** There is no watcher; `can_watch_listings` is `false` and stays so.
+- **❗ One sync socket per operation, ❌ no shared session behind a mutex**: a same-volume copy would deadlock and a
+  paused transfer would park every listing. `max_concurrent_ops` (1, the app's `"adb"` settings row) is what bounds
+  transfers.
+- **❗ `host:track-devices` is the hotplug channel AND the retirement signal**: `track_devices` refetches the long
+  list on every push and reconnects with backoff; the app retires the volume of a serial that left. Operations remain
+  the liveness detector in between, like SFTP.
+- **❗ Features are read once at connect** (`DeviceFeatures::fetch`). ❌ Never re-probe at a call site.
+- **❗ Report transitions, never states** (`volume/state.rs`); a retired volume reports nothing.
+- **❌ Never `cfg(test)`-gate a fixture; use `any(test, feature = "testing")`.** The app's ADB suites share
+  `testing::FakeAdbServer` and `volume::testing`.
+
+The wire contract, the `Volume` answers and why, the error policy, the testing story, and the known gaps:
+`DETAILS.md`. Read it first.

--- a/crates/cmdr-adb/Cargo.toml
+++ b/crates/cmdr-adb/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "cmdr-adb"
+version = "0.0.0"
+edition = "2024"
+license = "LicenseRef-BSL-1.1"
+publish = false
+
+# The house lint set lives in the workspace root's `[workspace.lints]`, so this
+# crate can't quietly become a lint-free zone. `unused_crate_dependencies` is the
+# one lint that stays at the crate root instead (it's judged per compilation unit).
+[lints]
+workspace = true
+
+[features]
+# "This is a test build." It widens `volume::testing` (the fake-adb-server
+# fixture and the unique-name helpers) from `#[cfg(test)]`-only to `pub`, so the
+# app's ADB suites — the ones driving the transfer pipeline and the volume
+# registry, which belong on that side of the seam — share one set of fixtures
+# with this crate's own instead of growing a second, drifting copy.
+#
+# Never enable in a production build.
+testing = ["cmdr-fs/testing"]
+
+[dependencies]
+# The `Volume` trait, every type it exchanges, and the host seams this backend
+# asks the app through. The only crate below this one.
+cmdr-fs = { path = "../cmdr-fs" }
+serde = { version = "1", features = ["derive"] }
+# Type export for the Rust↔TS bindings: the device list and its typed state
+# cross IPC. Pinned to the EXACT same version the app uses, for the reason
+# `cmdr-fs` gives: two `specta` crates in one graph would make these `Type` impls
+# stop satisfying `tauri-specta`, and the app's command signatures collect them
+# transitively.
+specta = { version = "=2.0.0-rc.24", features = ["derive"] }
+log = "0.4"
+# The backend's own async surface. `net` is the whole transport (the ADB server
+# is a TCP socket on loopback, nothing else), `process` starts an absent server
+# through the platform `adb` binary once, and the rest is what `cmdr-sftp` takes:
+# `sync` for the session lock, `time` for timeouts, `rt` for the handle
+# background work spawns onto, `macros` for `select!`. Deliberately NOT
+# `rt-multi-thread`: the runtime is the app's, handed down through
+# `VolumeHost::runtime`.
+tokio = { version = "1", features = ["io-util", "macros", "net", "process", "rt", "sync", "time"] }
+# `CancellationToken`, on the cancelable listing and transfer paths. Default
+# features off, the same shape `cmdr-fs` pins, so no second copy enters the graph.
+tokio-util = { version = "0.7.18", default-features = false }
+
+[dev-dependencies]
+# Depending on ourselves turns the `testing` feature on for every DEV target and
+# leaves it off for the lib, so a shipped build carries no fixtures. Same shape
+# as `cmdr-sftp`'s and the app's own self dev-dependency.
+cmdr-adb = { path = ".", features = ["testing"] }
+# `InMemoryVolume` and the recording / scripted host-seam fakes this crate's
+# tests assert against.
+cmdr-fs = { path = "../cmdr-fs", features = ["testing"] }
+# The fake-server suites drive real concurrency, so their tests need a
+# multi-threaded runtime the lib deliberately can't build for itself, and
+# `test-util` gives the timeout cells a `start_paused` clock so asserting on a
+# budget costs no wall time.
+tokio = { version = "1", features = ["rt-multi-thread", "test-util"] }

--- a/crates/cmdr-adb/DETAILS.md
+++ b/crates/cmdr-adb/DETAILS.md
@@ -1,0 +1,190 @@
+# `cmdr-adb` details
+
+The depth behind `CLAUDE.md`: the shape of the crate, the wire contract it implements, what the `Volume` impl answers
+and why, the error policy, where a test lives, and what is deliberately not done yet. The app-side half (the tracker
+task, the device provider, eject, the IPC commands) is `apps/desktop/src-tauri/src/adb/DETAILS.md`; the design that
+started this development is `docs/specs/android-adb-backend.md`.
+
+## Why a second Android backend
+
+MTP shows the curated media tree a phone chooses to expose, through PTP object handles. Developers want the real
+filesystem: `/data/local/tmp`, `/sdcard` as the kernel sees it, an app sandbox on a rooted or debuggable device, and
+the throughput of the `adb sync` protocol. `adb` is already on every Android developer's machine, so this backend adds
+no dependency of its own: it is a TCP client of a server that is already running.
+
+## The connection model
+
+Cmdr talks to the **ADB server** (`127.0.0.1:5037`, or `$ANDROID_ADB_SERVER_PORT`), never to the device. The server
+owns USB, authorization, and wireless pairing; a client only ever asks it for a socket to a device. That has three
+consequences the code is shaped around:
+
+- **Starting the server is a one-shot.** `server::AdbEndpoint::connect` answers a refused loopback connect with one
+  `adb -P <port> start-server` per process, through the binary `server::locate_adb_binary` finds (`$ADB`, `$PATH`,
+  `$ANDROID_HOME/platform-tools`, `$ANDROID_SDK_ROOT/platform-tools`, `~/Library/Android/sdk/platform-tools`, then
+  the Homebrew and `/usr/local` bins). No binary is `AdbConnectError::AdbNotInstalled`; a second refusal after a start
+  is `ServerUnreachable`, and both are the user's to look at. `AdbEndpoint::at(addr)` (fixtures, a forwarded port)
+  never starts anything.
+- **One socket per operation, no shared session.** Every sync operation opens its own `sync:` socket and closes it
+  with the operation. A shared session behind a mutex deadlocks a same-volume copy (the source stream holds it while
+  the destination write waits) and parks every listing while a transfer is paused mid-file. The server multiplexes
+  sockets and `adbd` serializes I/O on its side anyway, so nothing is gained by holding one. What bounds concurrent
+  transfers is `max_concurrent_ops`, below.
+- **A connect is four phases under one budget and one `CancellationToken`** (`volume::connect_adb_volume`): the device
+  list (a serial that isn't there is `DeviceGone`, one in `unauthorized` is `Unauthorized`), the feature probe (no
+  `shell_v2` is `DeviceTooOld`), then the hello (one `STAT` of `/`). A cancel ends the attempt where it stands and
+  leaves nothing behind: no volume, no socket. `CONNECT_BUDGET` is 10 s, all phases together.
+
+## The wire contract
+
+This section is the canonical account of what the crate implements; the spec points here. The protocol is what
+`adb/SERVICES.TXT`, `adb/SYNC.TXT`, and `adb/protocol.txt` in AOSP describe (verified against platform-tools 35 by
+reading those files and exercising a fake server built from them, 2026-09-01).
+
+**Host framing** (`transport.rs`, the ONLY module that knows this): a request is four ASCII hex digits of length then
+the payload (`000Chost:version`). The answer is `OKAY` or `FAIL`; `FAIL` is followed by a four-hex-length message.
+`host:version` and `host:devices-l` answer `OKAY` then one four-hex-length payload. `host:transport:<serial>` answers
+`OKAY` and binds the socket to that device; the next request on it is a device service (`sync:`,
+`shell,v2,raw:<cmd>`). `host-serial:<serial>:features` returns the device's comma-separated feature list.
+
+**Hotplug** (`devices.rs`): `host:track-devices` answers `OKAY` and then, for the life of the socket, a
+four-hex-length device list on every change (the SHORT `host:devices` format, `serial\tstate` per line; states are
+`device`, `unauthorized`, `offline`, `recovery`, `sideload`, `bootloader`, `no permissions`, `connecting`,
+`authorizing`). Only `device` (`AdbDeviceState::Ready`) is usable; the enum carries the rest as typed values so the
+app can word them. `track_devices` refetches `host:devices-l` on every push (the long format carries `product`,
+`model`, `device`, `transport_id`), hands the callback the full list, and when the socket drops reconnects with backoff
+(1 s doubling, capped at 15 s), redelivering the list after each reconnect so a listener catches up.
+
+**Sync service** (`sync.rs`): after `sync:` → `OKAY`, binary little-endian packets `[id: 4 ASCII][arg: u32 LE]`.
+
+- `STAT` + len + path → `STAT` + mode + size + mtime (all u32; mode 0 = doesn't exist). `STA2` (feature `stat_v2`) →
+  `STA2` + error(u32) + dev(u64) + ino(u64) + mode(u32) + nlink(u32) + uid + gid + size(u64) + atime + mtime + ctime
+  (i64 each). `STA2` is preferred: it carries errno and 64-bit sizes, which is what makes the error policy possible.
+- `LIST` + len + path → repeated `DENT` + mode + size + mtime + namelen + name, then `DONE` + 16 zero bytes. `LIS2`
+  (feature `ls_v2`) → repeated `DNT2` + error + dev + ino + mode + nlink + uid + gid + size + atime + mtime + ctime +
+  namelen + name, then `DONE`.
+- `RECV` + len + path → repeated `DATA` + len + bytes (≤ 64 KiB each), then `DONE` + 0; or `FAIL` + len + message.
+  `RCV2` (feature `sendrecv_v2`) sends `RCV2` + len + path, then `RCV2` + flags(u32) before data. There is no ranged
+  read on the wire: `open_read_stream_at_offset` reads and discards up to the offset (§ "Known gaps").
+- `SEND` + len + `path,mode` → then repeated `DATA` + len + bytes, then `DONE` + mtime(u32) → `OKAY` + 0 or `FAIL` +
+  len + message. `SND2` (feature `sendrecv_v2`) sends `SND2` + len + path then `SND2` + mode(u32) + flags(u32), then
+  the same data stream. `SEND` truncates on open, which is why every write here stages (§ "The `Volume` answers").
+
+**Shell** (`shell.rs`): `shell,v2,raw:<cmd>` (feature `shell_v2`) frames stdout, stderr, and the exit code as packets
+`[id: u8][len: u32 LE][payload]` with ids `0` stdin, `1` stdout, `2` stderr, `3` exit (payload one byte). A device
+without `shell_v2` (pre-Android 7, 2016) is refused with `AdbConnectError::DeviceTooOld` rather than guessed at: the
+legacy `shell:` service has no exit code, and inferring one from output would be string-matching control flow. Every
+argument is single-quoted (`'` → `'\''`). Verbs (`volume/writes.rs`): `mkdir -p`, `rmdir` for a directory and `rm -f`
+for anything else (strictly one node, so `delete` never recurses), `mv -f`, `cp -f` for `copy_within`, and `df -k <path>`
+(space info; parsed as data, never as an error signal). Shell reference: `adb/shell_protocol.h` (platform-tools 35).
+
+## The `Volume` answers, and why
+
+The volume is device-anchored, the same shape MTP has, and every answer below follows from that.
+
+- **Identity**: `volume_id` = `cmdr_fs::volume::adb_volume_id(serial)` (`adb:<serial>`); the root is the device's
+  `/`. Paths relative to the root ARE device paths, so nothing translates between two spellings of one tree.
+  `root_anchored` is idempotent: a pane's `adb://<serial>/sdcard/DCIM` and a dest box's `/sdcard/DCIM` land on the
+  same file. ❌ Never anchor an out-of-root path; refuse it.
+- **`rerooted` → `None`.** One volume per device; the pane's path is inside it. A device has no second root to offer.
+- **`lane_key` → the serial.** Two panes on one phone contend on one `adbd`, so they share a lane and the operation
+  manager serializes their writes.
+- **`max_concurrent_ops` reads `settings()` per batch dispatch**, and the app's `MAX_CONCURRENT_OPERATIONS_SOURCES`
+  table has an `"adb"` row answering the constant 1. ❗ A namespace with no row silently gets a cautious 2, which is
+  why the row exists even though it is not a user-facing knob. `adbd` serializes I/O per device, so a second
+  concurrent transfer only adds contention.
+- **`supports_export` → true, `is_writable` → true, `supports_streaming` → true.** Every read and write path is
+  implemented; the conformance assertions hold each declaration to what the device accepts. A read-only mount answers
+  `ReadOnly` per path when the shell's `EROFS` says so, not volume-wide.
+- **`can_watch_listings` → false, `listing_watch_coverage` → `None`.** There is no watcher, so ❌ nothing here may
+  claim an authoritative listing; the pane stays honest through `notify_mutation`, called once per changed directory
+  by every mutation, `write_from_stream` included.
+- **`supports_local_fs_access`, `paths_are_os_visible`, `operations_are_local` → false; `local_path` → `None`.**
+  Nothing on the host can open a device path.
+- **`create_directory_errors_on_existing_dir` → false.** `mkdir -p` is the verb, and it is idempotent by design.
+- **Streams**: `open_read_stream` is one `RECV` socket per file, chunk by chunk; `write_from_stream` is one `SEND`
+  socket per file into a staging sibling (`<dir>/<name>.cmdr-tmp-<pid>-<n>`, the house `STAGING_TEMP_MARKER`, so a
+  leftover is filtered from every pane), then `mv -f` via the shell; any failure removes the staging name. ❌ Never
+  collect a file into a `Vec<u8>`.
+- **Two accepted TOCTOU windows**: `create_file` and a `force = false` rename each `stat` the destination first and
+  refuse on a hit. Neither can be atomic on this protocol: `SEND` truncates unconditionally and `mv -n` exits 0 whether
+  it moved or not (verified on Android 14 `toybox 0.8.9`, 2026-09-01). The window is one round trip on a device only
+  this host writes to, and `conformance_test.rs` holds the refusal itself.
+- **Liveness**: operations are the detector (there is no keepalive), so every wire-touching delegator classifies a
+  `DeviceGone` into `VolumeError::DeviceDisconnected` and emits the transition once (`state.rs`). `track-devices`
+  additionally retires the volume when its serial leaves the list, which is the push channel MTP never had.
+- **Space**: `df -k` on the volume root, polled at `space_poll_interval` = 30 s. A `df` that fails is
+  `NotSupported` ("can't tell"), ❌ never a guessed number.
+
+## The error policy
+
+Typed only. `AdbError` is the transport's failure shape (`Io`, `Refused`, `Protocol`, `DeviceGone`, `Timeout`,
+`Cancelled`); `AdbConnectError` is why a connect didn't produce a volume (`AdbNotInstalled`, `ServerUnreachable`,
+`DeviceGone`, `Unauthorized`, `DeviceTooOld`, `TimedOut`, `Cancelled`, `Transport`). The one variant carrying the
+server's text (`Refused`) is a log diagnostic; ❌ branching on it is what `error-string-match` forbids.
+
+**The device's errno is the classifier.** `STA2` and `DNT2` carry a Linux errno, and `errors::volume_error_from_errno`
+maps it to the `Volume` vocabulary for an operation on `path` in one place: `ENOENT` → `NotFound(path)`,
+`EACCES`/`EPERM` → `PermissionDenied(path)`, `EEXIST` → `AlreadyExists(path)`, `EISDIR` → `IsADirectory(path)`,
+`ENAMETOOLONG` → `InvalidName(path)`, `ENOTEMPTY` → an `IoError` carrying the HOST's `ENOTEMPTY` number (the device
+numbers it 39, macOS 66; the app's classifier re-dispatches on `raw_os_error`, so the translation happens here, as
+`cmdr-sftp` does it), `EROFS` → `ReadOnly(path)`, `ENOSPC` → `StorageFull`. Anything else is an `IoError` with the raw
+number. `volume_error_from_adb` maps the transport's shapes (`DeviceGone` → `DeviceDisconnected`, `Timeout` →
+`ConnectionTimeout`, `Cancelled` → `Cancelled`); a `FAIL` text from the sync service lands as an unclassified `IoError`
+with the text in `message` for the log.
+
+**A shell failure is classified by a follow-up probe, never by stderr.** `shell,v2` gives an exit code, which says
+"no" and nothing else; `mkdir`, `rm`, and `mv` print their reason to stderr in `toybox`'s wording, which is for
+people and may be localized. So a non-zero exit is read through what the sync service says is at the path and its
+parent (`AdbVolume::classify_failed_verb` in `writes.rs`): parent missing → `NotFound(parent)`; parent there but not
+writable (`test -w`) → `PermissionDenied(path)`; anything else → an `IoError` carrying stderr for the technical-details
+panel. The probe classifies, ❌ never guards: asked before, it is a TOCTOU window (the two the backend accepts on
+purpose are listed under the `Volume` answers).
+
+**What a variant carries.** `VolumeError::NotFound` and `PermissionDenied` are defined to carry the PATH
+(`crates/cmdr-fs/src/volume/types.rs`), and the transfer layer forwards it straight into what the frontend renders as
+the missing file's name. The mapper takes the path it is mapping a failure for, so a pathless `NotFound` is not
+constructible here. Held by `conformance::assert_not_found_carries_the_path`.
+
+## Which side a test lives on
+
+A cell lives with whatever it **asserts**, never with whatever it connects to.
+
+- **Here**: the framing, the sync and shell codecs, the errno table, path anchoring, the connect phases and calling
+  one off, the state transitions, and the shared `cmdr_fs::volume::conformance` assertions. They run against the
+  **fake ADB server** in `src/testing.rs` (`FakeAdbServer`): a loopback `TcpListener` speaking the host framing,
+  `host:transport`, `host-serial:<serial>:features`, `sync:` (both v1 and v2 verbs), and `shell,v2,raw:` over an
+  in-memory `FakeTree`, plus `host:track-devices` with `push_devices` for scripted hotplug and `drop_connections` /
+  `stop` for faults. `volume/testing.rs` holds the volume-level fixtures on top of it. No `adb` binary, no device, no
+  Docker: every cell runs in the unit lane.
+- **App-side** (`apps/desktop/src-tauri/src/adb/`): anything driving
+  `write_operations`, the volume registry, `volume_listing::complete`, or the listing cache. ❌ Don't widen this
+  crate's public surface to keep a test on that side; move the test instead. ❗ A green suite here is not evidence that
+  a copy works: `supports_export` and the free-space pre-flight are read by the engine, so the cells that would catch
+  them live with the engine.
+- **`#[cfg(any(test, feature = "testing"))]`** widens `testing` and `volume::testing` to `pub` for the app's suites; the crate's own
+  `dev-dependencies` self-entry turns the feature on for every dev target and leaves it off for the lib, so a shipped
+  build carries no fixture. ❌ Never gate a fixture on `cfg(test)` alone.
+- **A real-device pass is pending** (§ "Known gaps"). The fake server implements what the AOSP docs say; the
+  documented differences between the docs and a phone's `adbd` are what that pass is for.
+
+## Known gaps and follow-ups
+
+- **No ranged read on the wire.** `RECV` has no offset; `open_read_stream_at_offset` reads and discards up to it. A
+  resumed pane read on a phone is rare, and a resume from the middle of a 2 GB file re-reads the first half. If it
+  matters, `shell dd` with `skip=`/`bs=` is the fallback, at the cost of the sync service's throughput.
+- **`sendrecv_v2` compression flags** (brotli, lz4, zstd) are off on purpose; measure before enabling, since the
+  device does the compressing.
+- **Wireless debugging** (`adb pair`) is out of scope: the server owns pairing, and a paired device appears in
+  `track-devices` like any other.
+- **Real-device pass pending**: the authorize prompt, an `unauthorized` → `device` transition mid-session, a 2 GB
+  `RECV` / `SEND`, and a `/data` listing on a non-rooted phone (expect `PermissionDenied` carrying the path).
+- **A settings switch for the `adb` binary path**, for machines where it is neither on `PATH` nor under
+  `$ANDROID_HOME`; `$ADB` is the only override today.
+
+## The public surface
+
+The crate is in `guardedIndexCrates`, so nothing here may name `cmdr`, `tauri`, or `tauri-specta`. The root re-exports
+are the app's whole vocabulary: `AdbVolume`, `connect_adb_volume`, `AdbConnectionParams`, `AdbEndpoint`, `AdbDevice`,
+`AdbDeviceState`, `DeviceTracker`, `list_devices`, `track_devices`, `DeviceFeatures`, `AdbError`, and
+`AdbConnectError`. `errors`, `features`, `params`, and `devices` are `pub(crate)`; ❗ keep them that way, since a
+`pub mod` promises everything `pub` inside it.

--- a/crates/cmdr-adb/src/devices.rs
+++ b/crates/cmdr-adb/src/devices.rs
@@ -1,0 +1,290 @@
+//! Which devices the server sees, and a push channel for when that changes.
+//!
+//! `host:devices-l` answers one line per device: `serial<spaces>state` then
+//! optional `product:x model:y device:z transport_id:n` fields.
+//! `host:track-devices` pushes the SHORT format (`serial\tstate`) on every
+//! change for the life of the socket; [`track_devices`] refetches the long
+//! format on each push so listeners always see the rich fields.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::errors::AdbConnectError;
+use crate::server::AdbEndpoint;
+
+/// One device the server knows about.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct AdbDevice {
+    /// The serial (`host:devices` column one). Identity of the volume.
+    pub serial: String,
+    /// What the server can do with it. Only [`AdbDeviceState::Ready`] mounts.
+    pub state: AdbDeviceState,
+    /// `ro.product.name`, when the server reports it.
+    pub product: Option<String>,
+    /// `ro.product.model`, when the server reports it. Underscores for spaces.
+    pub model: Option<String>,
+    /// `ro.product.device`, when the server reports it.
+    pub device: Option<String>,
+    /// The server's transport id, for telling two identical serials apart.
+    pub transport_id: Option<u32>,
+}
+
+/// The server's state word for a device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum AdbDeviceState {
+    /// `device`: authorized and online. The only mountable state.
+    Ready,
+    /// `unauthorized`: waiting on the phone's "Allow USB debugging" prompt.
+    Unauthorized,
+    /// `offline`: attached but `adbd` isn't answering.
+    Offline,
+    /// `no permissions`: the host can't open the USB device (udev on Linux).
+    NoPermissions,
+    /// `connecting`: a TCP device mid-handshake.
+    Connecting,
+    /// `authorizing`: mid RSA handshake.
+    Authorizing,
+    /// `recovery`: booted to recovery.
+    Recovery,
+    /// `bootloader`: in fastboot.
+    Bootloader,
+    /// `sideload`: recovery's sideload mode.
+    Sideload,
+    /// A word this crate doesn't know.
+    Unknown,
+}
+
+impl AdbDeviceState {
+    /// Parses the server's state word. `no permissions` carries extra text on
+    /// some servers (`no permissions (user in plugdev group?)`), so the match is
+    /// on the prefix.
+    pub fn parse(word: &str) -> Self {
+        match word {
+            "device" => Self::Ready,
+            "unauthorized" => Self::Unauthorized,
+            "offline" => Self::Offline,
+            "connecting" => Self::Connecting,
+            "authorizing" => Self::Authorizing,
+            "recovery" => Self::Recovery,
+            "bootloader" => Self::Bootloader,
+            "sideload" => Self::Sideload,
+            w if w.starts_with("no permissions") => Self::NoPermissions,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// The server's word for this state, for the fake server and logs.
+    pub fn as_word(self) -> &'static str {
+        match self {
+            Self::Ready => "device",
+            Self::Unauthorized => "unauthorized",
+            Self::Offline => "offline",
+            Self::NoPermissions => "no permissions",
+            Self::Connecting => "connecting",
+            Self::Authorizing => "authorizing",
+            Self::Recovery => "recovery",
+            Self::Bootloader => "bootloader",
+            Self::Sideload => "sideload",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl AdbDevice {
+    /// What to call this device: the model with underscores as spaces, else
+    /// the product, else the serial.
+    pub fn display_name(&self) -> String {
+        if let Some(model) = self.model.as_deref().filter(|m| !m.is_empty()) {
+            return model.replace('_', " ");
+        }
+        if let Some(product) = self.product.as_deref().filter(|p| !p.is_empty()) {
+            return product.to_string();
+        }
+        self.serial.clone()
+    }
+
+    /// Whether the device can be mounted right now.
+    pub fn is_ready(&self) -> bool {
+        self.state == AdbDeviceState::Ready
+    }
+}
+
+/// Parses a `host:devices-l` (or `host:devices`) payload.
+///
+/// The long format pads the serial with spaces to a column, then the state,
+/// then `key:value` fields; the short format is `serial\tstate`. `no
+/// permissions` is two words, so the state is everything up to the first
+/// `key:value` field rather than the second token.
+pub(crate) fn parse_device_list(payload: &str) -> Vec<AdbDevice> {
+    payload.lines().filter_map(parse_device_line).collect()
+}
+
+fn parse_device_line(line: &str) -> Option<AdbDevice> {
+    let line = line.trim_end();
+    if line.is_empty() {
+        return None;
+    }
+    let (serial, rest) = line.split_once(|c: char| c.is_whitespace())?;
+    let rest = rest.trim_start();
+    let mut state_words = Vec::new();
+    let mut device = AdbDevice {
+        serial: serial.to_string(),
+        state: AdbDeviceState::Unknown,
+        product: None,
+        model: None,
+        device: None,
+        transport_id: None,
+    };
+    for token in rest.split_whitespace() {
+        match token.split_once(':') {
+            Some(("product", v)) => device.product = Some(v.to_string()),
+            Some(("model", v)) => device.model = Some(v.to_string()),
+            Some(("device", v)) => device.device = Some(v.to_string()),
+            Some(("transport_id", v)) => device.transport_id = v.parse().ok(),
+            Some(_) => {}
+            None => state_words.push(token),
+        }
+    }
+    device.state = AdbDeviceState::parse(&state_words.join(" "));
+    Some(device)
+}
+
+/// Asks the server for every device it sees, with the long-format fields.
+pub async fn list_devices(endpoint: &AdbEndpoint) -> Result<Vec<AdbDevice>, AdbConnectError> {
+    let mut conn = endpoint.connect().await?;
+    conn.request("host:devices-l").await?;
+    let payload = conn.read_hex_message().await?;
+    conn.shutdown().await;
+    Ok(parse_device_list(&String::from_utf8_lossy(&payload)))
+}
+
+/// Tuning for the tracker's reconnect loop. Tests shorten it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TrackerBackoff {
+    /// The first wait after a drop.
+    pub initial: Duration,
+    /// Doubling stops here.
+    pub cap: Duration,
+}
+
+impl Default for TrackerBackoff {
+    fn default() -> Self {
+        Self {
+            initial: Duration::from_secs(1),
+            cap: Duration::from_secs(15),
+        }
+    }
+}
+
+/// A running `host:track-devices` subscription. Stops on [`DeviceTracker::stop`]
+/// or drop.
+pub struct DeviceTracker {
+    task: JoinHandle<()>,
+    cancel: CancellationToken,
+}
+
+impl std::fmt::Debug for DeviceTracker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeviceTracker").finish_non_exhaustive()
+    }
+}
+
+impl DeviceTracker {
+    /// Ends the subscription. Idempotent; the task is aborted, so no callback
+    /// runs after this returns to a caller on another thread only if it wasn't
+    /// already mid-call.
+    pub fn stop(&self) {
+        self.cancel.cancel();
+        self.task.abort();
+    }
+}
+
+impl Drop for DeviceTracker {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Subscribes to `host:track-devices` on `runtime`.
+///
+/// `on_change` gets the FULL parsed list (refetched through `host:devices-l`,
+/// since a push carries only serial and state) on the first answer and on every
+/// change after. When the socket drops, the tracker reconnects with backoff
+/// (1 s, 2 s, … capped at 15 s), and each successful reconnect delivers the
+/// list again so a listener that missed a change while the server was away
+/// catches up.
+pub fn track_devices(
+    endpoint: AdbEndpoint,
+    runtime: tokio::runtime::Handle,
+    on_change: Arc<dyn Fn(Vec<AdbDevice>) + Send + Sync>,
+) -> DeviceTracker {
+    track_devices_with(endpoint, runtime, on_change, TrackerBackoff::default())
+}
+
+pub(crate) fn track_devices_with(
+    endpoint: AdbEndpoint,
+    runtime: tokio::runtime::Handle,
+    on_change: Arc<dyn Fn(Vec<AdbDevice>) + Send + Sync>,
+    backoff: TrackerBackoff,
+) -> DeviceTracker {
+    let cancel = CancellationToken::new();
+    let token = cancel.clone();
+    let task = runtime.spawn(async move {
+        let mut wait = backoff.initial;
+        loop {
+            let session = token.run_until_cancelled(track_once(&endpoint, &on_change));
+            match session.await {
+                None => return,
+                Some(Ok(())) => {
+                    debug!("adb track-devices socket closed; reconnecting");
+                    wait = backoff.initial;
+                }
+                Some(Err(err)) => {
+                    warn!("adb track-devices dropped ({err}); retrying in {wait:?}");
+                }
+            }
+            if token.run_until_cancelled(tokio::time::sleep(wait)).await.is_none() {
+                return;
+            }
+            wait = (wait * 2).min(backoff.cap);
+        }
+    });
+    DeviceTracker { task, cancel }
+}
+
+/// One `host:track-devices` session: `Ok(())` when the server closed the
+/// socket cleanly, `Err` when anything else ended it.
+async fn track_once(
+    endpoint: &AdbEndpoint,
+    on_change: &Arc<dyn Fn(Vec<AdbDevice>) + Send + Sync>,
+) -> Result<(), AdbConnectError> {
+    let mut conn = endpoint.connect().await?;
+    conn.request("host:track-devices").await?;
+    loop {
+        let push = match conn.read_hex_message().await {
+            Ok(push) => push,
+            Err(crate::errors::AdbError::DeviceGone) => return Ok(()),
+            Err(err) => return Err(err.into()),
+        };
+        let short = parse_device_list(&String::from_utf8_lossy(&push));
+        let list = match list_devices(endpoint).await {
+            Ok(list) => list,
+            Err(err) => {
+                debug!("adb devices-l after a push refused ({err}); using the short list");
+                short
+            }
+        };
+        on_change(list);
+    }
+}
+
+#[cfg(test)]
+#[path = "devices_test.rs"]
+mod devices_test;

--- a/crates/cmdr-adb/src/devices_test.rs
+++ b/crates/cmdr-adb/src/devices_test.rs
@@ -1,0 +1,138 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use super::*;
+use crate::testing::{FAKE_SERIAL, FakeAdbServer, FakeTree, fake_device};
+
+#[test]
+fn parses_the_long_format() {
+    let list = parse_device_list(
+        "R5CT10ABCDE            device usb:1-1 product:beyond2lteeea model:SM_G975F device:beyond2 transport_id:3\n\
+         emulator-5554          unauthorized transport_id:4\n",
+    );
+    assert_eq!(list.len(), 2);
+    assert_eq!(list[0].serial, "R5CT10ABCDE");
+    assert_eq!(list[0].state, AdbDeviceState::Ready);
+    assert_eq!(list[0].product.as_deref(), Some("beyond2lteeea"));
+    assert_eq!(list[0].model.as_deref(), Some("SM_G975F"));
+    assert_eq!(list[0].device.as_deref(), Some("beyond2"));
+    assert_eq!(list[0].transport_id, Some(3));
+    assert_eq!(list[0].display_name(), "SM G975F");
+    assert!(list[0].is_ready());
+    assert_eq!(list[1].state, AdbDeviceState::Unauthorized);
+    assert_eq!(list[1].model, None);
+    assert_eq!(list[1].display_name(), "emulator-5554");
+    assert!(!list[1].is_ready());
+}
+
+#[test]
+fn parses_the_short_format_and_every_state_word() {
+    let cases = [
+        ("device", AdbDeviceState::Ready),
+        ("unauthorized", AdbDeviceState::Unauthorized),
+        ("offline", AdbDeviceState::Offline),
+        ("no permissions", AdbDeviceState::NoPermissions),
+        (
+            "no permissions (user in plugdev group?); see [url]",
+            AdbDeviceState::NoPermissions,
+        ),
+        ("connecting", AdbDeviceState::Connecting),
+        ("authorizing", AdbDeviceState::Authorizing),
+        ("recovery", AdbDeviceState::Recovery),
+        ("bootloader", AdbDeviceState::Bootloader),
+        ("sideload", AdbDeviceState::Sideload),
+        ("weird", AdbDeviceState::Unknown),
+    ];
+    for (word, state) in cases {
+        let list = parse_device_list(&format!("SER123\t{word}\n"));
+        assert_eq!(list.len(), 1, "{word}");
+        assert_eq!(list[0].state, state, "{word}");
+        assert_eq!(list[0].serial, "SER123");
+    }
+    assert!(parse_device_list("").is_empty());
+    assert!(parse_device_list("\n\n").is_empty());
+}
+
+#[test]
+fn display_name_falls_back_to_product_then_serial() {
+    let mut d = fake_device();
+    assert_eq!(d.display_name(), "Fake Phone");
+    d.model = None;
+    assert_eq!(d.display_name(), "sdk_gphone64_arm64");
+    d.product = None;
+    assert_eq!(d.display_name(), FAKE_SERIAL);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_devices_reads_the_long_fields() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let list = list_devices(&server.endpoint()).await.unwrap();
+    assert_eq!(list, vec![fake_device()]);
+}
+
+fn device(serial: &str, state: AdbDeviceState) -> AdbDevice {
+    AdbDevice {
+        serial: serial.to_string(),
+        state,
+        product: None,
+        model: Some(format!("Model_{serial}")),
+        device: None,
+        transport_id: None,
+    }
+}
+
+async fn next(rx: &mut mpsc::UnboundedReceiver<Vec<AdbDevice>>) -> Vec<AdbDevice> {
+    tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        .await
+        .expect("a device list within 10 s")
+        .expect("channel open")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tracker_delivers_pushes_and_reconnects_after_a_drop() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let on_change: Arc<dyn Fn(Vec<AdbDevice>) + Send + Sync> = Arc::new(move |list| {
+        let _ = tx.send(list);
+    });
+    let tracker = track_devices_with(
+        server.endpoint(),
+        tokio::runtime::Handle::current(),
+        on_change,
+        TrackerBackoff {
+            initial: Duration::from_millis(20),
+            cap: Duration::from_millis(100),
+        },
+    );
+
+    // The initial list, refetched with the long fields.
+    assert_eq!(next(&mut rx).await, vec![fake_device()]);
+
+    // A push reaches the listener with the full fields.
+    let two = vec![fake_device(), device("SECOND", AdbDeviceState::Unauthorized)];
+    server.push_devices(two.clone());
+    assert_eq!(next(&mut rx).await, two);
+
+    // The server drops every socket; the tracker reconnects and redelivers.
+    server.drop_connections();
+    assert_eq!(next(&mut rx).await, two);
+
+    // And pushes keep flowing on the new socket.
+    let three = vec![device("THIRD", AdbDeviceState::Ready)];
+    server.push_devices(three.clone());
+    assert_eq!(next(&mut rx).await, three);
+
+    tracker.stop();
+    drop(tracker);
+    // Drain anything that was already in flight when the stop landed, then
+    // check that a push after the stop reaches nobody.
+    while tokio::time::timeout(Duration::from_millis(100), rx.recv())
+        .await
+        .is_ok()
+    {}
+    server.push_devices(Vec::new());
+    let stray = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await;
+    assert!(stray.is_err(), "stopped tracker stays silent, got {stray:?}");
+}

--- a/crates/cmdr-adb/src/errors.rs
+++ b/crates/cmdr-adb/src/errors.rs
@@ -1,0 +1,241 @@
+//! What can go wrong talking to the ADB server, and how the device's answers map
+//! onto Cmdr's vocabulary.
+//!
+//! ❌ Nothing here is prose a user reads. The `String`s are log diagnostics, the
+//! same way `cmdr-sftp`'s `SftpConnectError` carries one; the host renders every
+//! human word from the typed variant.
+
+use std::io::ErrorKind;
+
+use cmdr_fs::volume::VolumeError;
+
+/// A transport-level failure on an open ADB socket.
+///
+/// Typed on the SHAPE of the failure, never on the server's wording: the one
+/// variant that carries the server's text ([`AdbError::Refused`]) is a log
+/// diagnostic, and ❌ branching on it is what `error-string-match` forbids.
+#[derive(Debug)]
+pub enum AdbError {
+    /// The socket itself broke in a way that isn't one of the shapes below.
+    Io(std::io::Error),
+    /// The server answered `FAIL`. The payload is its message, verbatim, for
+    /// the log.
+    Refused(String),
+    /// The server said something the protocol doesn't allow here (a status
+    /// that's neither `OKAY` nor `FAIL`, a non-hex length, an unknown sync id).
+    Protocol(String),
+    /// The socket closed under us: the device unplugged, `adbd` restarted, or
+    /// the server went away.
+    DeviceGone,
+    /// A read or connect ran past its budget.
+    Timeout,
+    /// The caller called the operation off.
+    Cancelled,
+}
+
+impl std::fmt::Display for AdbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "adb socket: {err}"),
+            Self::Refused(msg) => write!(f, "adb refused: {msg}"),
+            Self::Protocol(msg) => write!(f, "adb protocol: {msg}"),
+            Self::DeviceGone => f.write_str("adb device gone"),
+            Self::Timeout => f.write_str("adb timed out"),
+            Self::Cancelled => f.write_str("adb cancelled"),
+        }
+    }
+}
+
+impl std::error::Error for AdbError {}
+
+impl From<std::io::Error> for AdbError {
+    /// Sorts the socket's own failure shapes into the typed variants: a peer
+    /// that hung up is [`AdbError::DeviceGone`], a budget that ran out is
+    /// [`AdbError::Timeout`]. Everything else stays an [`AdbError::Io`].
+    fn from(err: std::io::Error) -> Self {
+        match err.kind() {
+            ErrorKind::UnexpectedEof
+            | ErrorKind::ConnectionReset
+            | ErrorKind::ConnectionAborted
+            | ErrorKind::BrokenPipe => Self::DeviceGone,
+            ErrorKind::TimedOut => Self::Timeout,
+            _ => Self::Io(err),
+        }
+    }
+}
+
+/// Why a connect didn't produce a volume.
+///
+/// A typed value rather than a message, because the app branches on it: an
+/// absent binary, an unauthorized phone, and a device too old for `shell_v2`
+/// each put a different thing in front of the user.
+#[derive(Debug)]
+pub enum AdbConnectError {
+    /// No `adb` binary anywhere [`crate::server::locate_adb_binary`] looks, so
+    /// an absent server can't be started.
+    AdbNotInstalled,
+    /// The server socket couldn't be reached, even after a start attempt.
+    ServerUnreachable(String),
+    /// The device with this serial isn't attached (or vanished mid-connect).
+    DeviceGone(String),
+    /// The device is attached but hasn't accepted this computer's RSA key. The
+    /// user has to tap "Allow" on the phone.
+    Unauthorized(String),
+    /// The device's ADB predates `shell_v2` (Android 7, 2016). The legacy
+    /// `shell:` service carries no exit code, so nothing above can be honest
+    /// about whether a mutation happened; refused up front.
+    DeviceTooOld {
+        /// The device's serial.
+        serial: String,
+    },
+    /// The connect ran past its budget.
+    TimedOut,
+    /// The user called the connect off.
+    Cancelled,
+    /// The transport refused or broke in a way none of the above names.
+    Transport(String),
+}
+
+impl std::fmt::Display for AdbConnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AdbNotInstalled => f.write_str("adb binary not found"),
+            Self::ServerUnreachable(msg) => write!(f, "adb server unreachable: {msg}"),
+            Self::DeviceGone(serial) => write!(f, "adb device gone: {serial}"),
+            Self::Unauthorized(serial) => write!(f, "adb device unauthorized: {serial}"),
+            Self::DeviceTooOld { serial } => write!(f, "adb device too old (no shell_v2): {serial}"),
+            Self::TimedOut => f.write_str("adb connect timed out"),
+            Self::Cancelled => f.write_str("adb connect cancelled"),
+            Self::Transport(msg) => write!(f, "adb transport: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for AdbConnectError {}
+
+impl From<AdbError> for AdbConnectError {
+    /// The transport's failure, seen from a connect that didn't finish.
+    ///
+    /// ❗ [`AdbError::DeviceGone`] arrives without a serial (the transport
+    /// doesn't know one), so it becomes a [`AdbConnectError::DeviceGone`] with
+    /// an EMPTY serial; [`AdbConnectError::for_device`] fills it in where the
+    /// serial is in scope.
+    fn from(err: AdbError) -> Self {
+        match err {
+            AdbError::Io(io) if io.kind() == ErrorKind::ConnectionRefused => Self::ServerUnreachable(io.to_string()),
+            AdbError::Io(io) => Self::Transport(io.to_string()),
+            AdbError::Refused(msg) | AdbError::Protocol(msg) => Self::Transport(msg),
+            AdbError::DeviceGone => Self::DeviceGone(String::new()),
+            AdbError::Timeout => Self::TimedOut,
+            AdbError::Cancelled => Self::Cancelled,
+        }
+    }
+}
+
+impl AdbConnectError {
+    /// The same error with `serial` filled into the variants that carry one
+    /// and arrived without it (see the `From<AdbError>` impl).
+    #[must_use]
+    pub fn for_device(self, serial: &str) -> Self {
+        match self {
+            Self::DeviceGone(s) if s.is_empty() => Self::DeviceGone(serial.to_string()),
+            Self::Unauthorized(s) if s.is_empty() => Self::Unauthorized(serial.to_string()),
+            other => other,
+        }
+    }
+}
+
+// The device is Linux whatever the host is, so the errno numbers `STA2`/`DNT2`
+// carry are Linux's. Named here rather than pulled from `libc`, which would tie
+// them to the HOST platform's table.
+
+/// Linux `EPERM`.
+pub const EPERM: i32 = 1;
+/// Linux `ENOENT`.
+pub const ENOENT: i32 = 2;
+/// Linux `EACCES`.
+pub const EACCES: i32 = 13;
+/// Linux `EEXIST`.
+pub const EEXIST: i32 = 17;
+/// Linux `ENOTDIR`.
+pub const ENOTDIR: i32 = 20;
+/// Linux `EISDIR`.
+pub const EISDIR: i32 = 21;
+/// Linux `ENOSPC`.
+pub const ENOSPC: i32 = 28;
+/// Linux `EROFS`.
+pub const EROFS: i32 = 30;
+/// Linux `ENAMETOOLONG`.
+pub const ENAMETOOLONG: i32 = 36;
+/// Linux `ENOTEMPTY`, as the DEVICE numbers it.
+pub const ENOTEMPTY_DEVICE: i32 = 39;
+
+/// `ENOTEMPTY` as the HOST numbers it, which is what the app's classifier
+/// re-dispatches `raw_os_error` against (`cmdr-sftp` makes the same translation).
+#[cfg(target_os = "linux")]
+const ENOTEMPTY_HOST: i32 = 39;
+/// `ENOTEMPTY` on everything else Cmdr builds for.
+#[cfg(not(target_os = "linux"))]
+const ENOTEMPTY_HOST: i32 = 66;
+
+/// Turns a device errno (from `STA2`/`DNT2`, or a shell probe) into the
+/// `Volume` vocabulary, for an operation on `path`.
+///
+/// ❗ **`path` is not context, it's the payload.** [`VolumeError::NotFound`] and
+/// [`VolumeError::PermissionDenied`] are DEFINED to carry the path
+/// (`cmdr-fs/src/volume/types.rs`), and the transfer layer forwards that string
+/// straight into `SourceNotFound { path }`, which the frontend renders as the
+/// name of the missing file. It goes in VERBATIM.
+///
+/// Anything unlisted is an [`VolumeError::IoError`] carrying the number, so the
+/// app's classifier can still dispatch on it; `ENOTEMPTY` is translated to the
+/// host's number on the way (the device is Linux, the host may not be).
+pub fn volume_error_from_errno(errno: i32, path: &str) -> VolumeError {
+    match errno {
+        ENOENT => VolumeError::NotFound(path.to_string()),
+        EACCES | EPERM => VolumeError::PermissionDenied(path.to_string()),
+        EEXIST => VolumeError::AlreadyExists(path.to_string()),
+        EROFS => VolumeError::ReadOnly(path.to_string()),
+        ENOSPC => VolumeError::StorageFull {
+            message: format!("ENOSPC on {path}"),
+        },
+        EISDIR => VolumeError::IsADirectory(path.to_string()),
+        ENAMETOOLONG => VolumeError::InvalidName(path.to_string()),
+        ENOTEMPTY_DEVICE => VolumeError::IoError {
+            message: format!("ENOTEMPTY on {path}"),
+            raw_os_error: Some(ENOTEMPTY_HOST),
+        },
+        other => VolumeError::IoError {
+            message: format!("errno {other} on {path}"),
+            raw_os_error: Some(other),
+        },
+    }
+}
+
+/// Turns a transport failure during an operation on `path` into the `Volume`
+/// vocabulary.
+///
+/// A [`AdbError::Refused`] is the device's `FAIL` text, which the sync service
+/// produces without an errno; it lands as an unclassified
+/// [`VolumeError::IoError`] with the text in `message` for the log. Callers that
+/// can do better (a shell probe, an `STA2` afterwards) resolve it before coming
+/// here.
+pub fn volume_error_from_adb(error: AdbError, path: &str) -> VolumeError {
+    match error {
+        AdbError::DeviceGone => VolumeError::DeviceDisconnected(path.to_string()),
+        AdbError::Timeout => VolumeError::ConnectionTimeout(path.to_string()),
+        AdbError::Cancelled => VolumeError::Cancelled(path.to_string()),
+        AdbError::Io(io) => VolumeError::IoError {
+            message: io.to_string(),
+            raw_os_error: None,
+        },
+        AdbError::Refused(msg) | AdbError::Protocol(msg) => VolumeError::IoError {
+            message: msg,
+            raw_os_error: None,
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "errors_test.rs"]
+mod errors_test;

--- a/crates/cmdr-adb/src/errors_test.rs
+++ b/crates/cmdr-adb/src/errors_test.rs
@@ -1,0 +1,99 @@
+use std::io::ErrorKind;
+
+use cmdr_fs::volume::VolumeError;
+
+use super::*;
+
+#[test]
+fn errno_maps_to_the_volume_vocabulary_carrying_the_path() {
+    let path = "/sdcard/DCIM/missing.jpg";
+    assert!(matches!(volume_error_from_errno(ENOENT, path), VolumeError::NotFound(p) if p == path));
+    assert!(matches!(volume_error_from_errno(EACCES, path), VolumeError::PermissionDenied(p) if p == path));
+    assert!(matches!(volume_error_from_errno(EPERM, path), VolumeError::PermissionDenied(p) if p == path));
+    assert!(matches!(volume_error_from_errno(EEXIST, path), VolumeError::AlreadyExists(p) if p == path));
+    assert!(matches!(volume_error_from_errno(EROFS, path), VolumeError::ReadOnly(p) if p == path));
+    assert!(matches!(
+        volume_error_from_errno(ENOSPC, path),
+        VolumeError::StorageFull { .. }
+    ));
+    assert!(matches!(volume_error_from_errno(EISDIR, path), VolumeError::IsADirectory(p) if p == path));
+    assert!(matches!(volume_error_from_errno(ENAMETOOLONG, path), VolumeError::InvalidName(p) if p == path));
+}
+
+#[test]
+fn unknown_errno_is_an_io_error_carrying_the_number() {
+    let err = volume_error_from_errno(20, "/x");
+    assert!(matches!(
+        err,
+        VolumeError::IoError {
+            raw_os_error: Some(20),
+            ..
+        }
+    ));
+}
+
+#[test]
+fn enotempty_is_translated_to_the_host_number() {
+    let err = volume_error_from_errno(ENOTEMPTY_DEVICE, "/x");
+    assert!(matches!(err, VolumeError::IoError { raw_os_error: Some(n), .. } if n == ENOTEMPTY_HOST));
+}
+
+#[test]
+fn transport_failures_map_by_shape() {
+    assert!(
+        matches!(volume_error_from_adb(AdbError::DeviceGone, "/p"), VolumeError::DeviceDisconnected(p) if p == "/p")
+    );
+    assert!(matches!(volume_error_from_adb(AdbError::Timeout, "/p"), VolumeError::ConnectionTimeout(p) if p == "/p"));
+    assert!(matches!(volume_error_from_adb(AdbError::Cancelled, "/p"), VolumeError::Cancelled(p) if p == "/p"));
+    assert!(matches!(
+        volume_error_from_adb(AdbError::Refused("nope".into()), "/p"),
+        VolumeError::IoError { message, raw_os_error: None } if message == "nope"
+    ));
+    assert!(matches!(
+        volume_error_from_adb(AdbError::Io(std::io::Error::other("x")), "/p"),
+        VolumeError::IoError { raw_os_error: None, .. }
+    ));
+}
+
+#[test]
+fn io_errors_sort_into_typed_variants() {
+    assert!(matches!(
+        AdbError::from(std::io::Error::from(ErrorKind::UnexpectedEof)),
+        AdbError::DeviceGone
+    ));
+    assert!(matches!(
+        AdbError::from(std::io::Error::from(ErrorKind::ConnectionReset)),
+        AdbError::DeviceGone
+    ));
+    assert!(matches!(
+        AdbError::from(std::io::Error::from(ErrorKind::BrokenPipe)),
+        AdbError::DeviceGone
+    ));
+    assert!(matches!(
+        AdbError::from(std::io::Error::from(ErrorKind::TimedOut)),
+        AdbError::Timeout
+    ));
+    assert!(matches!(
+        AdbError::from(std::io::Error::from(ErrorKind::Other)),
+        AdbError::Io(_)
+    ));
+}
+
+#[test]
+fn connect_errors_from_transport_errors() {
+    assert!(matches!(
+        AdbConnectError::from(AdbError::Timeout),
+        AdbConnectError::TimedOut
+    ));
+    assert!(matches!(
+        AdbConnectError::from(AdbError::Cancelled),
+        AdbConnectError::Cancelled
+    ));
+    assert!(matches!(
+        AdbConnectError::from(AdbError::Io(std::io::Error::from(ErrorKind::ConnectionRefused))),
+        AdbConnectError::ServerUnreachable(_)
+    ));
+    assert!(matches!(AdbConnectError::from(AdbError::Refused("x".into())), AdbConnectError::Transport(m) if m == "x"));
+    let gone = AdbConnectError::from(AdbError::DeviceGone).for_device("SER");
+    assert!(matches!(gone, AdbConnectError::DeviceGone(s) if s == "SER"));
+}

--- a/crates/cmdr-adb/src/features.rs
+++ b/crates/cmdr-adb/src/features.rs
@@ -1,0 +1,83 @@
+//! What a device's own ADB supports, read once per session.
+//!
+//! `host-serial:<serial>:features` answers the comma-separated list `adbd`
+//! advertised at connect (`shell_v2,cmd,stat_v2,ls_v2,fixed_push_mkdir,…`).
+//! The four that change what this crate sends are recorded; the rest are
+//! ignored.
+
+use crate::errors::AdbError;
+use crate::server::AdbEndpoint;
+
+/// The feature flags this crate branches on.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DeviceFeatures {
+    /// `shell,v2,raw:` with framed stdout/stderr/exit. ❗ Without it the device
+    /// is refused (`AdbConnectError::DeviceTooOld`): the legacy `shell:` has no
+    /// exit code.
+    pub shell_v2: bool,
+    /// `STA2`: stat with errno and 64-bit sizes.
+    pub stat_v2: bool,
+    /// `LIS2`: listing with errno and 64-bit sizes.
+    pub ls_v2: bool,
+    /// `SND2`/`RCV2`: transfers with a flags word (compression, dry-run).
+    pub sendrecv_v2: bool,
+}
+
+impl DeviceFeatures {
+    /// Parses the server's comma-separated feature list. Unknown names are
+    /// ignored; whitespace around names is tolerated.
+    pub fn parse(list: &str) -> Self {
+        let mut features = Self::default();
+        for name in list.split(',').map(str::trim) {
+            match name {
+                "shell_v2" => features.shell_v2 = true,
+                "stat_v2" => features.stat_v2 = true,
+                "ls_v2" => features.ls_v2 = true,
+                "sendrecv_v2" => features.sendrecv_v2 = true,
+                _ => {}
+            }
+        }
+        features
+    }
+
+    /// Everything on: what a current device advertises. For fixtures.
+    pub fn all() -> Self {
+        Self {
+            shell_v2: true,
+            stat_v2: true,
+            ls_v2: true,
+            sendrecv_v2: true,
+        }
+    }
+
+    /// Asks the server what the device with `serial` supports.
+    pub async fn fetch(endpoint: &AdbEndpoint, serial: &str) -> Result<Self, AdbError> {
+        let mut conn = endpoint.connect().await.map_err(connect_as_transport)?;
+        conn.request(&format!("host-serial:{serial}:features")).await?;
+        let list = conn.read_hex_message().await?;
+        conn.shutdown().await;
+        Ok(Self::parse(&String::from_utf8_lossy(&list)))
+    }
+}
+
+/// A connect failure seen from a call that promised an [`AdbError`].
+///
+/// The typed connect variants that matter (`AdbNotInstalled`, `Unauthorized`)
+/// arise before any device call, at the volume's own connect; by the time a
+/// feature fetch or a shell run dials, a refused socket means the server left.
+pub(crate) fn connect_as_transport(err: crate::errors::AdbConnectError) -> AdbError {
+    use crate::errors::AdbConnectError;
+    match err {
+        AdbConnectError::TimedOut => AdbError::Timeout,
+        AdbConnectError::Cancelled => AdbError::Cancelled,
+        AdbConnectError::DeviceGone(_) => AdbError::DeviceGone,
+        other => AdbError::Io(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            other.to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+#[path = "features_test.rs"]
+mod features_test;

--- a/crates/cmdr-adb/src/features_test.rs
+++ b/crates/cmdr-adb/src/features_test.rs
@@ -1,0 +1,32 @@
+use super::*;
+use crate::testing::{FAKE_SERIAL, FakeAdbServer, FakeTree};
+
+#[test]
+fn parses_the_four_flags_and_ignores_the_rest() {
+    let f = DeviceFeatures::parse("shell_v2,cmd,stat_v2, ls_v2 ,fixed_push_mkdir,sendrecv_v2,openscreen_mdns");
+    assert_eq!(f, DeviceFeatures::all());
+    assert_eq!(DeviceFeatures::parse(""), DeviceFeatures::default());
+    assert_eq!(
+        DeviceFeatures::parse("cmd,stat_v2"),
+        DeviceFeatures {
+            stat_v2: true,
+            ..DeviceFeatures::default()
+        }
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_reads_the_device_list() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    assert_eq!(
+        DeviceFeatures::fetch(&server.endpoint(), FAKE_SERIAL).await.unwrap(),
+        DeviceFeatures::all()
+    );
+    server.set_features("cmd,shell_v2");
+    let f = DeviceFeatures::fetch(&server.endpoint(), FAKE_SERIAL).await.unwrap();
+    assert!(f.shell_v2 && !f.stat_v2 && !f.ls_v2 && !f.sendrecv_v2);
+    assert!(matches!(
+        DeviceFeatures::fetch(&server.endpoint(), "ghost").await,
+        Err(AdbError::Refused(_))
+    ));
+}

--- a/crates/cmdr-adb/src/lib.rs
+++ b/crates/cmdr-adb/src/lib.rs
@@ -1,0 +1,51 @@
+#![warn(unused_crate_dependencies)]
+#![deny(missing_docs)]
+
+//! Everything Cmdr says to an Android device over ADB.
+//!
+//! The device-side twin of `cmdr-sftp`: one `Volume` per connected device,
+//! rooted at the device's real filesystem (`/`) rather than at the curated
+//! object tree MTP exposes. Nothing here knows about `tauri`, and nothing here
+//! holds a user-facing word — the host renders every sentence from the typed
+//! values this crate returns.
+//!
+//! ## The shape of the thing
+//!
+//! Cmdr talks to the **ADB server** (the `adb` daemon on `127.0.0.1:5037`), not
+//! to the device directly: the server owns USB, multiplexes clients, and is
+//! already running on any machine with the platform tools installed. Every
+//! module below is one layer of that conversation:
+//!
+//! - `server` finds the endpoint and, once, starts an absent server.
+//! - `transport` is the ONLY module that speaks the wire framing.
+//! - `devices` lists attached devices and — the reason this backend can do what
+//!   MTP can't — streams `host:track-devices` for hotplug.
+//! - `features` records what a device's own ADB supports, read once per session.
+//! - `sync` is the file-transfer service (`STAT`/`LIST`/`RECV`/`SEND`).
+//! - `shell` is everything the sync service has no verb for: mkdir, rm, mv, df.
+//! - `volume` is the `Volume` impl assembled from those.
+
+#[cfg(test)]
+use cmdr_adb as _;
+
+pub(crate) mod devices;
+pub(crate) mod errors;
+pub(crate) mod features;
+pub(crate) mod params;
+pub mod server;
+pub mod shell;
+pub mod sync;
+pub mod transport;
+pub mod volume;
+
+/// The fake ADB server and in-memory device tree, for this crate's tests and
+/// the app's. Compiled only under `#[cfg(test)]` or the `testing` feature.
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
+
+pub use devices::{AdbDevice, AdbDeviceState, DeviceTracker, list_devices, track_devices};
+pub use errors::{AdbConnectError, AdbError, volume_error_from_adb, volume_error_from_errno};
+pub use features::DeviceFeatures;
+pub use params::AdbConnectionParams;
+pub use server::AdbEndpoint;
+pub use volume::{AdbVolume, connect_adb_volume};

--- a/crates/cmdr-adb/src/params.rs
+++ b/crates/cmdr-adb/src/params.rs
@@ -1,0 +1,32 @@
+//! How to reach one device, and how to reach it again.
+
+use crate::server::AdbEndpoint;
+
+/// Everything needed to open (and later re-open) one ADB volume.
+///
+/// No secret lives here: authorization is the phone's RSA prompt, which the
+/// ADB server owns.
+#[derive(Debug, Clone)]
+pub struct AdbConnectionParams {
+    /// The device serial as `host:devices` lists it. ❗ The volume's whole
+    /// identity: `volume_id` is `adb:<serial>`.
+    pub serial: String,
+    /// The ADB server to ask for that device.
+    pub endpoint: AdbEndpoint,
+}
+
+impl AdbConnectionParams {
+    /// Params for the common case: the local server on `127.0.0.1:5037`.
+    pub fn new(serial: &str) -> Self {
+        Self::at(serial, AdbEndpoint::default_local())
+    }
+
+    /// Params for a device behind a specific server (tests, a fake, a
+    /// forwarded port).
+    pub fn at(serial: &str, endpoint: AdbEndpoint) -> Self {
+        Self {
+            serial: serial.to_string(),
+            endpoint,
+        }
+    }
+}

--- a/crates/cmdr-adb/src/server.rs
+++ b/crates/cmdr-adb/src/server.rs
@@ -1,0 +1,188 @@
+//! Where the ADB server is, and how to reach it.
+//!
+//! Cmdr never talks USB: the `adb` server daemon on `127.0.0.1:5037` owns the
+//! devices and multiplexes clients. It's already running on any machine where
+//! the user has run `adb` once; when it isn't, [`AdbEndpoint::connect`] starts
+//! it through the platform binary, ONCE per process, and only for the default
+//! endpoint. A fake or forwarded endpoint ([`AdbEndpoint::at`]) never starts
+//! anything.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use log::{debug, info, warn};
+use tokio::net::TcpStream;
+use tokio::sync::OnceCell;
+
+use crate::errors::AdbConnectError;
+use crate::transport::AdbConnection;
+
+/// The port the ADB server listens on unless `ANDROID_ADB_SERVER_PORT` says
+/// otherwise.
+pub const DEFAULT_PORT: u16 = 5037;
+
+/// How long a TCP connect to the server may take. Loopback answers in
+/// microseconds; a budget this long only ever trips on a wedged server.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// How long `adb start-server` may take to come up.
+const START_SERVER_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// The one start attempt this process makes. `true` if the binary reported
+/// success. A second refused connect after a start never starts again: either
+/// the server is there and something else is wrong, or the binary itself can't
+/// bring it up, and both are the user's to look at.
+static SERVER_STARTED: OnceCell<bool> = OnceCell::const_new();
+
+/// One ADB server to talk to.
+#[derive(Debug, Clone)]
+pub struct AdbEndpoint {
+    addr: SocketAddr,
+    /// The platform binary, when known up front. `None` on the default endpoint
+    /// means "locate lazily on first refused connect".
+    binary: Option<PathBuf>,
+    may_start_server: bool,
+}
+
+impl AdbEndpoint {
+    /// The local server on `127.0.0.1:5037` (or `$ANDROID_ADB_SERVER_PORT`),
+    /// started on demand through the located binary.
+    pub fn default_local() -> Self {
+        let port = std::env::var("ANDROID_ADB_SERVER_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(DEFAULT_PORT);
+        Self {
+            addr: SocketAddr::from((Ipv4Addr::LOCALHOST, port)),
+            binary: None,
+            may_start_server: true,
+        }
+    }
+
+    /// A server at a specific address (tests, the fake server, a forwarded
+    /// port). ❗ Never starts a server: nothing that runs here should spawn a
+    /// process because a fixture went away.
+    pub fn at(addr: SocketAddr) -> Self {
+        Self {
+            addr,
+            binary: None,
+            may_start_server: false,
+        }
+    }
+
+    /// Where this endpoint dials.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Opens one socket to the server.
+    ///
+    /// On `ECONNREFUSED` with a start allowed, runs `adb -P <port> start-server`
+    /// once per process and dials again. No binary anywhere →
+    /// [`AdbConnectError::AdbNotInstalled`].
+    pub async fn connect(&self) -> Result<AdbConnection, AdbConnectError> {
+        match self.dial().await {
+            Ok(conn) => Ok(conn),
+            Err(err) if err.kind() == std::io::ErrorKind::ConnectionRefused && self.may_start_server => {
+                let Some(binary) = self.binary.clone().or_else(locate_adb_binary) else {
+                    return Err(AdbConnectError::AdbNotInstalled);
+                };
+                let port = self.addr.port();
+                let started = SERVER_STARTED.get_or_init(|| start_server(binary, port)).await;
+                if !started {
+                    return Err(AdbConnectError::ServerUnreachable(err.to_string()));
+                }
+                self.dial()
+                    .await
+                    .map_err(|e| AdbConnectError::ServerUnreachable(e.to_string()))
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::TimedOut => Err(AdbConnectError::TimedOut),
+            Err(err) => Err(AdbConnectError::ServerUnreachable(err.to_string())),
+        }
+    }
+
+    async fn dial(&self) -> std::io::Result<AdbConnection> {
+        let stream = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(self.addr))
+            .await
+            .map_err(|_| std::io::Error::from(std::io::ErrorKind::TimedOut))??;
+        stream.set_nodelay(true)?;
+        Ok(AdbConnection::from_stream(stream))
+    }
+}
+
+/// Runs `adb -P <port> start-server` to completion. `true` on a zero exit.
+async fn start_server(binary: PathBuf, port: u16) -> bool {
+    info!("adb server not running; starting it via {}", binary.display());
+    let run = tokio::process::Command::new(&binary)
+        .arg("-P")
+        .arg(port.to_string())
+        .arg("start-server")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .output();
+    match tokio::time::timeout(START_SERVER_TIMEOUT, run).await {
+        Ok(Ok(output)) if output.status.success() => {
+            debug!("adb start-server succeeded");
+            true
+        }
+        Ok(Ok(output)) => {
+            warn!(
+                "adb start-server exited with {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+            false
+        }
+        Ok(Err(err)) => {
+            warn!("adb start-server could not run: {err}");
+            false
+        }
+        Err(_) => {
+            warn!("adb start-server did not finish within {START_SERVER_TIMEOUT:?}");
+            false
+        }
+    }
+}
+
+/// Finds the platform `adb` binary, in this order: `$ADB`, `$PATH`,
+/// `$ANDROID_HOME/platform-tools`, `$ANDROID_SDK_ROOT/platform-tools`,
+/// `~/Library/Android/sdk/platform-tools`, `/opt/homebrew/bin`,
+/// `/usr/local/bin`. `None` when nothing executable turns up.
+pub fn locate_adb_binary() -> Option<PathBuf> {
+    if let Some(explicit) = std::env::var_os("ADB").map(PathBuf::from).filter(|p| is_executable(p)) {
+        return Some(explicit);
+    }
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(path) = std::env::var_os("PATH") {
+        candidates.extend(std::env::split_paths(&path).map(|dir| dir.join("adb")));
+    }
+    for var in ["ANDROID_HOME", "ANDROID_SDK_ROOT"] {
+        if let Some(root) = std::env::var_os(var) {
+            candidates.push(PathBuf::from(root).join("platform-tools").join("adb"));
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        candidates.push(PathBuf::from(home).join("Library/Android/sdk/platform-tools/adb"));
+    }
+    candidates.push(PathBuf::from("/opt/homebrew/bin/adb"));
+    candidates.push(PathBuf::from("/usr/local/bin/adb"));
+    candidates.into_iter().find(|p| is_executable(p))
+}
+
+#[cfg(unix)]
+fn is_executable(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &std::path::Path) -> bool {
+    std::fs::metadata(path).is_ok_and(|m| m.is_file())
+}
+
+#[cfg(test)]
+#[path = "server_test.rs"]
+mod server_test;

--- a/crates/cmdr-adb/src/server_test.rs
+++ b/crates/cmdr-adb/src/server_test.rs
@@ -1,0 +1,24 @@
+use std::net::{Ipv4Addr, SocketAddr};
+
+use super::*;
+
+#[test]
+fn default_local_dials_loopback() {
+    let endpoint = AdbEndpoint::default_local();
+    assert_eq!(endpoint.addr().ip(), Ipv4Addr::LOCALHOST);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_fixed_endpoint_never_starts_a_server() {
+    // Bind then drop a listener so the port is known-closed.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    drop(listener);
+    let err = AdbEndpoint::at(addr).connect().await.unwrap_err();
+    assert!(matches!(err, AdbConnectError::ServerUnreachable(_)), "{err:?}");
+}
+
+#[test]
+fn locating_the_binary_never_panics() {
+    let _ = locate_adb_binary();
+}

--- a/crates/cmdr-adb/src/shell.rs
+++ b/crates/cmdr-adb/src/shell.rs
@@ -1,0 +1,134 @@
+//! Everything the sync service has no verb for: `mkdir`, `rm`, `mv`, `df`.
+//!
+//! Only `shell,v2,raw:` is spoken. It frames stdout, stderr, and the exit code
+//! as `[id: u8][len: u32 LE][payload]` (ids: 0 stdin, 1 stdout, 2 stderr,
+//! 3 exit with a one-byte payload). The legacy `shell:` service has no exit
+//! code, and a device without `shell_v2` is refused at connect
+//! (`AdbConnectError::DeviceTooOld`) rather than second-guessed from its
+//! output. Wire reference: `adb/shell_protocol.h` (verified against
+//! platform-tools 35, 2026-09).
+
+use crate::errors::AdbError;
+use crate::features::connect_as_transport;
+use crate::server::AdbEndpoint;
+
+/// Frame ids of the shell v2 protocol.
+const ID_STDOUT: u8 = 1;
+const ID_STDERR: u8 = 2;
+const ID_EXIT: u8 = 3;
+
+/// What one shell command produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellOutcome {
+    /// The process's exit status (0 is success; 127 is "no such command").
+    pub exit_code: u8,
+    /// Everything it wrote to stdout.
+    pub stdout: Vec<u8>,
+    /// Everything it wrote to stderr. A log diagnostic; ❌ never classify on it.
+    pub stderr: Vec<u8>,
+}
+
+impl ShellOutcome {
+    /// Whether the command exited 0.
+    pub fn succeeded(&self) -> bool {
+        self.exit_code == 0
+    }
+
+    /// stdout as text, lossily.
+    pub fn stdout_text(&self) -> String {
+        String::from_utf8_lossy(&self.stdout).into_owned()
+    }
+
+    /// stderr as text, lossily.
+    pub fn stderr_text(&self) -> String {
+        String::from_utf8_lossy(&self.stderr).into_owned()
+    }
+}
+
+/// Single-quotes `arg` for a POSIX shell: `'` becomes `'\''`, everything else
+/// is literal inside the quotes.
+pub fn quote(arg: &str) -> String {
+    let mut out = String::with_capacity(arg.len() + 2);
+    out.push('\'');
+    for c in arg.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Quotes every argument and joins them with spaces.
+pub fn command_line(argv: &[&str]) -> String {
+    argv.iter().map(|a| quote(a)).collect::<Vec<_>>().join(" ")
+}
+
+/// Runs `argv` on the device and collects its output and exit code.
+pub async fn run(endpoint: &AdbEndpoint, serial: &str, argv: &[&str]) -> Result<ShellOutcome, AdbError> {
+    let mut conn = endpoint.connect().await.map_err(connect_as_transport)?;
+    conn.bind_device(serial).await?;
+    conn.request(&format!("shell,v2,raw:{}", command_line(argv))).await?;
+    let mut outcome = ShellOutcome {
+        exit_code: 0,
+        stdout: Vec::new(),
+        stderr: Vec::new(),
+    };
+    loop {
+        let mut id = [0u8; 1];
+        conn.read_exact(&mut id).await?;
+        let len = conn.read_u32_le().await? as usize;
+        let mut payload = vec![0u8; len];
+        conn.read_exact(&mut payload).await?;
+        match id[0] {
+            ID_STDOUT => outcome.stdout.extend_from_slice(&payload),
+            ID_STDERR => outcome.stderr.extend_from_slice(&payload),
+            ID_EXIT => {
+                outcome.exit_code = payload.first().copied().unwrap_or(0);
+                conn.shutdown().await;
+                return Ok(outcome);
+            }
+            // Window-size and close-stdin frames flow the other way; anything
+            // else is tolerated and skipped so a newer adbd can't wedge us.
+            _ => {}
+        }
+    }
+}
+
+/// What `df -k` said about a filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpaceParts {
+    /// Total size in bytes.
+    pub total_bytes: u64,
+    /// Bytes available to the caller.
+    pub available_bytes: u64,
+}
+
+/// Parses `df -k <path>` output: the numbers on the last data line, in 1 KiB
+/// blocks, as `total used available`.
+///
+/// Robust to toybox and busybox column layouts, and to busybox wrapping a long
+/// device name onto its own line: every line after the header is tokenized and
+/// the first three numeric tokens are read, so column widths and the `Use%`
+/// token don't matter. `None` when there aren't three numbers.
+pub fn parse_df_k(stdout: &str) -> Option<SpaceParts> {
+    let numbers: Vec<u64> = stdout
+        .lines()
+        .skip(1)
+        .flat_map(str::split_whitespace)
+        .filter_map(|tok| tok.parse::<u64>().ok())
+        .collect();
+    let [total, _used, available, ..] = numbers[..] else {
+        return None;
+    };
+    Some(SpaceParts {
+        total_bytes: total.saturating_mul(1024),
+        available_bytes: available.saturating_mul(1024),
+    })
+}
+
+#[cfg(test)]
+#[path = "shell_test.rs"]
+mod shell_test;

--- a/crates/cmdr-adb/src/shell_test.rs
+++ b/crates/cmdr-adb/src/shell_test.rs
@@ -1,0 +1,186 @@
+use super::*;
+use crate::testing::{FAKE_SERIAL, FakeAdbServer, FakeTree, split_argv};
+
+#[test]
+fn quoting_is_posix_single_quotes() {
+    assert_eq!(quote("plain"), "'plain'");
+    assert_eq!(quote(""), "''");
+    assert_eq!(quote("it's"), "'it'\\''s'");
+    assert_eq!(quote("a b$c\"d"), "'a b$c\"d'");
+    assert_eq!(
+        command_line(&["mv", "/sdcard/a's", "/sdcard/b"]),
+        "'mv' '/sdcard/a'\\''s' '/sdcard/b'"
+    );
+}
+
+#[test]
+fn the_fake_shell_unquotes_what_command_line_quotes() {
+    let argv = ["mv", "/sdcard/it's here", "/x y", "", "tab\there"];
+    assert_eq!(
+        split_argv(&command_line(&argv)),
+        argv.iter().map(|s| s.to_string()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn parse_df_k_reads_toybox_and_busybox() {
+    let toybox = "Filesystem      1K-blocks     Used Available Use% Mounted on\n/dev/fuse       118120468 21356460  96764008  19% /storage/emulated\n";
+    assert_eq!(
+        parse_df_k(toybox),
+        Some(SpaceParts {
+            total_bytes: 118_120_468 * 1024,
+            available_bytes: 96_764_008 * 1024,
+        })
+    );
+    let busybox = "Filesystem           1K-blocks      Used Available Use% Mounted on\n/dev/block/dm-0      118120468  21356460  96764008  18% /data\n";
+    assert_eq!(parse_df_k(busybox).unwrap().total_bytes, 118_120_468 * 1024);
+    let wrapped = "Filesystem           1K-blocks      Used Available Use% Mounted on\n/dev/block/platform/soc/1d84000.ufshc/by-name/userdata\n                     118120468  21356460  96764008  18% /data\n";
+    assert_eq!(parse_df_k(wrapped).unwrap().available_bytes, 96_764_008 * 1024);
+    assert_eq!(parse_df_k(""), None);
+    assert_eq!(parse_df_k("Filesystem 1K-blocks\n"), None);
+    assert_eq!(parse_df_k("df: /nope: No such file or directory\n"), None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn runs_mutations_against_the_fake_tree() {
+    let mut tree = FakeTree::new();
+    tree.add_file("/sdcard/a.txt", b"a");
+    let server = FakeAdbServer::start(tree).await;
+    let ep = server.endpoint();
+
+    let out = run(&ep, FAKE_SERIAL, &["mkdir", "-p", "/sdcard/new/deep"])
+        .await
+        .unwrap();
+    assert!(out.succeeded(), "{out:?}");
+    let out = run(&ep, FAKE_SERIAL, &["mv", "/sdcard/a.txt", "/sdcard/new/deep/b.txt"])
+        .await
+        .unwrap();
+    assert!(out.succeeded(), "{out:?}");
+    assert!(
+        run(&ep, FAKE_SERIAL, &["test", "-e", "/sdcard/new/deep/b.txt"])
+            .await
+            .unwrap()
+            .succeeded()
+    );
+    assert!(
+        !run(&ep, FAKE_SERIAL, &["test", "-e", "/sdcard/a.txt"])
+            .await
+            .unwrap()
+            .succeeded()
+    );
+
+    let out = run(&ep, FAKE_SERIAL, &["rm", "-rf", "/sdcard/new"]).await.unwrap();
+    assert!(out.succeeded());
+    assert!(server.tree().lock().unwrap().get("/sdcard/new").is_none());
+
+    let out = run(&ep, FAKE_SERIAL, &["mv", "/sdcard/ghost", "/sdcard/x"])
+        .await
+        .unwrap();
+    assert_eq!(out.exit_code, 1);
+    assert!(!out.stderr.is_empty());
+
+    let out = run(&ep, FAKE_SERIAL, &["frobnicate"]).await.unwrap();
+    assert_eq!(out.exit_code, 127);
+
+    let out = run(&ep, FAKE_SERIAL, &["df", "-k", "/sdcard"]).await.unwrap();
+    assert!(out.succeeded());
+    let space = parse_df_k(&out.stdout_text()).unwrap();
+    assert_eq!(space.total_bytes, 118_120_468 * 1024);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn readlink_and_stat_probe() {
+    let mut tree = FakeTree::new();
+    tree.add_file("/sdcard/real.txt", b"12345")
+        .add_symlink("/sdcard/link", "real.txt");
+    let server = FakeAdbServer::start(tree).await;
+    let ep = server.endpoint();
+    let out = run(&ep, FAKE_SERIAL, &["readlink", "-f", "/sdcard/link"])
+        .await
+        .unwrap();
+    assert_eq!(out.stdout_text().trim(), "/sdcard/real.txt");
+    let out = run(&ep, FAKE_SERIAL, &["stat", "-c", "%f %s %Y", "/sdcard/real.txt"])
+        .await
+        .unwrap();
+    assert_eq!(
+        out.stdout_text().trim(),
+        format!("81a4 5 {}", crate::testing::DEFAULT_MTIME)
+    );
+    let out = run(&ep, FAKE_SERIAL, &["stat", "-c", "%f %s %Y", "/sdcard/nope"])
+        .await
+        .unwrap();
+    assert_eq!(out.exit_code, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn readlink_of_an_absolute_link_to_a_folder() {
+    let mut tree = FakeTree::new();
+    tree.add_dir("/sdcard")
+        .add_dir("/sdcard/DCIM")
+        .add_symlink("/sdcard/shortcut", "/sdcard/DCIM");
+    let server = FakeAdbServer::start(tree).await;
+    let ep = server.endpoint();
+    let out = run(&ep, FAKE_SERIAL, &["readlink", "-f", "/sdcard/shortcut"])
+        .await
+        .unwrap();
+    assert!(out.succeeded(), "{out:?}");
+    assert_eq!(out.stdout_text().trim(), "/sdcard/DCIM");
+    let mut session = crate::sync::SyncSession::open(&ep, FAKE_SERIAL, crate::features::DeviceFeatures::all())
+        .await
+        .unwrap();
+    let stat = session.stat(out.stdout_text().trim()).await.unwrap();
+    assert_eq!(stat.kind(), crate::sync::SyncEntryKind::Directory, "{stat:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rmdir_cp_and_test_flags() {
+    let mut tree = FakeTree::new();
+    tree.add_file("/sdcard/full/x.txt", b"x").add_dir("/sdcard/empty");
+    let server = FakeAdbServer::start(tree).await;
+    let ep = server.endpoint();
+    assert_eq!(
+        run(&ep, FAKE_SERIAL, &["rmdir", "/sdcard/full"])
+            .await
+            .unwrap()
+            .exit_code,
+        1
+    );
+    assert!(
+        run(&ep, FAKE_SERIAL, &["rmdir", "/sdcard/empty"])
+            .await
+            .unwrap()
+            .succeeded()
+    );
+    assert!(
+        run(&ep, FAKE_SERIAL, &["cp", "-f", "/sdcard/full/x.txt", "/sdcard/y.txt"])
+            .await
+            .unwrap()
+            .succeeded()
+    );
+    assert_eq!(server.tree().lock().unwrap().file_bytes("/sdcard/y.txt").unwrap(), b"x");
+    assert!(
+        run(&ep, FAKE_SERIAL, &["test", "-w", "/sdcard"])
+            .await
+            .unwrap()
+            .succeeded()
+    );
+    assert!(
+        run(&ep, FAKE_SERIAL, &["test", "-d", "/sdcard"])
+            .await
+            .unwrap()
+            .succeeded()
+    );
+    assert!(
+        !run(&ep, FAKE_SERIAL, &["test", "-f", "/sdcard"])
+            .await
+            .unwrap()
+            .succeeded()
+    );
+    server.tree().lock().unwrap().read_only = true;
+    assert!(
+        !run(&ep, FAKE_SERIAL, &["test", "-w", "/sdcard"])
+            .await
+            .unwrap()
+            .succeeded()
+    );
+}

--- a/crates/cmdr-adb/src/sync.rs
+++ b/crates/cmdr-adb/src/sync.rs
@@ -1,0 +1,328 @@
+//! The `sync:` service: stat, list, pull, push.
+//!
+//! After `sync:` → `OKAY`, the socket carries binary little-endian packets
+//! `[id: 4 ASCII][arg: u32 LE]`. One session per socket; the session ends with
+//! `QUIT` or by dropping the socket. Wire reference: `adb/SYNC.TXT` and
+//! `file_sync_protocol.h` (verified against platform-tools 35, 2026-09).
+//!
+//! The v2 verbs (`STA2`, `LIS2`, `SND2`, `RCV2`) are preferred where the
+//! device advertises them: they carry an errno and 64-bit sizes, which the v1
+//! verbs lose (a missing path is mode 0, a 5 GB file wraps).
+
+use crate::errors::AdbError;
+use crate::features::{DeviceFeatures, connect_as_transport};
+use crate::server::AdbEndpoint;
+use crate::transport::AdbConnection;
+
+/// The largest `DATA` payload the protocol allows.
+pub const MAX_DATA_CHUNK: usize = 64 * 1024;
+
+/// The `S_IFMT` mask and the file-type bits the mode word carries.
+const S_IFMT: u32 = 0o170000;
+const S_IFDIR: u32 = 0o040000;
+const S_IFREG: u32 = 0o100000;
+const S_IFLNK: u32 = 0o120000;
+
+/// What kind of node a mode word describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncEntryKind {
+    /// A regular file.
+    File,
+    /// A directory.
+    Directory,
+    /// A symlink (the sync service never follows them).
+    Symlink,
+    /// A socket, device, fifo, or a mode of 0.
+    Other,
+}
+
+/// A `STAT`/`STA2` answer, or the stat half of a directory entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyncStat {
+    /// The POSIX mode word (type bits and permissions).
+    pub mode: u32,
+    /// Size in bytes. 32-bit on the v1 verbs.
+    pub size: u64,
+    /// Modification time, seconds since the epoch.
+    pub mtime: i64,
+    /// The device's errno when the stat itself failed (v2 only). `None` on v1,
+    /// where a mode of 0 is the only "not there" signal.
+    pub errno: Option<i32>,
+}
+
+impl SyncStat {
+    /// The node type the mode word names.
+    pub fn kind(&self) -> SyncEntryKind {
+        match self.mode & S_IFMT {
+            S_IFDIR => SyncEntryKind::Directory,
+            S_IFREG => SyncEntryKind::File,
+            S_IFLNK => SyncEntryKind::Symlink,
+            _ => SyncEntryKind::Other,
+        }
+    }
+
+    /// Whether the stat found something: no errno and a non-zero mode.
+    pub fn exists(&self) -> bool {
+        self.errno.is_none() && self.mode != 0
+    }
+}
+
+/// One entry of a listing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncDirEntry {
+    /// The entry's name, never `.` or `..`.
+    pub name: String,
+    /// Its stat, as the listing verb reports it.
+    pub stat: SyncStat,
+}
+
+/// One open `sync:` session.
+pub struct SyncSession {
+    conn: AdbConnection,
+    features: DeviceFeatures,
+}
+
+impl std::fmt::Debug for SyncSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyncSession")
+            .field("features", &self.features)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SyncSession {
+    /// Connects, binds to `serial`, and opens the sync service.
+    pub async fn open(endpoint: &AdbEndpoint, serial: &str, features: DeviceFeatures) -> Result<Self, AdbError> {
+        let mut conn = endpoint.connect().await.map_err(connect_as_transport)?;
+        conn.bind_device(serial).await?;
+        conn.request("sync:").await?;
+        Ok(Self { conn, features })
+    }
+
+    /// Writes `[id][u32 LE]`.
+    async fn send_word(&mut self, id: &[u8; 4], arg: u32) -> Result<(), AdbError> {
+        let mut packet = Vec::with_capacity(8);
+        packet.extend_from_slice(id);
+        packet.extend_from_slice(&arg.to_le_bytes());
+        self.conn.write_all(&packet).await
+    }
+
+    /// Writes `[id][len][payload]`.
+    async fn send_payload(&mut self, id: &[u8; 4], payload: &[u8]) -> Result<(), AdbError> {
+        let len =
+            u32::try_from(payload.len()).map_err(|_| AdbError::Protocol("payload longer than u32".to_string()))?;
+        let mut packet = Vec::with_capacity(8 + payload.len());
+        packet.extend_from_slice(id);
+        packet.extend_from_slice(&len.to_le_bytes());
+        packet.extend_from_slice(payload);
+        self.conn.write_all(&packet).await
+    }
+
+    /// Reads a `FAIL` payload into [`AdbError::Refused`].
+    async fn read_fail(&mut self) -> AdbError {
+        match self.read_len_prefixed().await {
+            Ok(msg) => AdbError::Refused(String::from_utf8_lossy(&msg).into_owned()),
+            Err(err) => err,
+        }
+    }
+
+    /// Reads `[u32 len][bytes]`.
+    async fn read_len_prefixed(&mut self) -> Result<Vec<u8>, AdbError> {
+        let len = self.conn.read_u32_le().await? as usize;
+        let mut buf = vec![0u8; len];
+        self.conn.read_exact(&mut buf).await?;
+        Ok(buf)
+    }
+
+    /// Stats `path`. `STA2` where the device has it (errno on failure), else
+    /// `STAT` (mode 0 on failure). A missing path is `Ok` with
+    /// [`SyncStat::exists`] false, never `Err`.
+    pub async fn stat(&mut self, path: &str) -> Result<SyncStat, AdbError> {
+        if self.features.stat_v2 {
+            self.send_payload(b"STA2", path.as_bytes()).await?;
+            match &self.conn.read_id().await? {
+                b"STA2" => self.read_stat_v2().await,
+                b"FAIL" => Err(self.read_fail().await),
+                other => Err(unexpected("STA2", other)),
+            }
+        } else {
+            self.send_payload(b"STAT", path.as_bytes()).await?;
+            match &self.conn.read_id().await? {
+                b"STAT" => self.read_stat_v1().await,
+                b"FAIL" => Err(self.read_fail().await),
+                other => Err(unexpected("STAT", other)),
+            }
+        }
+    }
+
+    /// Reads the body of a `STAT` answer: mode, size, mtime (u32 each).
+    async fn read_stat_v1(&mut self) -> Result<SyncStat, AdbError> {
+        let mode = self.conn.read_u32_le().await?;
+        let size = self.conn.read_u32_le().await?;
+        let mtime = self.conn.read_u32_le().await?;
+        Ok(SyncStat {
+            mode,
+            size: u64::from(size),
+            mtime: i64::from(mtime),
+            errno: None,
+        })
+    }
+
+    /// Reads the body of a `STA2`/`DNT2` answer (everything after the id, up
+    /// to and excluding `DNT2`'s namelen).
+    async fn read_stat_v2(&mut self) -> Result<SyncStat, AdbError> {
+        let error = self.conn.read_u32_le().await?;
+        let _dev = self.conn.read_u64_le().await?;
+        let _ino = self.conn.read_u64_le().await?;
+        let mode = self.conn.read_u32_le().await?;
+        let _nlink = self.conn.read_u32_le().await?;
+        let _uid = self.conn.read_u32_le().await?;
+        let _gid = self.conn.read_u32_le().await?;
+        let size = self.conn.read_u64_le().await?;
+        let _atime = self.conn.read_i64_le().await?;
+        let mtime = self.conn.read_i64_le().await?;
+        let _ctime = self.conn.read_i64_le().await?;
+        Ok(SyncStat {
+            mode,
+            size,
+            mtime,
+            errno: (error != 0).then(|| i32::try_from(error).unwrap_or(i32::MAX)),
+        })
+    }
+
+    /// Lists `path`, handing each entry to `on_entry` as it arrives. `LIS2`
+    /// where the device has it, else `LIST`. `.` and `..` are skipped.
+    ///
+    /// ❗ A missing or unreadable directory lists as EMPTY on both verbs (the
+    /// device answers `DONE` straight away); callers that need to tell those
+    /// apart stat the path first.
+    pub async fn list(&mut self, path: &str, on_entry: &mut (dyn FnMut(SyncDirEntry) + Send)) -> Result<(), AdbError> {
+        if self.features.ls_v2 {
+            self.send_payload(b"LIS2", path.as_bytes()).await?;
+            loop {
+                match &self.conn.read_id().await? {
+                    b"DNT2" => {
+                        let stat = self.read_stat_v2().await?;
+                        let name = self.read_len_prefixed().await?;
+                        push_entry(on_entry, name, stat);
+                    }
+                    b"DONE" => {
+                        // `DONE` is a zeroed dent_v2 minus the id: 72 bytes.
+                        let mut rest = [0u8; 72];
+                        self.conn.read_exact(&mut rest).await?;
+                        return Ok(());
+                    }
+                    b"FAIL" => return Err(self.read_fail().await),
+                    other => return Err(unexpected("DNT2", other)),
+                }
+            }
+        } else {
+            self.send_payload(b"LIST", path.as_bytes()).await?;
+            loop {
+                match &self.conn.read_id().await? {
+                    b"DENT" => {
+                        let stat = self.read_stat_v1().await?;
+                        let name = self.read_len_prefixed().await?;
+                        push_entry(on_entry, name, stat);
+                    }
+                    b"DONE" => {
+                        // `DONE` is a zeroed dent_v1 minus the id: 16 bytes.
+                        let mut rest = [0u8; 16];
+                        self.conn.read_exact(&mut rest).await?;
+                        return Ok(());
+                    }
+                    b"FAIL" => return Err(self.read_fail().await),
+                    other => return Err(unexpected("DENT", other)),
+                }
+            }
+        }
+    }
+
+    /// Starts pulling `path`. Follow with [`SyncSession::recv_chunk`] until it
+    /// answers `None`.
+    pub async fn recv_start(&mut self, path: &str) -> Result<(), AdbError> {
+        if self.features.sendrecv_v2 {
+            self.send_payload(b"RCV2", path.as_bytes()).await?;
+            // The setup word: flags 0 (no compression, no dry run).
+            self.send_word(b"RCV2", 0).await
+        } else {
+            self.send_payload(b"RECV", path.as_bytes()).await
+        }
+    }
+
+    /// The next chunk of the file being pulled: `Some(bytes)` on `DATA`, `None`
+    /// on `DONE`, [`AdbError::Refused`] on `FAIL`.
+    pub async fn recv_chunk(&mut self) -> Result<Option<Vec<u8>>, AdbError> {
+        match &self.conn.read_id().await? {
+            b"DATA" => Ok(Some(self.read_len_prefixed().await?)),
+            b"DONE" => {
+                let _zero = self.conn.read_u32_le().await?;
+                Ok(None)
+            }
+            b"FAIL" => Err(self.read_fail().await),
+            other => Err(unexpected("DATA", other)),
+        }
+    }
+
+    /// Starts pushing to `path` with `mode`. Follow with
+    /// [`SyncSession::send_chunk`] then [`SyncSession::send_finish`].
+    pub async fn send_start(&mut self, path: &str, mode: u32) -> Result<(), AdbError> {
+        if self.features.sendrecv_v2 {
+            self.send_payload(b"SND2", path.as_bytes()).await?;
+            // The setup packet: id, mode, flags 0.
+            let mut packet = Vec::with_capacity(12);
+            packet.extend_from_slice(b"SND2");
+            packet.extend_from_slice(&mode.to_le_bytes());
+            packet.extend_from_slice(&0u32.to_le_bytes());
+            self.conn.write_all(&packet).await
+        } else {
+            let spec = format!("{path},{mode}");
+            self.send_payload(b"SEND", spec.as_bytes()).await
+        }
+    }
+
+    /// Pushes `bytes`, split into `DATA` packets of at most
+    /// [`MAX_DATA_CHUNK`].
+    pub async fn send_chunk(&mut self, bytes: &[u8]) -> Result<(), AdbError> {
+        for chunk in bytes.chunks(MAX_DATA_CHUNK) {
+            self.send_payload(b"DATA", chunk).await?;
+        }
+        Ok(())
+    }
+
+    /// Ends the push with `DONE` + `mtime` and reads the device's verdict.
+    pub async fn send_finish(&mut self, mtime: u32) -> Result<(), AdbError> {
+        self.send_word(b"DONE", mtime).await?;
+        match &self.conn.read_id().await? {
+            b"OKAY" => {
+                let _zero = self.conn.read_u32_le().await?;
+                Ok(())
+            }
+            b"FAIL" => Err(self.read_fail().await),
+            other => Err(unexpected("OKAY", other)),
+        }
+    }
+
+    /// Ends the session. Best effort: the device tears the socket down either
+    /// way.
+    pub async fn quit(mut self) {
+        let _ = self.send_word(b"QUIT", 0).await;
+        self.conn.shutdown().await;
+    }
+}
+
+fn push_entry(on_entry: &mut (dyn FnMut(SyncDirEntry) + Send), name: Vec<u8>, stat: SyncStat) {
+    let name = String::from_utf8_lossy(&name).into_owned();
+    if name == "." || name == ".." {
+        return;
+    }
+    on_entry(SyncDirEntry { name, stat });
+}
+
+fn unexpected(wanted: &str, got: &[u8; 4]) -> AdbError {
+    AdbError::Protocol(format!("expected {wanted}, got {:?}", String::from_utf8_lossy(got)))
+}
+
+#[cfg(test)]
+#[path = "sync_test.rs"]
+mod sync_test;

--- a/crates/cmdr-adb/src/sync_test.rs
+++ b/crates/cmdr-adb/src/sync_test.rs
@@ -1,0 +1,158 @@
+use super::*;
+use crate::testing::{FAKE_SERIAL, FakeAdbServer, FakeTree};
+
+fn seeded() -> FakeTree {
+    let mut tree = FakeTree::new();
+    tree.add_file("/sdcard/hello.txt", b"hello, phone")
+        .add_dir("/sdcard/DCIM")
+        .add_symlink("/sdcard/link", "/sdcard/hello.txt");
+    tree
+}
+
+async fn collect(session: &mut SyncSession, path: &str) -> Vec<SyncDirEntry> {
+    let mut entries = Vec::new();
+    session.list(path, &mut |e| entries.push(e)).await.unwrap();
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries
+}
+
+async fn stat_and_list(features: DeviceFeatures) {
+    let server = FakeAdbServer::start(seeded()).await;
+    let mut session = SyncSession::open(&server.endpoint(), FAKE_SERIAL, features)
+        .await
+        .unwrap();
+
+    let file = session.stat("/sdcard/hello.txt").await.unwrap();
+    assert!(file.exists());
+    assert_eq!(file.kind(), SyncEntryKind::File);
+    assert_eq!(file.size, 12);
+    assert_eq!(file.mtime, crate::testing::DEFAULT_MTIME);
+
+    let dir = session.stat("/sdcard/DCIM").await.unwrap();
+    assert_eq!(dir.kind(), SyncEntryKind::Directory);
+
+    let missing = session.stat("/sdcard/nope").await.unwrap();
+    assert!(!missing.exists());
+    if features.stat_v2 {
+        assert_eq!(missing.errno, Some(crate::errors::ENOENT));
+    } else {
+        assert_eq!(missing.mode, 0);
+    }
+
+    let entries = collect(&mut session, "/sdcard").await;
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, vec!["DCIM", "hello.txt", "link"], "dot entries are skipped");
+    assert_eq!(entries[2].stat.kind(), SyncEntryKind::Symlink);
+    assert_eq!(entries[1].stat.size, 12);
+
+    assert!(collect(&mut session, "/sdcard/DCIM").await.is_empty());
+    session.quit().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stat_and_list_v2() {
+    stat_and_list(DeviceFeatures::all()).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stat_and_list_v1() {
+    stat_and_list(DeviceFeatures::default()).await;
+}
+
+async fn recv_and_send(features: DeviceFeatures) {
+    let server = FakeAdbServer::start(seeded()).await;
+    let mut session = SyncSession::open(&server.endpoint(), FAKE_SERIAL, features)
+        .await
+        .unwrap();
+
+    session.recv_start("/sdcard/hello.txt").await.unwrap();
+    let mut got = Vec::new();
+    while let Some(chunk) = session.recv_chunk().await.unwrap() {
+        got.extend_from_slice(&chunk);
+    }
+    assert_eq!(got, b"hello, phone");
+
+    // Pushing a payload larger than one DATA packet splits it.
+    let big: Vec<u8> = (0..(MAX_DATA_CHUNK * 3 + 17)).map(|i| (i % 251) as u8).collect();
+    session.send_start("/sdcard/DCIM/big.bin", 0o644).await.unwrap();
+    session.send_chunk(&big).await.unwrap();
+    session.send_finish(1_700_000_000).await.unwrap();
+    {
+        let tree = server.tree();
+        let tree = tree.lock().unwrap();
+        assert_eq!(tree.file_bytes("/sdcard/DCIM/big.bin").unwrap(), big);
+        assert_eq!(tree.get("/sdcard/DCIM/big.bin").unwrap().mtime(), 1_700_000_000);
+    }
+
+    // The session is reusable: pull what was pushed, in several chunks.
+    session.recv_start("/sdcard/DCIM/big.bin").await.unwrap();
+    let mut chunks = 0;
+    let mut got = Vec::new();
+    while let Some(chunk) = session.recv_chunk().await.unwrap() {
+        assert!(chunk.len() <= MAX_DATA_CHUNK);
+        chunks += 1;
+        got.extend_from_slice(&chunk);
+    }
+    assert_eq!(got, big);
+    assert_eq!(chunks, 4);
+    session.quit().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recv_and_send_v2() {
+    recv_and_send(DeviceFeatures::all()).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recv_and_send_v1() {
+    recv_and_send(DeviceFeatures::default()).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_fail_is_refused_with_the_message() {
+    let server = FakeAdbServer::start(seeded()).await;
+    let mut session = SyncSession::open(&server.endpoint(), FAKE_SERIAL, DeviceFeatures::all())
+        .await
+        .unwrap();
+    session.recv_start("/sdcard/nope").await.unwrap();
+    assert!(matches!(session.recv_chunk().await, Err(AdbError::Refused(msg)) if msg.contains("/sdcard/nope")));
+
+    // Pushing into a missing directory fails at DONE.
+    session.send_start("/sdcard/missing-dir/x", 0o644).await.unwrap();
+    session.send_chunk(b"x").await.unwrap();
+    assert!(matches!(session.send_finish(0).await, Err(AdbError::Refused(_))));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn opening_on_an_unauthorized_device_is_refused() {
+    let server = FakeAdbServer::start(seeded()).await;
+    let mut dev = crate::testing::fake_device();
+    dev.state = crate::devices::AdbDeviceState::Unauthorized;
+    server.push_devices(vec![dev]);
+    let err = SyncSession::open(&server.endpoint(), FAKE_SERIAL, DeviceFeatures::all())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AdbError::Refused(_)));
+}
+
+#[test]
+fn kind_reads_the_type_bits() {
+    let stat = |mode| SyncStat {
+        mode,
+        size: 0,
+        mtime: 0,
+        errno: None,
+    };
+    assert_eq!(stat(0o100644).kind(), SyncEntryKind::File);
+    assert_eq!(stat(0o040755).kind(), SyncEntryKind::Directory);
+    assert_eq!(stat(0o120777).kind(), SyncEntryKind::Symlink);
+    assert_eq!(stat(0o140000).kind(), SyncEntryKind::Other);
+    assert!(!stat(0).exists());
+    assert!(
+        !SyncStat {
+            errno: Some(2),
+            ..stat(0o100644)
+        }
+        .exists()
+    );
+}

--- a/crates/cmdr-adb/src/testing.rs
+++ b/crates/cmdr-adb/src/testing.rs
@@ -1,0 +1,1016 @@
+//! A fake ADB server for tests: the host protocol over a `TcpListener` on
+//! loopback, backed by an in-memory device tree.
+//!
+//! Compiled under `#[cfg(test)]` and the `testing` feature, so the app's ADB
+//! suites use the same fixture as this crate's.
+//!
+//! ## What it speaks
+//!
+//! - `host:version`, `host:devices`, `host:devices-l`.
+//! - `host:track-devices`: the current short list, then one push per
+//!   [`FakeAdbServer::push_devices`].
+//! - `host:transport:<serial>`: `OKAY` for a listed [`AdbDeviceState::Ready`]
+//!   device, `FAIL` otherwise. The socket then takes ONE device service:
+//! - `host-serial:<serial>:features`: the string set by
+//!   [`FakeAdbServer::set_features`] (all four this crate reads, by default).
+//! - `sync:` with `STAT`/`STA2`/`LIST`/`LIS2`/`RECV`/`RCV2`/`SEND`/`SND2`/`QUIT`
+//!   over the [`FakeTree`].
+//! - `shell,v2,raw:<cmd>` with `mkdir [-p]`, `rmdir`, `rm [-rf]`, `mv`,
+//!   `cp [-f]`, `df -k`, `readlink -f`, `test -e|-d|-f|-w` (`-w` follows
+//!   [`FakeTree::read_only`]), and `stat -c '%f %s %Y'`; anything else exits
+//!   127.
+//!
+//! ## Faults
+//!
+//! [`FakeAdbServer::drop_connections`] kills every open socket (a tracker sees
+//! its stream end and reconnects); [`FakeAdbServer::stop`] closes the listener
+//! too. [`FakeTree::read_only`] makes every write answer `EROFS`.
+
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use crate::devices::{AdbDevice, AdbDeviceState};
+use crate::errors::{EEXIST, EISDIR, ENOENT, ENOTDIR, ENOTEMPTY_DEVICE, EROFS};
+use crate::server::AdbEndpoint;
+use crate::sync::MAX_DATA_CHUNK;
+use crate::transport::hex_message;
+
+/// The serial of the one device a fresh fake lists.
+pub const FAKE_SERIAL: &str = "emulator-5554";
+
+/// What a current device advertises. Everything this crate reads is on.
+pub const FAKE_FEATURES: &str = "shell_v2,cmd,stat_v2,ls_v2,fixed_push_mkdir,apex,abb,fixed_push_symlink_timestamp,abb_exec,remount_shell,track_app,sendrecv_v2,sendrecv_v2_brotli,sendrecv_v2_lz4,sendrecv_v2_zstd,sendrecv_v2_dry_run_send,openscreen_mdns";
+
+/// The device a fresh fake lists: `FAKE_SERIAL`, ready, with the long fields.
+pub fn fake_device() -> AdbDevice {
+    AdbDevice {
+        serial: FAKE_SERIAL.to_string(),
+        state: AdbDeviceState::Ready,
+        product: Some("sdk_gphone64_arm64".to_string()),
+        model: Some("Fake_Phone".to_string()),
+        device: Some("emu64a".to_string()),
+        transport_id: Some(1),
+    }
+}
+
+/// One node of the in-memory device filesystem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FakeNode {
+    /// A regular file.
+    File {
+        /// Its contents.
+        data: Vec<u8>,
+        /// Its full mode word (type bits included).
+        mode: u32,
+        /// Modification time, seconds since the epoch.
+        mtime: i64,
+    },
+    /// A directory.
+    Dir {
+        /// Its full mode word.
+        mode: u32,
+        /// Modification time.
+        mtime: i64,
+    },
+    /// A symlink. The sync service reports it as a link; `readlink -f`
+    /// resolves it.
+    Symlink {
+        /// Where it points.
+        target: String,
+        /// Modification time.
+        mtime: i64,
+    },
+}
+
+impl FakeNode {
+    /// The mode word the sync service reports.
+    pub fn mode(&self) -> u32 {
+        match self {
+            Self::File { mode, .. } | Self::Dir { mode, .. } => *mode,
+            Self::Symlink { .. } => 0o120777,
+        }
+    }
+
+    /// The size the sync service reports.
+    pub fn size(&self) -> u64 {
+        match self {
+            Self::File { data, .. } => data.len() as u64,
+            Self::Dir { .. } => 4096,
+            Self::Symlink { target, .. } => target.len() as u64,
+        }
+    }
+
+    /// The mtime the sync service reports.
+    pub fn mtime(&self) -> i64 {
+        match self {
+            Self::File { mtime, .. } | Self::Dir { mtime, .. } | Self::Symlink { mtime, .. } => *mtime,
+        }
+    }
+}
+
+/// The in-memory device filesystem, keyed by absolute path.
+#[derive(Debug, Clone)]
+pub struct FakeTree {
+    nodes: BTreeMap<String, FakeNode>,
+    /// What `df -k` reports as the total, in KiB.
+    pub total_kib: u64,
+    /// What `df -k` reports as available, in KiB.
+    pub available_kib: u64,
+    /// When set, every write answers `EROFS`.
+    pub read_only: bool,
+}
+
+impl Default for FakeTree {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The mtime every node gets unless a test sets one: 2026-01-01T00:00:00Z.
+pub const DEFAULT_MTIME: i64 = 1_767_225_600;
+
+impl FakeTree {
+    /// A tree holding `/` and `/sdcard`.
+    pub fn new() -> Self {
+        let mut tree = Self {
+            nodes: BTreeMap::new(),
+            total_kib: 118_120_468,
+            available_kib: 96_764_008,
+            read_only: false,
+        };
+        tree.add_dir("/");
+        tree.add_dir("/sdcard");
+        tree
+    }
+
+    /// Normalizes a device path: leading `/`, no trailing `/` (except `/`).
+    pub fn normalize(path: &str) -> String {
+        let mut out = String::from("/");
+        for part in path.split('/').filter(|p| !p.is_empty() && *p != ".") {
+            if !out.ends_with('/') {
+                out.push('/');
+            }
+            out.push_str(part);
+        }
+        out
+    }
+
+    fn parent_of(path: &str) -> Option<String> {
+        if path == "/" {
+            return None;
+        }
+        let idx = path.rfind('/')?;
+        Some(if idx == 0 {
+            "/".to_string()
+        } else {
+            path[..idx].to_string()
+        })
+    }
+
+    /// Adds a directory, creating ancestors. Chainable.
+    pub fn add_dir(&mut self, path: &str) -> &mut Self {
+        let path = Self::normalize(path);
+        if let Some(parent) = Self::parent_of(&path) {
+            self.add_dir(&parent);
+        }
+        self.nodes.entry(path).or_insert(FakeNode::Dir {
+            mode: 0o040755,
+            mtime: DEFAULT_MTIME,
+        });
+        self
+    }
+
+    /// Adds a file with `data`, creating ancestors. Chainable.
+    pub fn add_file(&mut self, path: &str, data: &[u8]) -> &mut Self {
+        let path = Self::normalize(path);
+        if let Some(parent) = Self::parent_of(&path) {
+            self.add_dir(&parent);
+        }
+        self.nodes.insert(
+            path,
+            FakeNode::File {
+                data: data.to_vec(),
+                mode: 0o100644,
+                mtime: DEFAULT_MTIME,
+            },
+        );
+        self
+    }
+
+    /// Adds a symlink to `target`, creating ancestors. Chainable.
+    pub fn add_symlink(&mut self, path: &str, target: &str) -> &mut Self {
+        let path = Self::normalize(path);
+        if let Some(parent) = Self::parent_of(&path) {
+            self.add_dir(&parent);
+        }
+        self.nodes.insert(
+            path,
+            FakeNode::Symlink {
+                target: target.to_string(),
+                mtime: DEFAULT_MTIME,
+            },
+        );
+        self
+    }
+
+    /// The node at `path`, if any.
+    pub fn get(&self, path: &str) -> Option<&FakeNode> {
+        self.nodes.get(&Self::normalize(path))
+    }
+
+    /// A file's bytes, if `path` is a file.
+    pub fn file_bytes(&self, path: &str) -> Option<Vec<u8>> {
+        match self.get(path) {
+            Some(FakeNode::File { data, .. }) => Some(data.clone()),
+            _ => None,
+        }
+    }
+
+    /// Every path in the tree, sorted.
+    pub fn paths(&self) -> Vec<String> {
+        self.nodes.keys().cloned().collect()
+    }
+
+    /// The direct children of `dir`: `(name, node)`.
+    pub fn children(&self, dir: &str) -> Vec<(String, FakeNode)> {
+        let dir = Self::normalize(dir);
+        let prefix = if dir == "/" { "/".to_string() } else { format!("{dir}/") };
+        self.nodes
+            .iter()
+            .filter(|(p, _)| p.starts_with(&prefix) && !p[prefix.len()..].contains('/') && p.len() > prefix.len())
+            .map(|(p, n)| (p[prefix.len()..].to_string(), n.clone()))
+            .collect()
+    }
+
+    /// Stat as the sync service would: `Err(errno)` when missing.
+    pub fn stat(&self, path: &str) -> Result<FakeNode, i32> {
+        self.get(path).cloned().ok_or(ENOENT)
+    }
+
+    /// Creates `path` and every missing ancestor (`mkdir -p`).
+    pub fn mkdir_p(&mut self, path: &str) -> Result<(), i32> {
+        if self.read_only {
+            return Err(EROFS);
+        }
+        let path = Self::normalize(path);
+        match self.nodes.get(&path) {
+            Some(FakeNode::Dir { .. }) => Ok(()),
+            Some(_) => Err(EEXIST),
+            None => {
+                self.add_dir(&path);
+                Ok(())
+            }
+        }
+    }
+
+    /// Writes a file (`SEND`). The parent must exist and be a directory.
+    pub fn write_file(&mut self, path: &str, data: Vec<u8>, mode: u32, mtime: i64) -> Result<(), i32> {
+        if self.read_only {
+            return Err(EROFS);
+        }
+        let path = Self::normalize(path);
+        match Self::parent_of(&path).and_then(|p| self.nodes.get(&p)) {
+            Some(FakeNode::Dir { .. }) => {}
+            _ => return Err(ENOENT),
+        }
+        if matches!(self.nodes.get(&path), Some(FakeNode::Dir { .. })) {
+            return Err(EISDIR);
+        }
+        let mode = if mode & 0o170000 == 0 { 0o100000 | mode } else { mode };
+        self.nodes.insert(path, FakeNode::File { data, mode, mtime });
+        Ok(())
+    }
+
+    /// Removes `path` and everything under it (`rm -rf`). `Err(ENOENT)` when
+    /// nothing was there.
+    pub fn remove_tree(&mut self, path: &str) -> Result<(), i32> {
+        if self.read_only {
+            return Err(EROFS);
+        }
+        let path = Self::normalize(path);
+        if !self.nodes.contains_key(&path) {
+            return Err(ENOENT);
+        }
+        let prefix = format!("{path}/");
+        self.nodes.retain(|p, _| p != &path && !p.starts_with(&prefix));
+        Ok(())
+    }
+
+    /// Removes one node, refusing a directory that still holds something.
+    pub fn remove_one(&mut self, path: &str) -> Result<(), i32> {
+        if self.read_only {
+            return Err(EROFS);
+        }
+        let path = Self::normalize(path);
+        if !self.nodes.contains_key(&path) {
+            return Err(ENOENT);
+        }
+        if !self.children(&path).is_empty() {
+            return Err(ENOTEMPTY_DEVICE);
+        }
+        self.nodes.remove(&path);
+        Ok(())
+    }
+
+    /// Renames `from` to `to` (`mv`), overwriting a file at `to`. Moves a
+    /// whole subtree.
+    pub fn rename(&mut self, from: &str, to: &str) -> Result<(), i32> {
+        if self.read_only {
+            return Err(EROFS);
+        }
+        let from = Self::normalize(from);
+        let to = Self::normalize(to);
+        if !self.nodes.contains_key(&from) {
+            return Err(ENOENT);
+        }
+        match Self::parent_of(&to).and_then(|p| self.nodes.get(&p)) {
+            Some(FakeNode::Dir { .. }) => {}
+            _ => return Err(ENOENT),
+        }
+        if matches!(self.nodes.get(&to), Some(FakeNode::Dir { .. })) && !self.children(&to).is_empty() {
+            return Err(ENOTEMPTY_DEVICE);
+        }
+        let prefix = format!("{from}/");
+        let moving: Vec<(String, FakeNode)> = self
+            .nodes
+            .iter()
+            .filter(|(p, _)| *p == &from || p.starts_with(&prefix))
+            .map(|(p, n)| (p.clone(), n.clone()))
+            .collect();
+        for (p, _) in &moving {
+            self.nodes.remove(p);
+        }
+        for (p, n) in moving {
+            let new_path = format!("{to}{}", &p[from.len()..]);
+            self.nodes.insert(new_path, n);
+        }
+        Ok(())
+    }
+
+    /// `readlink -f`: follows a symlink at `path` (one level; relative targets
+    /// resolve against its directory). A non-link answers itself.
+    pub fn resolve(&self, path: &str) -> Result<String, i32> {
+        let path = Self::normalize(path);
+        match self.nodes.get(&path) {
+            None => Err(ENOENT),
+            Some(FakeNode::Symlink { target, .. }) => {
+                if target.starts_with('/') {
+                    Ok(Self::normalize(target))
+                } else {
+                    let parent = Self::parent_of(&path).unwrap_or_else(|| "/".to_string());
+                    Ok(Self::normalize(&format!("{parent}/{target}")))
+                }
+            }
+            Some(_) => Ok(path),
+        }
+    }
+}
+
+/// The running fake. Stops on drop.
+pub struct FakeAdbServer {
+    addr: SocketAddr,
+    tree: Arc<Mutex<FakeTree>>,
+    devices: watch::Sender<Vec<AdbDevice>>,
+    features: Arc<Mutex<String>>,
+    accept: JoinHandle<()>,
+    connections: Arc<Mutex<Vec<JoinHandle<()>>>>,
+}
+
+impl std::fmt::Debug for FakeAdbServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FakeAdbServer")
+            .field("addr", &self.addr)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Everything a connection handler shares.
+#[derive(Clone)]
+struct Shared {
+    tree: Arc<Mutex<FakeTree>>,
+    devices: watch::Sender<Vec<AdbDevice>>,
+    features: Arc<Mutex<String>>,
+}
+
+impl FakeAdbServer {
+    /// Binds `127.0.0.1:0` and starts serving `tree`, listing [`fake_device`].
+    /// Needs a tokio runtime.
+    pub async fn start(tree: FakeTree) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let shared = Shared {
+            tree: Arc::new(Mutex::new(tree)),
+            devices: watch::Sender::new(vec![fake_device()]),
+            features: Arc::new(Mutex::new(FAKE_FEATURES.to_string())),
+        };
+        let connections: Arc<Mutex<Vec<JoinHandle<()>>>> = Arc::new(Mutex::new(Vec::new()));
+        let accept = {
+            let shared = shared.clone();
+            let connections = connections.clone();
+            tokio::spawn(async move {
+                loop {
+                    let Ok((stream, _)) = listener.accept().await else {
+                        return;
+                    };
+                    let shared = shared.clone();
+                    let handle = tokio::spawn(async move {
+                        let _ = serve_connection(stream, shared).await;
+                    });
+                    connections.lock().expect("connections lock").push(handle);
+                }
+            })
+        };
+        Self {
+            addr,
+            tree: shared.tree,
+            devices: shared.devices,
+            features: shared.features,
+            accept,
+            connections,
+        }
+    }
+
+    /// An endpoint that dials this fake and never starts a real server.
+    pub fn endpoint(&self) -> AdbEndpoint {
+        AdbEndpoint::at(self.addr)
+    }
+
+    /// Where the fake listens.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Replaces the device list and pushes it to every `host:track-devices`
+    /// subscriber.
+    pub fn push_devices(&self, devices: Vec<AdbDevice>) {
+        self.devices.send_replace(devices);
+    }
+
+    /// The current device list.
+    pub fn devices(&self) -> Vec<AdbDevice> {
+        self.devices.borrow().clone()
+    }
+
+    /// The device tree, for seeding and asserting.
+    pub fn tree(&self) -> Arc<Mutex<FakeTree>> {
+        self.tree.clone()
+    }
+
+    /// Changes what `host-serial:<serial>:features` answers.
+    pub fn set_features(&self, list: &str) {
+        *self.features.lock().expect("features lock") = list.to_string();
+    }
+
+    /// Kills every open socket. The listener stays up, so clients reconnect.
+    pub fn drop_connections(&self) {
+        let handles: Vec<JoinHandle<()>> = std::mem::take(&mut *self.connections.lock().expect("connections lock"));
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    /// Closes the listener and every socket.
+    pub fn stop(&self) {
+        self.accept.abort();
+        self.drop_connections();
+    }
+}
+
+impl Drop for FakeAdbServer {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+async fn read_request(stream: &mut TcpStream) -> std::io::Result<String> {
+    let mut len = [0u8; 4];
+    stream.read_exact(&mut len).await?;
+    let len = usize::from_str_radix(std::str::from_utf8(&len).unwrap_or("0"), 16).unwrap_or(0);
+    let mut payload = vec![0u8; len];
+    stream.read_exact(&mut payload).await?;
+    Ok(String::from_utf8_lossy(&payload).into_owned())
+}
+
+async fn write_fail(stream: &mut TcpStream, msg: &str) -> std::io::Result<()> {
+    stream.write_all(b"FAIL").await?;
+    stream.write_all(&hex_message(msg.as_bytes())).await
+}
+
+fn short_list(devices: &[AdbDevice]) -> String {
+    devices
+        .iter()
+        .map(|d| format!("{}\t{}\n", d.serial, d.state.as_word()))
+        .collect()
+}
+
+fn long_list(devices: &[AdbDevice]) -> String {
+    devices
+        .iter()
+        .map(|d| {
+            let mut line = format!("{:<22} {}", d.serial, d.state.as_word());
+            if let Some(p) = &d.product {
+                line.push_str(&format!(" product:{p}"));
+            }
+            if let Some(m) = &d.model {
+                line.push_str(&format!(" model:{m}"));
+            }
+            if let Some(v) = &d.device {
+                line.push_str(&format!(" device:{v}"));
+            }
+            if let Some(t) = d.transport_id {
+                line.push_str(&format!(" transport_id:{t}"));
+            }
+            line.push('\n');
+            line
+        })
+        .collect()
+}
+
+async fn serve_connection(mut stream: TcpStream, shared: Shared) -> std::io::Result<()> {
+    loop {
+        let request = read_request(&mut stream).await?;
+        if let Some(serial) = request.strip_prefix("host:transport:") {
+            let state = shared
+                .devices
+                .borrow()
+                .iter()
+                .find(|d| d.serial == serial)
+                .map(|d| d.state);
+            match state {
+                Some(AdbDeviceState::Ready) => stream.write_all(b"OKAY").await?,
+                Some(AdbDeviceState::Unauthorized) => return write_fail(&mut stream, "device unauthorized").await,
+                Some(other) => return write_fail(&mut stream, &format!("device {}", other.as_word())).await,
+                None => return write_fail(&mut stream, &format!("device '{serial}' not found")).await,
+            }
+            continue;
+        }
+        if let Some(rest) = request.strip_prefix("host-serial:") {
+            let Some((serial, "features")) = rest.rsplit_once(':') else {
+                return write_fail(&mut stream, "unknown host-serial service").await;
+            };
+            if !shared.devices.borrow().iter().any(|d| d.serial == serial) {
+                return write_fail(&mut stream, &format!("device '{serial}' not found")).await;
+            }
+            let features = shared.features.lock().expect("features lock").clone();
+            stream.write_all(b"OKAY").await?;
+            stream.write_all(&hex_message(features.as_bytes())).await?;
+            continue;
+        }
+        if let Some(cmd) = request.strip_prefix("shell,v2,raw:") {
+            stream.write_all(b"OKAY").await?;
+            return serve_shell(&mut stream, &shared, cmd).await;
+        }
+        match request.as_str() {
+            "host:version" => {
+                stream.write_all(b"OKAY").await?;
+                stream.write_all(&hex_message(b"0029")).await?;
+            }
+            "host:devices" => {
+                let list = short_list(&shared.devices.borrow());
+                stream.write_all(b"OKAY").await?;
+                stream.write_all(&hex_message(list.as_bytes())).await?;
+            }
+            "host:devices-l" => {
+                let list = long_list(&shared.devices.borrow());
+                stream.write_all(b"OKAY").await?;
+                stream.write_all(&hex_message(list.as_bytes())).await?;
+            }
+            "host:track-devices" => {
+                let mut rx = shared.devices.subscribe();
+                stream.write_all(b"OKAY").await?;
+                loop {
+                    let list = short_list(&rx.borrow_and_update());
+                    stream.write_all(&hex_message(list.as_bytes())).await?;
+                    if rx.changed().await.is_err() {
+                        return Ok(());
+                    }
+                }
+            }
+            "sync:" => {
+                stream.write_all(b"OKAY").await?;
+                return serve_sync(&mut stream, &shared).await;
+            }
+            other => return write_fail(&mut stream, &format!("unknown host service: {other}")).await,
+        }
+    }
+}
+
+async fn read_sync_path(stream: &mut TcpStream, len: u32) -> std::io::Result<String> {
+    let mut buf = vec![0u8; len as usize];
+    stream.read_exact(&mut buf).await?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+fn stat_v1_bytes(node: Option<&FakeNode>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(12);
+    let (mode, size, mtime) = node.map_or((0, 0, 0), |n| (n.mode(), n.size() as u32, n.mtime() as u32));
+    out.extend_from_slice(&mode.to_le_bytes());
+    out.extend_from_slice(&size.to_le_bytes());
+    out.extend_from_slice(&mtime.to_le_bytes());
+    out
+}
+
+fn stat_v2_bytes(result: &Result<FakeNode, i32>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(68);
+    let (error, mode, size, mtime) = match result {
+        Ok(n) => (0u32, n.mode(), n.size(), n.mtime()),
+        Err(errno) => (*errno as u32, 0, 0, 0),
+    };
+    out.extend_from_slice(&error.to_le_bytes());
+    out.extend_from_slice(&1u64.to_le_bytes()); // dev
+    out.extend_from_slice(&1u64.to_le_bytes()); // ino
+    out.extend_from_slice(&mode.to_le_bytes());
+    out.extend_from_slice(&1u32.to_le_bytes()); // nlink
+    out.extend_from_slice(&0u32.to_le_bytes()); // uid
+    out.extend_from_slice(&0u32.to_le_bytes()); // gid
+    out.extend_from_slice(&size.to_le_bytes());
+    out.extend_from_slice(&mtime.to_le_bytes()); // atime
+    out.extend_from_slice(&mtime.to_le_bytes());
+    out.extend_from_slice(&mtime.to_le_bytes()); // ctime
+    out
+}
+
+fn sync_fail(msg: &str) -> Vec<u8> {
+    let mut out = b"FAIL".to_vec();
+    out.extend_from_slice(&(msg.len() as u32).to_le_bytes());
+    out.extend_from_slice(msg.as_bytes());
+    out
+}
+
+async fn serve_sync(stream: &mut TcpStream, shared: &Shared) -> std::io::Result<()> {
+    loop {
+        let mut id = [0u8; 4];
+        stream.read_exact(&mut id).await?;
+        let mut arg = [0u8; 4];
+        stream.read_exact(&mut arg).await?;
+        let arg = u32::from_le_bytes(arg);
+        match &id {
+            b"QUIT" => return Ok(()),
+            b"STAT" => {
+                let path = read_sync_path(stream, arg).await?;
+                let body = stat_v1_bytes(shared.tree.lock().expect("tree lock").get(&path));
+                stream.write_all(b"STAT").await?;
+                stream.write_all(&body).await?;
+            }
+            b"STA2" => {
+                let path = read_sync_path(stream, arg).await?;
+                let body = stat_v2_bytes(&shared.tree.lock().expect("tree lock").stat(&path));
+                stream.write_all(b"STA2").await?;
+                stream.write_all(&body).await?;
+            }
+            b"LIST" | b"LIS2" => {
+                let v2 = &id == b"LIS2";
+                let path = read_sync_path(stream, arg).await?;
+                let mut out = Vec::new();
+                {
+                    let tree = shared.tree.lock().expect("tree lock");
+                    if let Some(FakeNode::Dir { .. }) = tree.get(&path) {
+                        let mut entries = vec![
+                            (".".to_string(), tree.stat(&path)),
+                            ("..".to_string(), tree.stat(&path)),
+                        ];
+                        entries.extend(tree.children(&path).into_iter().map(|(n, node)| (n, Ok(node))));
+                        for (name, node) in entries {
+                            if v2 {
+                                out.extend_from_slice(b"DNT2");
+                                out.extend_from_slice(&stat_v2_bytes(&node));
+                            } else {
+                                out.extend_from_slice(b"DENT");
+                                out.extend_from_slice(&stat_v1_bytes(node.as_ref().ok()));
+                            }
+                            out.extend_from_slice(&(name.len() as u32).to_le_bytes());
+                            out.extend_from_slice(name.as_bytes());
+                        }
+                    }
+                }
+                out.extend_from_slice(b"DONE");
+                out.extend_from_slice(&vec![0u8; if v2 { 72 } else { 16 }]);
+                stream.write_all(&out).await?;
+            }
+            b"RECV" | b"RCV2" => {
+                let path = read_sync_path(stream, arg).await?;
+                if &id == b"RCV2" {
+                    let mut setup = [0u8; 8];
+                    stream.read_exact(&mut setup).await?;
+                }
+                let data = {
+                    let tree = shared.tree.lock().expect("tree lock");
+                    match tree.get(&path) {
+                        Some(FakeNode::File { data, .. }) => Ok(data.clone()),
+                        Some(_) => Err(format!("open failed: {path}: Is a directory")),
+                        None => Err(format!("open failed: {path}: No such file or directory")),
+                    }
+                };
+                match data {
+                    Ok(data) => {
+                        let mut out = Vec::with_capacity(data.len() + 64);
+                        for chunk in data.chunks(MAX_DATA_CHUNK) {
+                            out.extend_from_slice(b"DATA");
+                            out.extend_from_slice(&(chunk.len() as u32).to_le_bytes());
+                            out.extend_from_slice(chunk);
+                        }
+                        out.extend_from_slice(b"DONE");
+                        out.extend_from_slice(&0u32.to_le_bytes());
+                        stream.write_all(&out).await?;
+                    }
+                    Err(msg) => stream.write_all(&sync_fail(&msg)).await?,
+                }
+            }
+            b"SEND" | b"SND2" => {
+                let spec = read_sync_path(stream, arg).await?;
+                let (path, mode) = if &id == b"SND2" {
+                    let mut setup = [0u8; 12];
+                    stream.read_exact(&mut setup).await?;
+                    (spec, u32::from_le_bytes([setup[4], setup[5], setup[6], setup[7]]))
+                } else {
+                    let (p, m) = spec.rsplit_once(',').unwrap_or((&spec, "33188"));
+                    (p.to_string(), m.parse().unwrap_or(0o100644))
+                };
+                let mut data = Vec::new();
+                loop {
+                    let mut id = [0u8; 4];
+                    stream.read_exact(&mut id).await?;
+                    let mut arg = [0u8; 4];
+                    stream.read_exact(&mut arg).await?;
+                    let arg = u32::from_le_bytes(arg);
+                    match &id {
+                        b"DATA" => {
+                            let mut chunk = vec![0u8; arg as usize];
+                            stream.read_exact(&mut chunk).await?;
+                            data.extend_from_slice(&chunk);
+                        }
+                        b"DONE" => {
+                            let result =
+                                shared
+                                    .tree
+                                    .lock()
+                                    .expect("tree lock")
+                                    .write_file(&path, data, mode, i64::from(arg));
+                            match result {
+                                Ok(()) => {
+                                    stream.write_all(b"OKAY").await?;
+                                    stream.write_all(&0u32.to_le_bytes()).await?;
+                                }
+                                Err(errno) => {
+                                    stream
+                                        .write_all(&sync_fail(&format!("couldn't create file: errno {errno}")))
+                                        .await?;
+                                }
+                            }
+                            break;
+                        }
+                        _ => return Ok(()),
+                    }
+                }
+            }
+            _ => {
+                stream.write_all(&sync_fail("unknown command")).await?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Splits a POSIX command line into words: single quotes literal, double quotes
+/// and backslashes handled minimally.
+pub fn split_argv(line: &str) -> Vec<String> {
+    let mut argv = Vec::new();
+    let mut cur = String::new();
+    let mut in_word = false;
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' => {
+                in_word = true;
+                for q in chars.by_ref() {
+                    if q == '\'' {
+                        break;
+                    }
+                    cur.push(q);
+                }
+            }
+            '"' => {
+                in_word = true;
+                while let Some(q) = chars.next() {
+                    match q {
+                        '"' => break,
+                        '\\' => {
+                            if let Some(n) = chars.next() {
+                                cur.push(n);
+                            }
+                        }
+                        other => cur.push(other),
+                    }
+                }
+            }
+            '\\' => {
+                in_word = true;
+                if let Some(n) = chars.next() {
+                    cur.push(n);
+                }
+            }
+            c if c.is_whitespace() => {
+                if in_word {
+                    argv.push(std::mem::take(&mut cur));
+                    in_word = false;
+                }
+            }
+            other => {
+                in_word = true;
+                cur.push(other);
+            }
+        }
+    }
+    if in_word {
+        argv.push(cur);
+    }
+    argv
+}
+
+fn errno_text(errno: i32) -> &'static str {
+    match errno {
+        ENOENT => "No such file or directory",
+        EEXIST => "File exists",
+        EISDIR => "Is a directory",
+        EROFS => "Read-only file system",
+        ENOTEMPTY_DEVICE => "Directory not empty",
+        ENOTDIR => "Not a directory",
+        _ => "Unknown error",
+    }
+}
+
+/// Runs one fake shell command over the tree: `(exit_code, stdout, stderr)`.
+pub fn run_fake_shell(tree: &Mutex<FakeTree>, argv: &[String]) -> (u8, String, String) {
+    let Some(cmd) = argv.first() else {
+        return (0, String::new(), String::new());
+    };
+    let flags: Vec<&str> = argv[1..]
+        .iter()
+        .map(String::as_str)
+        .filter(|a| a.starts_with('-'))
+        .collect();
+    let args: Vec<&str> = argv[1..]
+        .iter()
+        .map(String::as_str)
+        .filter(|a| !a.starts_with('-'))
+        .collect();
+    let mut tree = tree.lock().expect("tree lock");
+    match cmd.as_str() {
+        "mkdir" => {
+            for p in &args {
+                let result = if flags.contains(&"-p") {
+                    tree.mkdir_p(p)
+                } else if tree.get(p).is_some() {
+                    Err(EEXIST)
+                } else {
+                    tree.mkdir_p(p)
+                };
+                if let Err(e) = result {
+                    return (1, String::new(), format!("mkdir: '{p}': {}\n", errno_text(e)));
+                }
+            }
+            (0, String::new(), String::new())
+        }
+        "rm" => {
+            let recursive = flags.iter().any(|f| f.contains('r'));
+            let force = flags.iter().any(|f| f.contains('f'));
+            for p in &args {
+                let result = if recursive {
+                    tree.remove_tree(p)
+                } else {
+                    tree.remove_one(p)
+                };
+                match result {
+                    Ok(()) => {}
+                    Err(ENOENT) if force => {}
+                    Err(e) => return (1, String::new(), format!("rm: {p}: {}\n", errno_text(e))),
+                }
+            }
+            (0, String::new(), String::new())
+        }
+        "mv" => {
+            let [from, to] = args[..] else {
+                return (1, String::new(), "mv: need two arguments\n".to_string());
+            };
+            match tree.rename(from, to) {
+                Ok(()) => (0, String::new(), String::new()),
+                Err(e) => (
+                    1,
+                    String::new(),
+                    format!("mv: bad rename of '{from}': {}\n", errno_text(e)),
+                ),
+            }
+        }
+        "df" => {
+            let used = tree.total_kib.saturating_sub(tree.available_kib);
+            let pct = (used * 100).checked_div(tree.total_kib).unwrap_or(0);
+            let out = format!(
+                "Filesystem      1K-blocks     Used Available Use% Mounted on\n/dev/fuse       {} {} {} {}% /storage/emulated\n",
+                tree.total_kib, used, tree.available_kib, pct
+            );
+            (0, out, String::new())
+        }
+        "readlink" => {
+            let Some(p) = args.first() else {
+                return (1, String::new(), String::new());
+            };
+            match tree.resolve(p) {
+                Ok(target) => (0, format!("{target}\n"), String::new()),
+                Err(_) => (1, String::new(), String::new()),
+            }
+        }
+        "test" => {
+            let node = args.first().and_then(|p| tree.get(p));
+            let ok = match flags.first().copied().unwrap_or("-e") {
+                "-e" => node.is_some(),
+                "-d" => matches!(node, Some(FakeNode::Dir { .. })),
+                "-f" => matches!(node, Some(FakeNode::File { .. })),
+                "-w" => node.is_some() && !tree.read_only,
+                _ => false,
+            };
+            (u8::from(!ok), String::new(), String::new())
+        }
+        "rmdir" => {
+            for p in &args {
+                let result = match tree.get(p) {
+                    Some(FakeNode::Dir { .. }) => tree.remove_one(p),
+                    Some(_) => Err(ENOTDIR),
+                    None => Err(ENOENT),
+                };
+                if let Err(e) = result {
+                    return (1, String::new(), format!("rmdir: '{p}': {}\n", errno_text(e)));
+                }
+            }
+            (0, String::new(), String::new())
+        }
+        "cp" => {
+            let [from, to] = args[..] else {
+                return (1, String::new(), "cp: need two arguments\n".to_string());
+            };
+            let result = match tree.get(from).cloned() {
+                Some(FakeNode::File { data, mode, mtime }) => tree.write_file(to, data, mode, mtime),
+                Some(_) => Err(EISDIR),
+                None => Err(ENOENT),
+            };
+            match result {
+                Ok(()) => (0, String::new(), String::new()),
+                Err(e) => (
+                    1,
+                    String::new(),
+                    format!("cp: bad copy of '{from}': {}\n", errno_text(e)),
+                ),
+            }
+        }
+        "stat" => {
+            let Some(p) = args.last() else {
+                return (1, String::new(), String::new());
+            };
+            let format = args.first().filter(|_| args.len() > 1).copied().unwrap_or("%n");
+            match tree.stat(p) {
+                Ok(node) => {
+                    let line = format
+                        .replace("%f", &format!("{:x}", node.mode()))
+                        .replace("%s", &node.size().to_string())
+                        .replace("%Y", &node.mtime().to_string())
+                        .replace("%n", p);
+                    (0, format!("{line}\n"), String::new())
+                }
+                Err(e) => (1, String::new(), format!("stat: '{p}': {}\n", errno_text(e))),
+            }
+        }
+        other => (
+            127,
+            String::new(),
+            format!("/system/bin/sh: {other}: inaccessible or not found\n"),
+        ),
+    }
+}
+
+fn shell_frame(id: u8, payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(5 + payload.len());
+    out.push(id);
+    out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+async fn serve_shell(stream: &mut TcpStream, shared: &Shared, cmd: &str) -> std::io::Result<()> {
+    let argv = split_argv(cmd);
+    let (exit_code, stdout, stderr) = run_fake_shell(&shared.tree, &argv);
+    let mut out = Vec::new();
+    if !stdout.is_empty() {
+        out.extend_from_slice(&shell_frame(1, stdout.as_bytes()));
+    }
+    if !stderr.is_empty() {
+        out.extend_from_slice(&shell_frame(2, stderr.as_bytes()));
+    }
+    out.extend_from_slice(&shell_frame(3, &[exit_code]));
+    stream.write_all(&out).await?;
+    stream.shutdown().await
+}

--- a/crates/cmdr-adb/src/transport.rs
+++ b/crates/cmdr-adb/src/transport.rs
@@ -1,0 +1,155 @@
+//! The ADB host-protocol socket: the ONE module that knows the framing.
+//!
+//! A request is four ASCII hex digits of length, then the payload
+//! (`000Chost:version`). The answer is `OKAY` or `FAIL`; `FAIL` is followed by
+//! a 4-hex-length message. Payload-bearing answers (`host:devices-l`,
+//! `host:track-devices` pushes) are one 4-hex-length message each. After
+//! `host:transport:<serial>`, the socket is bound to that device and the next
+//! request names a device service (`sync:`, `shell,v2,raw:<cmd>`), whose own
+//! binary framing `sync.rs` and `shell.rs` read through the raw helpers here.
+//!
+//! Wire reference: `adb/protocol.txt` in the AOSP platform tools (verified
+//! against platform-tools 35, 2026-09).
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use crate::errors::AdbError;
+
+/// One TCP socket to the ADB server.
+///
+/// Every method takes `&mut self`: the protocol is strictly request/response
+/// (or, after `sync:` / `shell`, a single stream), so two callers can't share
+/// one socket.
+pub struct AdbConnection {
+    stream: TcpStream,
+}
+
+impl std::fmt::Debug for AdbConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdbConnection").finish_non_exhaustive()
+    }
+}
+
+impl AdbConnection {
+    /// Wraps a connected socket. The caller has already dialed; see
+    /// [`crate::server::AdbEndpoint::connect`].
+    pub(crate) fn from_stream(stream: TcpStream) -> Self {
+        Self { stream }
+    }
+
+    /// Sends one host request and reads its status. `OKAY` is `Ok(())`; `FAIL`
+    /// is [`AdbError::Refused`] carrying the server's message.
+    pub async fn request(&mut self, service: &str) -> Result<(), AdbError> {
+        self.write_all(&frame(service)).await?;
+        self.read_status().await
+    }
+
+    /// Reads a 4-hex-length payload: what `host:devices-l` answers after `OKAY`,
+    /// and what `host:track-devices` pushes for the life of the socket.
+    pub async fn read_hex_message(&mut self) -> Result<Vec<u8>, AdbError> {
+        let mut len = [0u8; 4];
+        self.read_exact(&mut len).await?;
+        let len = parse_hex_len(&len)?;
+        let mut payload = vec![0u8; len];
+        self.read_exact(&mut payload).await?;
+        Ok(payload)
+    }
+
+    /// Binds this socket to the device with `serial` (`host:transport:<serial>`).
+    /// The next request is a device service.
+    pub async fn bind_device(&mut self, serial: &str) -> Result<(), AdbError> {
+        self.request(&format!("host:transport:{serial}")).await
+    }
+
+    /// Fills `buf` from the socket. A peer that hangs up first is
+    /// [`AdbError::DeviceGone`].
+    pub async fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), AdbError> {
+        self.stream.read_exact(buf).await?;
+        Ok(())
+    }
+
+    /// Writes all of `buf` to the socket.
+    pub async fn write_all(&mut self, buf: &[u8]) -> Result<(), AdbError> {
+        self.stream.write_all(buf).await?;
+        Ok(())
+    }
+
+    /// Reads one little-endian `u32`, the sync service's argument word.
+    pub async fn read_u32_le(&mut self) -> Result<u32, AdbError> {
+        let mut buf = [0u8; 4];
+        self.read_exact(&mut buf).await?;
+        Ok(u32::from_le_bytes(buf))
+    }
+
+    /// Reads one little-endian `u64`, the `STA2`/`DNT2` wide fields.
+    pub async fn read_u64_le(&mut self) -> Result<u64, AdbError> {
+        let mut buf = [0u8; 8];
+        self.read_exact(&mut buf).await?;
+        Ok(u64::from_le_bytes(buf))
+    }
+
+    /// Reads one little-endian `i64`, the `STA2`/`DNT2` timestamps.
+    pub async fn read_i64_le(&mut self) -> Result<i64, AdbError> {
+        let mut buf = [0u8; 8];
+        self.read_exact(&mut buf).await?;
+        Ok(i64::from_le_bytes(buf))
+    }
+
+    /// Reads a four-byte ASCII id (`OKAY`, `FAIL`, `DATA`, `DENT`, …).
+    pub async fn read_id(&mut self) -> Result<[u8; 4], AdbError> {
+        let mut id = [0u8; 4];
+        self.read_exact(&mut id).await?;
+        Ok(id)
+    }
+
+    /// Reads an `OKAY`/`FAIL` status word, turning a `FAIL` into
+    /// [`AdbError::Refused`] with its 4-hex-length message.
+    pub async fn read_status(&mut self) -> Result<(), AdbError> {
+        match &self.read_id().await? {
+            b"OKAY" => Ok(()),
+            b"FAIL" => {
+                let msg = self.read_hex_message().await?;
+                Err(AdbError::Refused(String::from_utf8_lossy(&msg).into_owned()))
+            }
+            other => Err(AdbError::Protocol(format!(
+                "expected OKAY or FAIL, got {:?}",
+                String::from_utf8_lossy(other)
+            ))),
+        }
+    }
+
+    /// Closes the write side. Best effort: a socket that's already gone has
+    /// nothing left to say.
+    pub async fn shutdown(&mut self) {
+        let _ = self.stream.shutdown().await;
+    }
+}
+
+/// Frames one host request: four lowercase hex digits of length, then the
+/// service string. Pure, so the framing is testable without a socket.
+pub(crate) fn frame(service: &str) -> Vec<u8> {
+    let mut out = format!("{:04x}", service.len()).into_bytes();
+    out.extend_from_slice(service.as_bytes());
+    out
+}
+
+/// Frames one 4-hex-length payload the way the SERVER writes it (an
+/// `OKAY`-following message or a `FAIL` reason). Used by the fake server.
+#[cfg(any(test, feature = "testing"))]
+pub(crate) fn hex_message(payload: &[u8]) -> Vec<u8> {
+    let mut out = format!("{:04x}", payload.len()).into_bytes();
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Decodes a four-digit hex length. Either case is accepted, since the server
+/// writes lowercase and the reference client uppercase.
+pub(crate) fn parse_hex_len(digits: &[u8; 4]) -> Result<usize, AdbError> {
+    let text = std::str::from_utf8(digits).map_err(|_| AdbError::Protocol("length is not ASCII".to_string()))?;
+    usize::from_str_radix(text, 16).map_err(|_| AdbError::Protocol(format!("length is not hex: {text:?}")))
+}
+
+#[cfg(test)]
+#[path = "transport_test.rs"]
+mod transport_test;

--- a/crates/cmdr-adb/src/transport_test.rs
+++ b/crates/cmdr-adb/src/transport_test.rs
@@ -1,0 +1,51 @@
+use super::*;
+use crate::testing::{FakeAdbServer, FakeTree};
+
+#[test]
+fn frame_is_four_hex_digits_then_the_service() {
+    assert_eq!(frame("host:version"), b"000chost:version".to_vec());
+    assert_eq!(frame(""), b"0000".to_vec());
+    let long = "x".repeat(0x1234);
+    assert_eq!(&frame(&long)[..4], b"1234");
+}
+
+#[test]
+fn hex_length_parses_either_case_and_rejects_junk() {
+    assert_eq!(parse_hex_len(b"000c").unwrap(), 12);
+    assert_eq!(parse_hex_len(b"00FF").unwrap(), 255);
+    assert!(matches!(parse_hex_len(b"zzzz"), Err(AdbError::Protocol(_))));
+}
+
+#[test]
+fn hex_message_round_trips_through_frame_parsing() {
+    let msg = hex_message(b"hello");
+    assert_eq!(&msg[..4], b"0005");
+    assert_eq!(parse_hex_len(&[msg[0], msg[1], msg[2], msg[3]]).unwrap(), 5);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn request_reads_okay_then_a_payload() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let mut conn = server.endpoint().connect().await.unwrap();
+    conn.request("host:version").await.unwrap();
+    assert_eq!(conn.read_hex_message().await.unwrap(), b"0029".to_vec());
+    conn.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fail_becomes_refused_with_the_message() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let mut conn = server.endpoint().connect().await.unwrap();
+    let err = conn.request("host:no-such-service").await.unwrap_err();
+    assert!(matches!(err, AdbError::Refused(msg) if msg.contains("no-such-service")));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn binding_an_unknown_serial_is_refused_and_a_closed_socket_is_device_gone() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let mut conn = server.endpoint().connect().await.unwrap();
+    assert!(matches!(conn.bind_device("nope").await, Err(AdbError::Refused(_))));
+    // The fake closes after a FAIL on transport; the next read sees EOF.
+    let mut byte = [0u8; 1];
+    assert!(matches!(conn.read_exact(&mut byte).await, Err(AdbError::DeviceGone)));
+}

--- a/crates/cmdr-adb/src/volume/conformance_test.rs
+++ b/crates/cmdr-adb/src/volume/conformance_test.rs
@@ -1,0 +1,223 @@
+//! The shared `Volume` conformance promises, against the fake ADB server, plus
+//! the cells that pin what this backend does on its own.
+//!
+//! No `#[ignore]`: the fake is in-process, so these run in every lane.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use cmdr_fs::staging::is_staging_temp_name;
+use cmdr_fs::volume::conformance;
+use cmdr_fs::volume::{DirectoryCreation, Volume, VolumeError};
+
+use super::AdbVolume;
+use super::testing::{FIXTURE_SERIAL, connect_fake};
+use crate::testing::{FakeAdbServer, FakeTree};
+
+/// A phone with the usual `/sdcard` and a handful of files in it.
+fn seeded_tree() -> FakeTree {
+    let mut tree = FakeTree::new();
+    tree.add_dir("/sdcard")
+        .add_file("/sdcard/notes.txt", b"the user's notes")
+        .add_file("/sdcard/source.txt", b"source")
+        .add_file("/sdcard/target.txt", b"the user's target file")
+        .add_dir("/sdcard/album")
+        .add_file("/sdcard/album/keep.txt", b"content")
+        .add_file("/sdcard/exported.txt", b"the bytes a copy would move");
+    tree
+}
+
+async fn seeded() -> (FakeAdbServer, Arc<AdbVolume>) {
+    let server = FakeAdbServer::start(seeded_tree()).await;
+    let (volume, _) = connect_fake(&server, FIXTURE_SERIAL).await;
+    (server, volume)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_forceless_rename_refuses_an_existing_destination() {
+    // `mv -n` exits 0 whether it moved or not, so the refusal here is the
+    // pre-flight stat's: this is the cell that would notice it going missing.
+    let (_server, volume) = seeded().await;
+    conformance::assert_rename_refuses_an_existing_destination(
+        volume.as_ref(),
+        Path::new("/sdcard/source.txt"),
+        Path::new("/sdcard/target.txt"),
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_file_refuses_to_clobber() {
+    // `SEND` truncates unconditionally, so the refusal is the pre-flight
+    // stat's here too.
+    let (_server, volume) = seeded().await;
+    conformance::assert_create_file_refuses_to_clobber(volume.as_ref(), Path::new("/sdcard/notes.txt"), b"new").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_directory_all_reports_an_existing_directory_honestly() {
+    // `mkdir -p` says nothing about whether the directory was there, so the
+    // honesty rests on the stat before it.
+    let (_server, volume) = seeded().await;
+    conformance::assert_create_directory_all_reports_an_existing_dir_honestly(
+        volume.as_ref(),
+        Path::new("/sdcard/album"),
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_leaves_a_non_empty_directory_intact() {
+    let (_server, volume) = seeded().await;
+    conformance::assert_delete_leaves_a_non_empty_dir_intact(volume.as_ref(), Path::new("/sdcard/album"), "keep.txt")
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn writability_matches_the_mutations_offered() {
+    let (_server, volume) = seeded().await;
+    conformance::assert_writability_matches_the_mutations_offered(volume.as_ref(), Path::new("/sdcard/scratch")).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn export_matches_the_bytes_offered() {
+    let (_server, volume) = seeded().await;
+    conformance::assert_export_matches_the_bytes_offered(
+        volume.as_ref(),
+        Path::new("/sdcard/exported.txt"),
+        b"the bytes a copy would move",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn not_found_carries_the_path() {
+    let (_server, volume) = seeded().await;
+    conformance::assert_not_found_carries_the_path(volume.as_ref(), Path::new("/sdcard/no-such-file.txt")).await;
+}
+
+// ── This backend's own cells ─────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_path_escaping_the_root_is_refused_before_any_io() {
+    let (server, volume) = seeded().await;
+    let outcome = volume.get_metadata(Path::new("/sdcard/../../etc/passwd")).await;
+    assert!(matches!(outcome, Err(VolumeError::NotFound(_))), "{outcome:?}");
+    // And nothing was created or asked for under a wrong name.
+    assert!(server.tree().lock().unwrap().get("/etc/passwd").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_write_lands_through_a_staging_sibling_and_leaves_no_partial() {
+    let (server, volume) = seeded().await;
+    let payload: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect();
+    let source = Box::new(super::streams::BytesReadStream::new(payload.clone()));
+    let seen = std::sync::Mutex::new(Vec::new());
+    let written = volume
+        .write_from_stream(
+            Path::new("/sdcard/big.bin"),
+            payload.len() as u64,
+            source,
+            &|done, total| {
+                seen.lock().unwrap().push((done, total));
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+        .await
+        .expect("the upload must land");
+    assert_eq!(written, payload.len() as u64);
+
+    let tree = server.tree();
+    let tree = tree.lock().unwrap();
+    assert_eq!(tree.file_bytes("/sdcard/big.bin").as_deref(), Some(payload.as_slice()));
+    let leftovers: Vec<String> = tree
+        .paths()
+        .into_iter()
+        .filter(|p| p.rsplit('/').next().is_some_and(is_staging_temp_name))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "the staging name must be gone after the rename: {leftovers:?}"
+    );
+    let seen = seen.lock().unwrap();
+    assert!(!seen.is_empty(), "progress must be reported");
+    assert_eq!(seen.last(), Some(&(payload.len() as u64, payload.len() as u64)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_cancelled_write_removes_its_partial() {
+    let (server, volume) = seeded().await;
+    let payload = vec![7u8; 100_000];
+    let source = Box::new(super::streams::BytesReadStream::new(payload.clone()));
+    let outcome = volume
+        .write_from_stream(Path::new("/sdcard/never.bin"), payload.len() as u64, source, &|_, _| {
+            std::ops::ControlFlow::Break(())
+        })
+        .await;
+    assert!(matches!(outcome, Err(VolumeError::Cancelled(_))), "{outcome:?}");
+    let tree = server.tree();
+    let tree = tree.lock().unwrap();
+    assert!(tree.get("/sdcard/never.bin").is_none());
+    assert!(
+        !tree
+            .paths()
+            .iter()
+            .any(|p| p.rsplit('/').next().is_some_and(is_staging_temp_name)),
+        "{:?}",
+        tree.paths()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mkdir_on_an_existing_directory_succeeds() {
+    let (_server, volume) = seeded().await;
+    volume
+        .create_directory(Path::new("/sdcard/album"))
+        .await
+        .expect("mkdir -p over an existing directory is a success");
+    assert!(!volume.create_directory_errors_on_existing_dir());
+    let deep = volume
+        .create_directory_all(Path::new("/sdcard/a/b/c"))
+        .await
+        .expect("a deep create must work");
+    assert_eq!(deep, DirectoryCreation::Created);
+    assert!(volume.is_directory(Path::new("/sdcard/a/b/c")).await.unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelling_a_read_mid_file_releases_the_socket_and_the_volume_keeps_working() {
+    let mut tree = seeded_tree();
+    let big: Vec<u8> = (0..(3 * crate::sync::MAX_DATA_CHUNK))
+        .map(|i| (i % 253) as u8)
+        .collect();
+    tree.add_file("/sdcard/big.bin", &big);
+    let server = FakeAdbServer::start(tree).await;
+    let (volume, _) = connect_fake(&server, FIXTURE_SERIAL).await;
+
+    let mut stream = volume
+        .open_read_stream(Path::new("/sdcard/big.bin"))
+        .await
+        .expect("open");
+    assert_eq!(stream.total_size(), big.len() as u64);
+    let first = stream.next_chunk().await.expect("a first chunk").expect("no error");
+    assert_eq!(&first[..], &big[..first.len()]);
+    stream.cancel_and_release().await;
+    drop(stream);
+
+    // The volume is still perfectly usable afterwards.
+    let entries = volume
+        .list_directory(Path::new("/sdcard"), None)
+        .await
+        .expect("list after cancel");
+    assert!(entries.iter().any(|e| e.name == "big.bin"));
+    let mut resumed = volume
+        .open_read_stream_at_offset(Path::new("/sdcard/big.bin"), 100_000)
+        .await
+        .expect("open at offset");
+    let mut tail = Vec::new();
+    while let Some(chunk) = resumed.next_chunk().await {
+        tail.extend_from_slice(&chunk.unwrap());
+    }
+    assert_eq!(&tail[..], &big[100_000..]);
+    assert_eq!(resumed.total_size(), big.len() as u64);
+}

--- a/crates/cmdr-adb/src/volume/mapping.rs
+++ b/crates/cmdr-adb/src/volume/mapping.rs
@@ -1,0 +1,31 @@
+//! Pure type mapping: a sync-service stat into `FileEntry`.
+use cmdr_fs::entry::FileEntry;
+
+use crate::sync::{SyncEntryKind, SyncStat};
+
+/// Builds a [`FileEntry`] from one stat answer.
+///
+/// `device_path` is the absolute device-side path, which is also what the app
+/// addresses the entry by. A symlink is reported as a symlink; whether it points
+/// at a directory is the caller's to settle with a following `stat`
+/// ([`with_link_target`]), because the sync service's listing is an `lstat`.
+pub(super) fn stat_to_file_entry(name: &str, device_path: &str, stat: &SyncStat) -> FileEntry {
+    let kind = stat.kind();
+    let is_directory = kind == SyncEntryKind::Directory;
+    let is_symlink = kind == SyncEntryKind::Symlink;
+    let mut entry = FileEntry::new(name.to_string(), device_path.to_string(), is_directory, is_symlink);
+    entry.size = if is_directory { None } else { Some(stat.size) };
+    entry.modified_at = u64::try_from(stat.mtime).ok();
+    entry.permissions = stat.mode & 0o7777;
+    entry
+}
+
+/// Folds what a symlink points at into its entry, so a link to a folder
+/// navigates like one instead of showing as a file.
+pub(super) fn with_link_target(mut entry: FileEntry, target: &SyncStat) -> FileEntry {
+    if target.kind() == SyncEntryKind::Directory {
+        entry.is_directory = true;
+        entry.size = None;
+    }
+    entry
+}

--- a/crates/cmdr-adb/src/volume/mod.rs
+++ b/crates/cmdr-adb/src/volume/mod.rs
@@ -1,0 +1,252 @@
+//! The ADB backend: a `Volume` over one Android device, reached through the ADB
+//! server's sync service and its shell.
+//!
+//! There is no OS mount under this and never will be: every listing, read, and
+//! write rides a socket to the ADB server, which relays it to the device's
+//! `adbd`. The volume is rooted at the device's own `/`, so the paths it hands
+//! out ARE device paths and nothing has to be translated between two spellings
+//! of the same tree.
+//!
+//! Nothing here names the application. What the backend needs from it arrives
+//! through the [`VolumeHost`] seams handed to [`connect_adb_volume`].
+//!
+//! ## One socket per operation, no shared session
+//!
+//! Every sync operation opens its OWN `sync:` socket and closes it when done,
+//! rather than queueing on one shared session behind a mutex. Two reasons:
+//!
+//! - A shared session serialized behind a lock deadlocks a same-volume copy: the
+//!   source stream holds the session while the destination write waits for it.
+//! - A paused transfer parks its read stream mid-file; on a shared session that
+//!   parks every listing on the volume with it, and the pane can't navigate.
+//!
+//! The ADB server multiplexes sockets to the device, and `adbd` serializes the
+//! I/O on its side anyway, so nothing is gained by holding one socket. What
+//! bounds concurrent TRANSFERS is `max_concurrent_ops`, which the app's settings
+//! table answers with 1 for this backend.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8};
+use std::time::Duration;
+
+use cmdr_fs::volume::host::VolumeHost;
+use cmdr_fs::volume::host::settings::BackendName;
+use cmdr_fs::volume::{Retirement, VolumeError, adb_volume_id};
+use tokio_util::sync::CancellationToken;
+
+use crate::devices::{AdbDeviceState, list_devices};
+use crate::errors::{AdbConnectError, AdbError};
+use crate::features::DeviceFeatures;
+use crate::params::AdbConnectionParams;
+use crate::server::AdbEndpoint;
+use crate::sync::SyncSession;
+
+mod mapping;
+mod mutation;
+mod paths;
+mod query;
+mod scan;
+mod state;
+mod streams;
+mod volume_impl;
+mod writes;
+
+pub use state::ConnectionState;
+
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
+
+/// This backend's settings namespace, for everything it reads through
+/// [`VolumeHost::settings`]. A namespace, not a classification: nothing branches
+/// on it, and the app resolves it through a table.
+const BACKEND: BackendName = "adb";
+
+/// How long a connect may take, all phases together: the device list, the
+/// feature probe, and the hello. A device that answers none of them inside this
+/// is not going to.
+const CONNECT_BUDGET: Duration = Duration::from_secs(10);
+
+/// A volume backed by one Android device over ADB.
+pub struct AdbVolume {
+    /// Display name: the device's model as `list_devices` reported it.
+    name: String,
+    /// Always the device's `/`. A plain field so `root()` stays a borrow.
+    root: PathBuf,
+    inner: Arc<AdbVolumeInner>,
+}
+
+/// The device-scoped half: what every operation on this volume shares.
+struct AdbVolumeInner {
+    /// From `adb_volume_id(serial)`, the key every piece of durable per-volume
+    /// state is filed under.
+    volume_id: String,
+    /// The device this volume is, as the ADB server names it.
+    serial: String,
+    /// The ADB server every socket is opened against.
+    endpoint: AdbEndpoint,
+    /// What the device's own ADB supports, read once at connect. ❌ Never
+    /// re-probed at a call site: `adbd` doesn't change under a session.
+    features: DeviceFeatures,
+    /// The state the host was last told about, so a device that is gone doesn't
+    /// produce one event per failing operation (`state.rs`).
+    state: AtomicU8,
+    /// Whether the registry still serves this volume under its id.
+    retirement: Retirement,
+    /// Set by `on_unmount`, so a reconnect in flight bails rather than reviving
+    /// a volume the app has forgotten.
+    unmounted: AtomicBool,
+    /// Single-flight around a hello re-run.
+    reconnect_lock: tokio::sync::Mutex<()>,
+    /// Everything this backend asks the app around it.
+    host: VolumeHost,
+}
+
+impl AdbVolume {
+    /// The volume id every listing-cache lookup and connection event uses.
+    pub fn volume_id(&self) -> &str {
+        &self.inner.volume_id
+    }
+
+    /// The device's serial, as the ADB server names it.
+    pub fn serial(&self) -> &str {
+        &self.inner.serial
+    }
+
+    /// The device's display name, as the sidebar labels it.
+    pub fn device_name(&self) -> &str {
+        &self.name
+    }
+
+    /// What the device's own ADB supports.
+    pub fn features(&self) -> DeviceFeatures {
+        self.inner.features
+    }
+
+    /// Where the connection stands right now.
+    pub fn connection_state(&self) -> ConnectionState {
+        self.inner.connection_state()
+    }
+
+    /// Opens a fresh sync socket to the device.
+    ///
+    /// One per operation, and it closes with the operation: `mod.rs` § "One
+    /// socket per operation" has why there is no shared session to reach for.
+    pub(super) async fn open_sync(&self, path: &str) -> Result<SyncSession, VolumeError> {
+        self.inner.open_sync(path).await
+    }
+}
+
+impl AdbVolumeInner {
+    async fn open_sync(&self, path: &str) -> Result<SyncSession, VolumeError> {
+        if self.unmounted.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(VolumeError::DeviceDisconnected(self.volume_id.clone()));
+        }
+        SyncSession::open(&self.endpoint, &self.serial, self.features)
+            .await
+            .map_err(|e| self.map_adb_error(e, path))
+    }
+
+    /// The crate's error mapper, with the one thing it can't know: which volume
+    /// a `DeviceGone` describes.
+    pub(super) fn map_adb_error(&self, error: AdbError, path: &str) -> VolumeError {
+        match error {
+            AdbError::DeviceGone => VolumeError::DeviceDisconnected(self.volume_id.clone()),
+            other => crate::errors::volume_error_from_adb(other, path),
+        }
+    }
+
+    /// The hello: one `stat` of the root, which proves the device answers sync
+    /// requests at all. Shared by the connect and every reconnect.
+    async fn hello(&self) -> Result<(), AdbError> {
+        let mut session = SyncSession::open(&self.endpoint, &self.serial, self.features).await?;
+        let stat = session.stat("/").await?;
+        session.quit().await;
+        if !stat.exists() {
+            return Err(AdbError::Protocol(
+                "the device answered the hello with a missing root".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Opens an ADB volume for the device with `params.serial`.
+///
+/// Four phases, all under one [`CONNECT_BUDGET`] and `cancel`: list the
+/// devices (a serial that isn't there is `DeviceGone`; one the user hasn't
+/// authorized yet is `Unauthorized`), read the device's features (no
+/// `shell_v2` is a device too old to give exit codes, and every write verb
+/// here depends on those), then the hello. A cancel ends the attempt where it
+/// stands and leaves nothing behind: no volume, no socket.
+pub async fn connect_adb_volume(
+    params: AdbConnectionParams,
+    host: VolumeHost,
+    cancel: CancellationToken,
+) -> Result<AdbVolume, AdbConnectError> {
+    let attempt = async {
+        let devices = list_devices(&params.endpoint).await?;
+        let device = devices
+            .into_iter()
+            .find(|d| d.serial == params.serial)
+            .ok_or_else(|| AdbConnectError::DeviceGone(params.serial.clone()))?;
+        match device.state {
+            AdbDeviceState::Ready => {}
+            AdbDeviceState::Unauthorized => return Err(AdbConnectError::Unauthorized(params.serial.clone())),
+            _ => return Err(AdbConnectError::DeviceGone(params.serial.clone())),
+        }
+        let features = DeviceFeatures::fetch(&params.endpoint, &params.serial)
+            .await
+            .map_err(|e| AdbConnectError::from(e).for_device(&params.serial))?;
+        if !features.shell_v2 {
+            return Err(AdbConnectError::DeviceTooOld {
+                serial: params.serial.clone(),
+            });
+        }
+        Ok((device.display_name(), features))
+    };
+
+    let (name, features) = tokio::select! {
+        biased;
+        () = cancel.cancelled() => return Err(AdbConnectError::Cancelled),
+        outcome = tokio::time::timeout(CONNECT_BUDGET, attempt) => match outcome {
+            Ok(outcome) => outcome?,
+            Err(_) => return Err(AdbConnectError::TimedOut),
+        },
+    };
+
+    let inner = Arc::new(AdbVolumeInner {
+        volume_id: adb_volume_id(&params.serial),
+        serial: params.serial.clone(),
+        endpoint: params.endpoint.clone(),
+        features,
+        state: AtomicU8::new(ConnectionState::Connected as u8),
+        retirement: Retirement::new(),
+        unmounted: AtomicBool::new(false),
+        reconnect_lock: tokio::sync::Mutex::new(()),
+        host,
+    });
+
+    tokio::select! {
+        biased;
+        () = cancel.cancelled() => return Err(AdbConnectError::Cancelled),
+        outcome = tokio::time::timeout(CONNECT_BUDGET, inner.hello()) => match outcome {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(AdbConnectError::from(e).for_device(&params.serial)),
+            Err(_) => return Err(AdbConnectError::TimedOut),
+        },
+    }
+
+    // PII-free: an ADB volume came up. ❌ No serial, model, or path crosses.
+    inner.host.analytics().record("adb_connected", &[]);
+    Ok(AdbVolume {
+        name,
+        root: PathBuf::from("/"),
+        inner,
+    })
+}
+
+#[cfg(test)]
+mod conformance_test;
+#[cfg(test)]
+mod volume_impl_test;

--- a/crates/cmdr-adb/src/volume/mutation.rs
+++ b/crates/cmdr-adb/src/volume/mutation.rs
@@ -1,0 +1,110 @@
+//! The listing-cache patch each write leaves behind.
+//!
+//! There is no watcher on this backend, so `notify_mutation` is the ONLY thing
+//! that keeps a pane honest after a write. ❗ One call per changed DIRECTORY,
+//! ❌ never one per entry: the host walks every cached listing on the volume.
+
+use std::path::Path;
+
+use cmdr_fs::volume::{DirectoryChange, MutationEvent, Volume};
+
+use super::AdbVolume;
+
+impl AdbVolume {
+    /// The one patch a create leaves behind. A path that doesn't translate
+    /// skips it: the write already succeeded, and a patch must never fail it.
+    pub(super) async fn notify_created(&self, path: &Path) {
+        let (Some(parent), Some(name)) = (path.parent(), path.file_name()) else {
+            return;
+        };
+        let Some(parent_display) = self.display_path_for(parent) else {
+            return;
+        };
+        self.notify_mutation(
+            self.volume_id(),
+            &parent_display,
+            MutationEvent::Created(name.to_string_lossy().to_string()),
+        )
+        .await;
+    }
+
+    /// The same for a delete.
+    pub(super) async fn notify_deleted(&self, path: &Path) {
+        let (Some(parent), Some(name)) = (path.parent(), path.file_name()) else {
+            return;
+        };
+        let Some(parent_display) = self.display_path_for(parent) else {
+            return;
+        };
+        self.notify_mutation(
+            self.volume_id(),
+            &parent_display,
+            MutationEvent::Deleted(name.to_string_lossy().to_string()),
+        )
+        .await;
+    }
+
+    /// One `Renamed` when both ends share a parent, otherwise a `Deleted` at
+    /// the source and a `Created` at the destination.
+    pub(super) async fn notify_renamed(&self, from: &Path, to: &Path) {
+        if from.parent() == to.parent() {
+            let (Some(parent), Some(from_name), Some(to_name)) = (from.parent(), from.file_name(), to.file_name())
+            else {
+                return;
+            };
+            let Some(parent_display) = self.display_path_for(parent) else {
+                return;
+            };
+            self.notify_mutation(
+                self.volume_id(),
+                &parent_display,
+                MutationEvent::Renamed {
+                    from: from_name.to_string_lossy().to_string(),
+                    to: to_name.to_string_lossy().to_string(),
+                },
+            )
+            .await;
+            return;
+        }
+        self.notify_deleted(from).await;
+        self.notify_created(to).await;
+    }
+
+    /// Patches the cached listing of ONE directory to match a mutation that
+    /// has already landed on the device.
+    pub(super) async fn notify_mutation_impl(&self, parent_path: &Path, mutation: MutationEvent) {
+        let listings = self.inner.host.listings();
+        let volume_id = self.volume_id();
+        match mutation {
+            MutationEvent::Created(ref name) | MutationEvent::Modified(ref name) => {
+                // One stat, and a failure is simply no patch: the pane re-lists
+                // eventually, and the mutation itself has already succeeded.
+                let Ok(entry) = self.get_metadata_impl(&parent_path.join(name)).await else {
+                    return;
+                };
+                let change = if matches!(mutation, MutationEvent::Created(_)) {
+                    DirectoryChange::Added(entry)
+                } else {
+                    DirectoryChange::Modified(entry)
+                };
+                listings.directory_changed(volume_id, parent_path, change);
+            }
+            MutationEvent::Deleted(name) => {
+                listings.directory_changed(volume_id, parent_path, DirectoryChange::Removed(name));
+            }
+            MutationEvent::Renamed { from, to } => {
+                let Ok(entry) = self.get_metadata_impl(&parent_path.join(&to)).await else {
+                    return;
+                };
+                listings.directory_changed(
+                    volume_id,
+                    parent_path,
+                    DirectoryChange::Renamed {
+                        old_name: from,
+                        new_entry: entry,
+                    },
+                );
+            }
+        }
+    }
+}

--- a/crates/cmdr-adb/src/volume/paths.rs
+++ b/crates/cmdr-adb/src/volume/paths.rs
@@ -1,0 +1,63 @@
+//! Turning the paths the app addresses this volume with into device paths.
+//!
+//! The volume is rooted at the device's `/`, so anchoring is close to the
+//! identity: a relative path hangs off `/`, an absolute one is already a device
+//! path, and both spell the same file. What the function guards against is
+//! `..`, which the device would resolve happily and which is the one way a path
+//! can address something outside a volume rooted at `/`.
+
+use std::path::{Component, Path, PathBuf};
+
+use cmdr_fs::volume::VolumeError;
+
+use super::AdbVolume;
+
+impl AdbVolume {
+    /// The absolute device-side path for `path`, or `NotFound` when `path`
+    /// escapes the root.
+    ///
+    /// Idempotent: a pane's `/sdcard/DCIM` and a destination box's
+    /// `sdcard/DCIM` land on the same file. Empty, `.`, and a bare `/` all mean
+    /// the root. `..` is resolved lexically before anything is sent, and a path
+    /// that would climb above `/` is refused the way `SftpVolume::to_remote_path`
+    /// refuses one outside its export: ❌ never anchored, because anchoring
+    /// silently addresses a real, wrong file.
+    pub(super) fn to_device_path(&self, path: &Path) -> Result<String, VolumeError> {
+        let mut out = PathBuf::from("/");
+        for component in path.components() {
+            match component {
+                Component::RootDir | Component::CurDir => {}
+                Component::ParentDir => {
+                    if !out.pop() {
+                        return Err(VolumeError::NotFound(path.to_string_lossy().into_owned()));
+                    }
+                }
+                Component::Normal(part) => out.push(part),
+                // No drive letters on a device reached over a socket.
+                Component::Prefix(_) => {}
+            }
+        }
+        Ok(out.to_string_lossy().into_owned())
+    }
+
+    /// The path the APP addresses `path` by, which for this backend is the same
+    /// string the device does. A refusal becomes "no patch to make": a
+    /// listing-cache patch is a courtesy and ❌ must never fail a mutation that
+    /// already landed.
+    pub(super) fn display_path_for(&self, path: &Path) -> Option<PathBuf> {
+        self.to_device_path(path).ok().map(PathBuf::from)
+    }
+}
+
+/// `parent/name` on the device, with the root's own slash not doubled.
+pub(super) fn join_device_path(parent: &str, name: &str) -> String {
+    if parent.ends_with('/') {
+        format!("{parent}{name}")
+    } else {
+        format!("{parent}/{name}")
+    }
+}
+
+#[cfg(test)]
+#[path = "paths_test.rs"]
+mod paths_test;

--- a/crates/cmdr-adb/src/volume/paths_test.rs
+++ b/crates/cmdr-adb/src/volume/paths_test.rs
@@ -1,0 +1,56 @@
+use std::path::Path;
+
+use cmdr_fs::volume::VolumeError;
+
+use super::join_device_path;
+use crate::volume::testing::detached_volume;
+
+#[test]
+fn every_spelling_of_the_root_is_the_root() {
+    let volume = detached_volume();
+    for spelling in ["", ".", "/", "//", "/./"] {
+        assert_eq!(volume.to_device_path(Path::new(spelling)).unwrap(), "/", "{spelling:?}");
+    }
+}
+
+#[test]
+fn anchoring_is_idempotent() {
+    let volume = detached_volume();
+    assert_eq!(volume.to_device_path(Path::new("sdcard/DCIM")).unwrap(), "/sdcard/DCIM");
+    assert_eq!(
+        volume.to_device_path(Path::new("/sdcard/DCIM")).unwrap(),
+        "/sdcard/DCIM"
+    );
+    assert_eq!(
+        volume.to_device_path(Path::new("/sdcard/DCIM/")).unwrap(),
+        "/sdcard/DCIM"
+    );
+}
+
+#[test]
+fn dot_dot_is_resolved_lexically() {
+    let volume = detached_volume();
+    assert_eq!(
+        volume.to_device_path(Path::new("/sdcard/DCIM/../Pictures")).unwrap(),
+        "/sdcard/Pictures"
+    );
+    assert_eq!(volume.to_device_path(Path::new("/sdcard/..")).unwrap(), "/");
+}
+
+#[test]
+fn a_path_climbing_above_the_root_is_refused_not_anchored() {
+    let volume = detached_volume();
+    for escape in ["/..", "../etc", "/sdcard/../../etc/passwd"] {
+        let outcome = volume.to_device_path(Path::new(escape));
+        assert!(
+            matches!(outcome, Err(VolumeError::NotFound(ref p)) if p == escape),
+            "{escape}: {outcome:?}"
+        );
+    }
+}
+
+#[test]
+fn joining_never_doubles_the_root_slash() {
+    assert_eq!(join_device_path("/", "sdcard"), "/sdcard");
+    assert_eq!(join_device_path("/sdcard", "DCIM"), "/sdcard/DCIM");
+}

--- a/crates/cmdr-adb/src/volume/query.rs
+++ b/crates/cmdr-adb/src/volume/query.rs
@@ -1,0 +1,183 @@
+//! Reading what's on the device without changing it.
+use std::path::Path;
+
+use cmdr_fs::entry::FileEntry;
+use cmdr_fs::volume::{ListingProgress, VolumeError};
+use tokio_util::sync::CancellationToken;
+
+use super::AdbVolume;
+use super::mapping::{stat_to_file_entry, with_link_target};
+use super::paths::join_device_path;
+use crate::errors::{ENOENT, volume_error_from_errno};
+use crate::sync::{SyncDirEntry, SyncEntryKind, SyncSession, SyncStat};
+
+/// How many entries go by between two progress reports.
+///
+/// ❗ Never quieted: the pane's "Loading N entries…" line and the listing
+/// watchdog both read it, and a quarter-million-entry `/sdcard/DCIM` with no
+/// report looks exactly like a device that stopped answering.
+const PROGRESS_EVERY: usize = 256;
+
+impl AdbVolume {
+    /// One `LIST` walk, as the device streams it.
+    ///
+    /// Cancellation is checked per entry, which is free here: the token is an
+    /// atomic and the entries arrive on one socket.
+    pub(super) async fn list_directory_impl(
+        &self,
+        path: &Path,
+        on_progress: Option<&(dyn Fn(ListingProgress) + Sync)>,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<Vec<FileEntry>, VolumeError> {
+        let device = self.to_device_path(path)?;
+        let mut session = self.open_sync(&device).await?;
+
+        // ❗ `LIST` answers an unreadable or missing directory with an EMPTY
+        // listing rather than an error, so the directory is stat'ed first and
+        // the refusal comes from that. One round trip, and the only way to tell
+        // "/data on an unrooted phone" from "an empty folder".
+        let top = session
+            .stat(&device)
+            .await
+            .map_err(|e| self.inner.map_adb_error(e, &device))?;
+        if !top.exists() {
+            session.quit().await;
+            return Err(volume_error_from_errno(top.errno.unwrap_or(ENOENT), &device));
+        }
+        if top.kind() != SyncEntryKind::Directory {
+            let followed = if top.kind() == SyncEntryKind::Symlink {
+                self.follow(&mut session, &device).await
+            } else {
+                None
+            };
+            if followed.is_none_or(|t| t.kind() != SyncEntryKind::Directory) {
+                session.quit().await;
+                return Err(volume_error_from_errno(ENOTDIR, &device));
+            }
+        }
+
+        let mut entries: Vec<FileEntry> = Vec::new();
+        let mut symlinks: Vec<usize> = Vec::new();
+        let mut tally = ListingProgress::default();
+        let mut cancelled = false;
+        let outcome = session
+            .list(&device, &mut |entry: SyncDirEntry| {
+                if cancel.is_some_and(CancellationToken::is_cancelled) {
+                    cancelled = true;
+                    return;
+                }
+                let child = join_device_path(&device, &entry.name);
+                let built = stat_to_file_entry(&entry.name, &child, &entry.stat);
+                if built.is_symlink {
+                    symlinks.push(entries.len());
+                }
+                if built.is_directory {
+                    tally.dirs += 1;
+                } else {
+                    tally.files += 1;
+                    tally.bytes += built.size.unwrap_or(0);
+                }
+                entries.push(built);
+                if let Some(on_progress) = on_progress
+                    && entries.len().is_multiple_of(PROGRESS_EVERY)
+                {
+                    on_progress(tally);
+                }
+            })
+            .await;
+        if let Err(e) = outcome {
+            session.quit().await;
+            return Err(self.inner.map_adb_error(e, &device));
+        }
+        if cancelled {
+            session.quit().await;
+            return Err(VolumeError::Cancelled(device));
+        }
+
+        // A link to a folder must navigate like one. One `stat` per symlink,
+        // on the same socket, ❗ never per entry: a listing is mostly files.
+        for index in symlinks {
+            if let Some(target) = self.follow(&mut session, &entries[index].path.clone()).await {
+                let entry = std::mem::replace(
+                    &mut entries[index],
+                    FileEntry::new(String::new(), String::new(), false, false),
+                );
+                let entry = with_link_target(entry, &target);
+                if entry.is_directory {
+                    tally.dirs += 1;
+                    tally.files = tally.files.saturating_sub(1);
+                }
+                entries[index] = entry;
+            }
+        }
+        session.quit().await;
+
+        if let Some(on_progress) = on_progress {
+            on_progress(tally);
+        }
+        Ok(entries)
+    }
+
+    /// One `stat` round trip, as a `FileEntry`.
+    pub(super) async fn get_metadata_impl(&self, path: &Path) -> Result<FileEntry, VolumeError> {
+        let device = self.to_device_path(path)?;
+        let mut session = self.open_sync(&device).await?;
+        let stat = session
+            .stat(&device)
+            .await
+            .map_err(|e| self.inner.map_adb_error(e, &device))?;
+        if !stat.exists() {
+            session.quit().await;
+            return Err(volume_error_from_errno(stat.errno.unwrap_or(ENOENT), &device));
+        }
+        let name = Path::new(&device)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| self.name.clone());
+        let mut entry = stat_to_file_entry(&name, &device, &stat);
+        if entry.is_symlink
+            && let Some(target) = self.follow(&mut session, &device).await
+        {
+            entry = with_link_target(entry, &target);
+        }
+        session.quit().await;
+        Ok(entry)
+    }
+
+    /// Whether `path` is there, as a plain yes/no. A path off this volume
+    /// doesn't exist ON THIS VOLUME, which is the question asked.
+    pub(super) async fn exists_impl(&self, path: &Path) -> bool {
+        self.get_metadata_impl(path).await.is_ok()
+    }
+
+    /// One `stat` round trip, reduced to the directory bit.
+    pub(super) async fn is_directory_impl(&self, path: &Path) -> Result<bool, VolumeError> {
+        Ok(self.get_metadata_impl(path).await?.is_directory)
+    }
+
+    /// What a symlink at `device` points at, or `None` when the target is
+    /// missing or the device declined to say.
+    ///
+    /// The sync service's `STAT` is an `lstat`, so the target is asked of the
+    /// shell (`readlink -f`, in every Android `toybox`) and then stat'ed on the
+    /// same sync socket. A `Symlink` answer again means `readlink` couldn't
+    /// resolve a chain, which is left as a plain link rather than walked.
+    async fn follow(&self, session: &mut SyncSession, device: &str) -> Option<SyncStat> {
+        let outcome = crate::shell::run(&self.inner.endpoint, &self.inner.serial, &["readlink", "-f", device])
+            .await
+            .ok()?;
+        if !outcome.succeeded() {
+            return None;
+        }
+        let target = outcome.stdout_text();
+        let target = target.trim_end_matches(['\n', '\r']);
+        if target.is_empty() {
+            return None;
+        }
+        session.stat(target).await.ok().filter(SyncStat::exists)
+    }
+}
+
+/// Linux `ENOTDIR`, which `crate::errors` has no name for: the device numbers
+/// it, and every Android is Linux.
+const ENOTDIR: i32 = 20;

--- a/crates/cmdr-adb/src/volume/scan.rs
+++ b/crates/cmdr-adb/src/volume/scan.rs
@@ -1,0 +1,159 @@
+//! Walking a subtree to say what a copy is about to cost, and reading a
+//! destination for names that are already taken.
+//!
+//! Both are READS: ❗ neither reports a listing change, and ❌ nothing here
+//! calls `authoritative_listing` (no watcher, so no cached listing is fresh).
+//! The walk is one `LIST` per DIRECTORY, ❌ never a stat per child: a listing
+//! already carries every child's size and type.
+
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+
+use cmdr_fs::volume::{
+    BatchScanResult, CopyScanResult, ListingProgress, ScanConflict, ScanTicker, SourceItemInfo, VolumeError,
+};
+
+use super::AdbVolume;
+
+impl AdbVolume {
+    /// One subtree's file count, directory count, and bytes.
+    pub(super) fn scan_for_copy_impl<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<CopyScanResult, VolumeError>> + Send + 'a>> {
+        Box::pin(async move {
+            let ticker = ScanTicker::new(None);
+            self.scan_recursive(path, &ticker).await
+        })
+    }
+
+    /// Several subtrees, with the counts climbing across all of them: ❗ one
+    /// ticker for the whole call, cumulative-for-the-call being what the trait
+    /// promises.
+    pub(super) fn scan_for_copy_batch_impl<'a>(
+        &'a self,
+        paths: &'a [PathBuf],
+        on_progress: Option<&'a (dyn Fn(ListingProgress) + Sync)>,
+    ) -> Pin<Box<dyn Future<Output = Result<BatchScanResult, VolumeError>> + Send + 'a>> {
+        Box::pin(async move {
+            let ticker = ScanTicker::new(on_progress);
+            let mut aggregate = CopyScanResult {
+                file_count: 0,
+                dir_count: 0,
+                total_bytes: 0,
+                dedup_bytes: 0,
+                top_level_is_directory: false,
+            };
+            let mut per_path = Vec::with_capacity(paths.len());
+            for path in paths {
+                let scan = self.scan_recursive(path, &ticker).await?;
+                aggregate.file_count += scan.file_count;
+                aggregate.dir_count += scan.dir_count;
+                aggregate.total_bytes += scan.total_bytes;
+                aggregate.dedup_bytes += scan.dedup_bytes;
+                per_path.push((path.clone(), scan));
+            }
+            if paths.len() == 1 {
+                aggregate.top_level_is_directory = per_path[0].1.top_level_is_directory;
+            }
+            Ok(BatchScanResult { aggregate, per_path })
+        })
+    }
+
+    /// Which of `source_items` already have a name at `dest_path`. One listing,
+    /// ❗ never one `exists()` per item.
+    pub(super) fn scan_for_conflicts_impl<'a>(
+        &'a self,
+        source_items: &'a [SourceItemInfo],
+        dest_path: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<ScanConflict>, VolumeError>> + Send + 'a>> {
+        Box::pin(async move {
+            let entries = match self.list_directory_impl(dest_path, None, None).await {
+                Ok(entries) => entries,
+                // A destination that isn't there yet holds nothing.
+                Err(VolumeError::NotFound(_)) => return Ok(Vec::new()),
+                Err(e) => return Err(e),
+            };
+            let mut conflicts = Vec::new();
+            for item in source_items {
+                let Some(existing) = entries.iter().find(|entry| entry.name == item.name) else {
+                    continue;
+                };
+                conflicts.push(ScanConflict {
+                    source_path: item.name.clone(),
+                    dest_path: existing.path.clone(),
+                    source_size: item.size,
+                    dest_size: existing.size.unwrap_or(0),
+                    source_modified: item.modified,
+                    dest_modified: existing.modified_at.map(|seconds| seconds as i64),
+                    source_is_directory: item.is_directory,
+                    dest_is_directory: existing.is_directory,
+                });
+            }
+            Ok(conflicts)
+        })
+    }
+
+    /// The walk itself: one stat for the top, then one listing per directory.
+    fn scan_recursive<'a>(
+        &'a self,
+        path: &'a Path,
+        ticker: &'a ScanTicker<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<CopyScanResult, VolumeError>> + Send + 'a>> {
+        Box::pin(async move {
+            let top = self.get_metadata_impl(path).await?;
+            if !top.is_directory {
+                let size = top.size.unwrap_or(0);
+                ticker.file(size);
+                return Ok(CopyScanResult {
+                    file_count: 1,
+                    dir_count: 0,
+                    total_bytes: size,
+                    // No link count on the wire, so the source footprint is
+                    // the write footprint.
+                    dedup_bytes: size,
+                    top_level_is_directory: false,
+                });
+            }
+            let mut result = CopyScanResult {
+                file_count: 0,
+                dir_count: 0,
+                total_bytes: 0,
+                dedup_bytes: 0,
+                top_level_is_directory: true,
+            };
+            self.scan_directory(path, ticker, &mut result).await?;
+            Ok(result)
+        })
+    }
+
+    /// One directory's contents, folded into `into`, recursing into children.
+    fn scan_directory<'a>(
+        &'a self,
+        dir: &'a Path,
+        ticker: &'a ScanTicker<'a>,
+        into: &'a mut CopyScanResult,
+    ) -> Pin<Box<dyn Future<Output = Result<(), VolumeError>> + Send + 'a>> {
+        Box::pin(async move {
+            into.dir_count += 1;
+            ticker.dir();
+            let entries = self.list_directory_impl(dir, None, None).await?;
+            for entry in entries {
+                let child = dir.join(&entry.name);
+                // A symlinked folder is counted as the one entry it is, not
+                // walked: following links in a scan is how a loop becomes a
+                // hang.
+                if entry.is_directory && !entry.is_symlink {
+                    self.scan_directory(&child, ticker, into).await?;
+                } else {
+                    let size = entry.size.unwrap_or(0);
+                    into.file_count += 1;
+                    into.total_bytes += size;
+                    into.dedup_bytes += size;
+                    ticker.file(size);
+                }
+            }
+            Ok(())
+        })
+    }
+}

--- a/crates/cmdr-adb/src/volume/state.rs
+++ b/crates/cmdr-adb/src/volume/state.rs
@@ -1,0 +1,131 @@
+//! Where a volume's connection stands, and the rule that keeps the frontend from
+//! flickering.
+//!
+//! **A backend reports transitions, never states.** A device that is gone fails
+//! every operation aimed at it, and reporting each failure as news would flood a
+//! frontend that acted on the first one. So every report goes through
+//! [`AdbVolumeInner::emit_if_changed`], which swaps an atomic and stays quiet
+//! when the value didn't move.
+//!
+//! ❗ **A retired volume stays silent.** Once a newer instance owns the id, this
+//! one's news would describe a volume that no longer exists under that name.
+
+use std::sync::atomic::Ordering;
+
+use cmdr_fs::volume::VolumeError;
+use cmdr_fs::volume::host::events::VolumeConnection;
+use cmdr_fs::volume::{Retirement, Retires};
+
+use super::{AdbVolume, AdbVolumeInner};
+
+/// How this volume's device stands.
+///
+/// Two values: there is no credential to ask for on this backend (the device
+/// authorizes the HOST, once, on its own screen), so nothing rests between
+/// "up" and "gone".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ConnectionState {
+    /// The device answers sync requests.
+    Connected = 0,
+    /// The device is gone or not answering, and something is expected to retry.
+    Disconnected = 1,
+}
+
+impl ConnectionState {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Connected,
+            _ => Self::Disconnected,
+        }
+    }
+}
+
+/// Widens the backend's own state into the enum every connecting backend reports
+/// in. ❌ Deliberately not the frontend's wire enum: `events::volume_mapping`
+/// owns that translation.
+impl From<ConnectionState> for VolumeConnection {
+    fn from(state: ConnectionState) -> Self {
+        match state {
+            ConnectionState::Connected => Self::Connected,
+            ConnectionState::Disconnected => Self::Disconnected,
+        }
+    }
+}
+
+impl Retires for AdbVolumeInner {
+    fn retirement(&self) -> &Retirement {
+        &self.retirement
+    }
+}
+
+impl AdbVolumeInner {
+    /// Where the connection stands right now.
+    pub(super) fn connection_state(&self) -> ConnectionState {
+        ConnectionState::from_u8(self.state.load(Ordering::Relaxed))
+    }
+
+    /// Records that the device is gone ❗ without reporting it, for the paths
+    /// where the volume is LEAVING: the frontend learns through
+    /// `volumes-changed`, and a `disconnected` alongside it would race that into
+    /// a banner for a volume no longer in the sidebar.
+    pub(super) fn mark_gone_silently(&self) {
+        self.state.store(ConnectionState::Disconnected as u8, Ordering::Relaxed);
+    }
+
+    /// Moves to `next` and reports it, ❗ only if that is a change.
+    pub(super) fn emit_if_changed(&self, next: ConnectionState) -> bool {
+        let previous = self.state.swap(next as u8, Ordering::Relaxed);
+        if previous == next as u8 {
+            return false;
+        }
+        if !self.retirement.is_retired() {
+            self.host.events().connection_changed(&self.volume_id, next.into());
+        }
+        true
+    }
+
+    /// Re-runs the hello, single-flight, and reports the outcome as a
+    /// transition.
+    pub(super) async fn do_attempt_reconnect(&self) -> Result<(), VolumeError> {
+        let _guard = self.reconnect_lock.lock().await;
+        if self.unmounted.load(Ordering::Relaxed) || self.retirement.is_retired() {
+            return Err(VolumeError::DeviceDisconnected(self.volume_id.clone()));
+        }
+        match self.hello().await {
+            Ok(()) => {
+                self.emit_if_changed(ConnectionState::Connected);
+                Ok(())
+            }
+            Err(e) => {
+                self.emit_if_changed(ConnectionState::Disconnected);
+                Err(self.map_adb_error(e, "/"))
+            }
+        }
+    }
+}
+
+impl AdbVolume {
+    /// Reads a failed operation's answer for "the device is gone" and reports
+    /// the transition once.
+    ///
+    /// Operations ARE the detector on this backend: there is no watcher, so a
+    /// device that went away is invisible until something asks it for
+    /// something.
+    pub(super) fn note_lost_session(&self, error: &VolumeError) {
+        if matches!(
+            error,
+            VolumeError::DeviceDisconnected(_) | VolumeError::ConnectionTimeout(_)
+        ) {
+            self.inner.emit_if_changed(ConnectionState::Disconnected);
+        }
+    }
+
+    /// The device tracker saw this serial leave the list.
+    ///
+    /// Published so the app can retire the volume the moment `track-devices`
+    /// says so, rather than waiting for the next operation to fail on it.
+    pub fn note_device_gone(&self) {
+        self.inner.emit_if_changed(ConnectionState::Disconnected);
+    }
+}

--- a/crates/cmdr-adb/src/volume/streams.rs
+++ b/crates/cmdr-adb/src/volume/streams.rs
@@ -1,0 +1,266 @@
+//! The byte path: one `RECV` socket per file out, one `SEND` socket per file
+//! in.
+//!
+//! The sync service streams a file as a sequence of `DATA` frames of at most
+//! `MAX_DATA_CHUNK` bytes and ends it with `DONE`, so a read is exactly the
+//! chunk shape [`ChannelReadStream`] wants and ❌ nothing here ever holds a
+//! whole file. The producer runs on the host's runtime and stops on the first
+//! of: the file ending, the consumer going away, or the stream's cancel.
+
+use std::ops::ControlFlow;
+use std::path::Path;
+
+use cmdr_fs::staging::STAGING_TEMP_MARKER;
+use cmdr_fs::volume::{ChannelReadStream, VolumeError, VolumeReadStream};
+use log::debug;
+
+use super::AdbVolume;
+use super::paths::join_device_path;
+use crate::errors::{ENOENT, volume_error_from_errno};
+use crate::sync::{MAX_DATA_CHUNK, SyncEntryKind, SyncSession};
+
+/// Chunks buffered between the producer and the consumer. Peak memory per
+/// stream is `this * MAX_DATA_CHUNK`, regardless of file size.
+const STREAM_CHANNEL_CAPACITY: usize = 4;
+
+/// The mode a fresh file lands with: `rw-rw----`, what `adb push` uses.
+const NEW_FILE_MODE: u32 = 0o100660;
+
+impl AdbVolume {
+    /// Opens `[offset, size)` of `path` for streaming.
+    ///
+    /// The size is settled by a `stat` before this returns, so the caller has
+    /// an honest `total_size()` from its first progress tick. `RECV` has no
+    /// offset of its own, so a non-zero `offset` is honored by discarding bytes
+    /// as they arrive: correct, and the cost of a resume on this protocol.
+    pub(super) async fn open_read_stream_impl(
+        &self,
+        path: &Path,
+        offset: u64,
+    ) -> Result<ChannelReadStream, VolumeError> {
+        let device = self.to_device_path(path)?;
+        let mut session = self.open_sync(&device).await?;
+        let stat = session
+            .stat(&device)
+            .await
+            .map_err(|e| self.inner.map_adb_error(e, &device))?;
+        if !stat.exists() {
+            session.quit().await;
+            return Err(volume_error_from_errno(stat.errno.unwrap_or(ENOENT), &device));
+        }
+        if stat.kind() == SyncEntryKind::Directory {
+            session.quit().await;
+            return Err(VolumeError::IsADirectory(device));
+        }
+        let total_size = stat.size;
+
+        let (chunk_tx, chunk_rx) = tokio::sync::mpsc::channel::<Result<Vec<u8>, VolumeError>>(STREAM_CHANNEL_CAPACITY);
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+        let inner = std::sync::Arc::clone(&self.inner);
+        // ❌ Never `tokio::spawn` here: a backend inherits whatever runtime it
+        // is called on, and some of those have none.
+        self.inner
+            .host
+            .runtime()
+            .spawn(async move { produce(inner, session, device, offset, chunk_tx, cancel_rx).await });
+
+        Ok(ChannelReadStream::new(chunk_rx, cancel_tx, total_size))
+    }
+
+    /// Streams `stream` onto `dest` through a staging sibling, then moves it
+    /// into place.
+    ///
+    /// `SEND` writes the file at the name it is given, byte by byte, so the
+    /// name holds a partial for the whole upload. It lands on
+    /// `<name>.cmdr-tmp-<n>` beside the destination and takes the real name by
+    /// one `mv -f`, so nothing half-written ever wears the user's filename; on
+    /// any failure the staging name is removed. ❗ Cancellation arrives only
+    /// through `on_progress` answering `Break`: there is no token on this path.
+    pub(super) async fn write_from_stream_impl(
+        &self,
+        dest: &Path,
+        size: u64,
+        mut stream: Box<dyn VolumeReadStream>,
+        on_progress: &(dyn Fn(u64, u64) -> ControlFlow<()> + Sync),
+    ) -> Result<u64, VolumeError> {
+        let device = self.to_device_path(dest)?;
+        let staging = staging_name_for(&device);
+        debug!("AdbVolume::write_from_stream: {device} via {staging}, size={size}");
+
+        let mut session = self.open_sync(&device).await?;
+        let pumped = self
+            .pump(&mut session, &staging, &device, size, &mut stream, on_progress)
+            .await;
+        session.quit().await;
+
+        match pumped {
+            Ok(written) => {
+                if let Err(e) = self.shell_verb(&["mv", "-f", &staging, &device], &device).await {
+                    self.remove_partial(&staging).await;
+                    return Err(e);
+                }
+                self.notify_created(dest).await;
+                Ok(written)
+            }
+            Err(e) => {
+                self.remove_partial(&staging).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// The upload itself: `SEND`, one `DATA` frame per chunk, `DONE` with the
+    /// mtime, progress after every chunk the device took.
+    async fn pump(
+        &self,
+        session: &mut SyncSession,
+        staging: &str,
+        device: &str,
+        size: u64,
+        stream: &mut Box<dyn VolumeReadStream>,
+        on_progress: &(dyn Fn(u64, u64) -> ControlFlow<()> + Sync),
+    ) -> Result<u64, VolumeError> {
+        let map = |e| self.inner.map_adb_error(e, device);
+        session.send_start(staging, NEW_FILE_MODE).await.map_err(map)?;
+        let mut written = 0u64;
+        while let Some(chunk) = stream.next_chunk().await {
+            let chunk = chunk?;
+            for piece in chunk.chunks(MAX_DATA_CHUNK) {
+                session.send_chunk(piece).await.map_err(map)?;
+                written += piece.len() as u64;
+            }
+            if on_progress(written, size).is_break() {
+                return Err(VolumeError::Cancelled(device.to_string()));
+            }
+        }
+        let mtime = u32::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        )
+        .unwrap_or(u32::MAX);
+        session.send_finish(mtime).await.map_err(map)?;
+        Ok(written)
+    }
+
+    /// Best-effort removal of a partial upload. A failure here must never
+    /// replace the error that caused it.
+    async fn remove_partial(&self, staging: &str) {
+        if let Err(e) = crate::shell::run(&self.inner.endpoint, &self.inner.serial, &["rm", "-f", staging]).await {
+            debug!("AdbVolume::write_from_stream: couldn't remove the partial {staging}: {e:?}");
+        }
+    }
+}
+
+/// `<dir>/<name>.cmdr-tmp-<pid>-<n>`: the house marker, so a leftover from a
+/// crash is recognized as Cmdr's, and a counter so two uploads of one name
+/// never share a partial.
+fn staging_name_for(device: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let (parent, name) = match device.rfind('/') {
+        Some(at) => (&device[..at.max(1)], &device[at + 1..]),
+        None => ("/", device),
+    };
+    join_device_path(
+        parent,
+        &format!(
+            "{name}{STAGING_TEMP_MARKER}{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ),
+    )
+}
+
+/// The producer half of a read stream: `RECV`, then chunks until the file, the
+/// consumer, or a cancellation ends it.
+async fn produce(
+    inner: std::sync::Arc<super::AdbVolumeInner>,
+    mut session: SyncSession,
+    device: String,
+    offset: u64,
+    chunk_tx: tokio::sync::mpsc::Sender<Result<Vec<u8>, VolumeError>>,
+    mut cancel_rx: tokio::sync::oneshot::Receiver<()>,
+) {
+    if let Err(e) = session.recv_start(&device).await {
+        let _ = chunk_tx.send(Err(inner.map_adb_error(e, &device))).await;
+        return;
+    }
+    let mut to_skip = offset;
+    loop {
+        let next = tokio::select! {
+            biased;
+            _ = &mut cancel_rx => {
+                debug!("AdbVolume::open_read_stream({device}): cancelled");
+                break;
+            }
+            next = session.recv_chunk() => next,
+        };
+        match next {
+            Ok(Some(mut bytes)) => {
+                if to_skip > 0 {
+                    let drop_now = (to_skip.min(bytes.len() as u64)) as usize;
+                    bytes.drain(..drop_now);
+                    to_skip -= drop_now as u64;
+                }
+                if !bytes.is_empty() && chunk_tx.send(Ok(bytes)).await.is_err() {
+                    break;
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                let _ = chunk_tx.send(Err(inner.map_adb_error(e, &device))).await;
+                break;
+            }
+        }
+    }
+    // Closing the socket IS the release: the device stops sending the moment
+    // the transport goes, so a cancelled 2 GB read costs nothing further.
+    session.quit().await;
+}
+
+/// A stream over bytes already in hand, for `create_file`'s small payload.
+///
+/// ❌ Not a general-purpose reader: the only caller holds the bytes already,
+/// by contract (`Volume::create_file` takes a slice), so nothing here
+/// pre-buffers a file.
+pub(super) struct BytesReadStream {
+    bytes: Option<Vec<u8>>,
+    total: u64,
+    read: u64,
+}
+
+impl BytesReadStream {
+    pub(super) fn new(bytes: Vec<u8>) -> Self {
+        let total = bytes.len() as u64;
+        Self {
+            bytes: Some(bytes),
+            total,
+            read: 0,
+        }
+    }
+}
+
+impl VolumeReadStream for BytesReadStream {
+    fn next_chunk(
+        &mut self,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Option<Result<Vec<u8>, VolumeError>>> + Send + '_>> {
+        Box::pin(async move {
+            let bytes = self.bytes.take()?;
+            if bytes.is_empty() {
+                return None;
+            }
+            self.read += bytes.len() as u64;
+            Some(Ok(bytes))
+        })
+    }
+
+    fn total_size(&self) -> u64 {
+        self.total
+    }
+
+    fn bytes_read(&self) -> u64 {
+        self.read
+    }
+}

--- a/crates/cmdr-adb/src/volume/testing.rs
+++ b/crates/cmdr-adb/src/volume/testing.rs
@@ -1,0 +1,59 @@
+//! Fixtures for the ADB volume suites, on both sides of the crate boundary.
+//!
+//! Gated behind the `testing` feature, so it exists in dev targets and in no
+//! shipped build. The fake server itself is `crate::testing::FakeAdbServer`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8};
+
+use cmdr_fs::volume::host::VolumeHost;
+use cmdr_fs::volume::host::listings::RecordingListings;
+use cmdr_fs::volume::{Retirement, adb_volume_id};
+use tokio_util::sync::CancellationToken;
+
+use super::{AdbVolume, AdbVolumeInner, ConnectionState, connect_adb_volume};
+use crate::features::DeviceFeatures;
+use crate::params::AdbConnectionParams;
+use crate::server::AdbEndpoint;
+use crate::testing::FakeAdbServer;
+
+/// The serial every fixture device answers to: the fake server's own.
+pub const FIXTURE_SERIAL: &str = crate::testing::FAKE_SERIAL;
+
+/// A volume with no server behind it, for the pure paths (path translation,
+/// capability answers). Every wire-touching call on it fails.
+pub fn detached_volume() -> AdbVolume {
+    AdbVolume {
+        name: "Fixture phone".to_string(),
+        root: PathBuf::from("/"),
+        inner: Arc::new(AdbVolumeInner {
+            volume_id: adb_volume_id(FIXTURE_SERIAL),
+            serial: FIXTURE_SERIAL.to_string(),
+            endpoint: AdbEndpoint::at(std::net::SocketAddr::from(([127, 0, 0, 1], 1))),
+            features: DeviceFeatures::all(),
+            state: AtomicU8::new(ConnectionState::Connected as u8),
+            retirement: Retirement::new(),
+            unmounted: AtomicBool::new(false),
+            reconnect_lock: tokio::sync::Mutex::new(()),
+            host: VolumeHost::detached(),
+        }),
+    }
+}
+
+/// Connects to the fake server's device `serial` through a host that records
+/// what the volume tells its panes.
+pub async fn connect_fake(server: &FakeAdbServer, serial: &str) -> (Arc<AdbVolume>, Arc<RecordingListings>) {
+    let listings = Arc::new(RecordingListings::new());
+    let host = VolumeHost::builder()
+        .listings(Arc::clone(&listings) as Arc<dyn cmdr_fs::volume::host::listings::ListingHost>)
+        .build();
+    let volume = connect_adb_volume(
+        AdbConnectionParams::at(serial, server.endpoint()),
+        host,
+        CancellationToken::new(),
+    )
+    .await
+    .unwrap_or_else(|e| panic!("connecting to the fake server's {serial} must work, got {e:?}"));
+    (Arc::new(volume), listings)
+}

--- a/crates/cmdr-adb/src/volume/volume_impl.rs
+++ b/crates/cmdr-adb/src/volume/volume_impl.rs
@@ -1,0 +1,368 @@
+//! The whole `impl Volume`: the capability answers, and one-line delegators to
+//! the modules that do the work.
+//!
+//! Every answer here is deliberate. A default this backend accepts silently is
+//! a promise it may not be able to keep: `supports_local_fs_access` defaults
+//! to `true` in the trait, and a device path handed to the OS opens nothing.
+
+use std::ops::ControlFlow;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use cmdr_fs::entry::FileEntry;
+use cmdr_fs::volume::{
+    BatchScanResult, CopyScanResult, DirectoryCreation, LaneKey, ListingProgress, MutationEvent, Retirement,
+    ScanConflict, SignInPrompt, SourceItemInfo, SpaceInfo, Volume, VolumeError, VolumeReadStream, WatchCoverage,
+};
+use tokio_util::sync::CancellationToken;
+
+use super::{AdbVolume, BACKEND};
+use crate::shell;
+
+impl AdbVolume {
+    /// Runs `work`, noticing on the way out if the answer says the device is
+    /// gone.
+    ///
+    /// ❗ Every delegator below that can reach the wire wraps itself in this:
+    /// with no watcher on this backend, a gone device is invisible until an
+    /// operation asks it for something, so the operations ARE the detector.
+    async fn noting<T>(&self, work: impl Future<Output = Result<T, VolumeError>> + Send) -> Result<T, VolumeError> {
+        let outcome = work.await;
+        if let Err(error) = &outcome {
+            self.note_lost_session(error);
+        }
+        outcome
+    }
+}
+
+impl Volume for AdbVolume {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    /// The DEVICE: one USB pipe, whatever path a transfer touches on it.
+    fn lane_key(&self) -> LaneKey {
+        LaneKey::new(format!("adb:{}", self.inner.serial))
+    }
+
+    /// Read per batch dispatch, ❗ never captured at construction. The app's
+    /// table answers 1 for this namespace: one sync socket at a time is what a
+    /// phone's `adbd` serves without thrashing.
+    fn max_concurrent_ops(&self) -> usize {
+        self.inner.host.settings().max_concurrent_operations(BACKEND)
+    }
+
+    fn list_directory<'a>(
+        &'a self,
+        path: &'a Path,
+        on_progress: Option<&'a (dyn Fn(ListingProgress) + Sync)>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<FileEntry>, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.list_directory_impl(path, on_progress, None)))
+    }
+
+    fn list_directory_with_cancel<'a>(
+        &'a self,
+        path: &'a Path,
+        on_progress: Option<&'a (dyn Fn(ListingProgress) + Sync)>,
+        cancel: Option<&'a CancellationToken>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<FileEntry>, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.list_directory_impl(path, on_progress, cancel)))
+    }
+
+    fn list_directory_for_scan<'a>(
+        &'a self,
+        path: &'a Path,
+        cancel: Option<&'a CancellationToken>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<FileEntry>, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.list_directory_impl(path, None, cancel)))
+    }
+
+    fn get_metadata<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<FileEntry, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.get_metadata_impl(path)))
+    }
+
+    fn exists<'a>(&'a self, path: &'a Path) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+        Box::pin(self.exists_impl(path))
+    }
+
+    fn is_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.is_directory_impl(path)))
+    }
+
+    // ── The byte path ────────────────────────────────────────────────
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    /// ❗ Implementing the read path does not declare it: the copy engine
+    /// refuses a source answering `false` before it opens anything.
+    fn supports_export(&self) -> bool {
+        true
+    }
+
+    #[allow(
+        clippy::type_complexity,
+        reason = "async trait method returns a pinned boxed future by design"
+    )]
+    fn open_read_stream<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn VolumeReadStream>, VolumeError>> + Send + 'a>> {
+        self.open_read_stream_at_offset(path, 0)
+    }
+
+    #[allow(
+        clippy::type_complexity,
+        reason = "async trait method returns a pinned boxed future by design"
+    )]
+    fn open_read_stream_with_hint<'a>(
+        &'a self,
+        path: &'a Path,
+        _size_hint: Option<u64>,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn VolumeReadStream>, VolumeError>> + Send + 'a>> {
+        self.open_read_stream_at_offset(path, 0)
+    }
+
+    #[allow(
+        clippy::type_complexity,
+        reason = "async trait method returns a pinned boxed future by design"
+    )]
+    fn open_read_stream_for_scan<'a>(
+        &'a self,
+        path: &'a Path,
+        _size_hint: Option<u64>,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn VolumeReadStream>, VolumeError>> + Send + 'a>> {
+        self.open_read_stream_at_offset(path, 0)
+    }
+
+    /// `RECV` has no offset, so `[offset, size)` is honored by discarding the
+    /// head as it arrives (`streams.rs`).
+    #[allow(
+        clippy::type_complexity,
+        reason = "async trait method returns a pinned boxed future by design"
+    )]
+    fn open_read_stream_at_offset<'a>(
+        &'a self,
+        path: &'a Path,
+        offset: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn VolumeReadStream>, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(async move {
+            let stream = self.open_read_stream_impl(path, offset).await?;
+            Ok(Box::new(stream) as Box<dyn VolumeReadStream>)
+        }))
+    }
+
+    // ── The write path ───────────────────────────────────────────────
+
+    /// Every mutation below is implemented, so New folder, New file, Rename,
+    /// and Paste are honestly enabled.
+    fn is_writable(&self) -> bool {
+        true
+    }
+
+    fn create_file<'a>(
+        &'a self,
+        path: &'a Path,
+        content: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = Result<(), VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.create_file_impl(path, content)))
+    }
+
+    fn create_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<(), VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.create_directory_impl(path)))
+    }
+
+    fn create_directory_all<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<DirectoryCreation, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.create_directory_all_impl(path)))
+    }
+
+    /// `mkdir -p` succeeds on a directory that is already there, so the
+    /// folder-merge walker pre-checks existence here the way it does on MTP.
+    fn create_directory_errors_on_existing_dir(&self) -> bool {
+        false
+    }
+
+    fn delete<'a>(&'a self, path: &'a Path) -> Pin<Box<dyn Future<Output = Result<(), VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.delete_impl(path)))
+    }
+
+    fn delete_with_cancel<'a>(
+        &'a self,
+        path: &'a Path,
+        cancel: Option<&'a CancellationToken>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(async move {
+            if cancel.is_some_and(CancellationToken::is_cancelled) {
+                return Err(VolumeError::Cancelled(path.to_string_lossy().into_owned()));
+            }
+            self.delete_impl(path).await
+        }))
+    }
+
+    fn rename<'a>(
+        &'a self,
+        from: &'a Path,
+        to: &'a Path,
+        force: bool,
+    ) -> Pin<Box<dyn Future<Output = Result<(), VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.rename_impl(from, to, force)))
+    }
+
+    fn write_from_stream<'a>(
+        &'a self,
+        dest: &'a Path,
+        size: u64,
+        stream: Box<dyn VolumeReadStream>,
+        on_progress: &'a (dyn Fn(u64, u64) -> ControlFlow<()> + Sync),
+    ) -> Pin<Box<dyn Future<Output = Result<u64, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.write_from_stream_impl(dest, size, stream, on_progress)))
+    }
+
+    fn copy_within<'a>(
+        &'a self,
+        from: &'a Path,
+        to: &'a Path,
+        on_progress: &'a (dyn Fn(u64, u64) -> ControlFlow<()> + Sync),
+    ) -> Pin<Box<dyn Future<Output = Result<u64, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.copy_within_impl(from, to, on_progress)))
+    }
+
+    /// ❗ No watcher here, so this patch is the ONLY thing that keeps a
+    /// destination pane honest after a copy.
+    fn notify_mutation<'a>(
+        &'a self,
+        _volume_id: &'a str,
+        parent_path: &'a Path,
+        mutation: MutationEvent,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(self.notify_mutation_impl(parent_path, mutation))
+    }
+
+    // ── Scanning, before a copy runs ─────────────────────────────────
+
+    fn scan_for_copy<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<CopyScanResult, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.scan_for_copy_impl(path)))
+    }
+
+    fn scan_for_copy_batch_with_progress<'a>(
+        &'a self,
+        paths: &'a [PathBuf],
+        on_progress: Option<&'a (dyn Fn(ListingProgress) + Sync)>,
+    ) -> Pin<Box<dyn Future<Output = Result<BatchScanResult, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.scan_for_copy_batch_impl(paths, on_progress)))
+    }
+
+    fn scan_for_conflicts<'a>(
+        &'a self,
+        source_items: &'a [SourceItemInfo],
+        dest_path: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<ScanConflict>, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(self.scan_for_conflicts_impl(source_items, dest_path)))
+    }
+
+    // ── Lifecycle ────────────────────────────────────────────────────
+
+    fn retirement(&self) -> Option<&Retirement> {
+        Some(&self.inner.retirement)
+    }
+
+    fn on_superseded(&self) {
+        self.inner.retirement.retire();
+    }
+
+    /// ❌ No connection event: the frontend learns through `volumes-changed`.
+    fn on_unmount(&self) {
+        self.inner.unmounted.store(true, Ordering::Relaxed);
+        self.inner.mark_gone_silently();
+    }
+
+    /// The device authorizes the HOST on its own screen; there is no secret a
+    /// person could type here.
+    fn sign_in_prompt(&self) -> SignInPrompt {
+        SignInPrompt::Nothing
+    }
+
+    fn attempt_reconnect<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<(), VolumeError>> + Send + 'a>> {
+        Box::pin(self.inner.do_attempt_reconnect())
+    }
+
+    // ── What this backend is, in capability terms ────────────────────
+
+    /// No mount, so no local path and nothing the OS can open. ❗ The trait
+    /// default is `true`.
+    fn supports_local_fs_access(&self) -> bool {
+        false
+    }
+
+    fn paths_are_os_visible(&self) -> bool {
+        false
+    }
+
+    fn local_path(&self) -> Option<PathBuf> {
+        None
+    }
+
+    fn operations_are_local(&self) -> bool {
+        false
+    }
+
+    /// ❗ No watcher, so ❌ nothing here may call `authoritative_listing`.
+    fn can_watch_listings(&self) -> bool {
+        false
+    }
+
+    fn listing_watch_coverage(&self, _path: &Path) -> WatchCoverage {
+        WatchCoverage::None
+    }
+
+    /// `df -k` on the volume root, parsed by the shell module.
+    fn get_space_info<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<SpaceInfo, VolumeError>> + Send + 'a>> {
+        Box::pin(self.noting(async move {
+            let root = self.to_device_path(&self.root)?;
+            let outcome = shell::run(&self.inner.endpoint, &self.inner.serial, &["df", "-k", &root])
+                .await
+                .map_err(|e| self.inner.map_adb_error(e, &root))?;
+            if !outcome.succeeded() {
+                return Err(VolumeError::NotSupported);
+            }
+            let parts =
+                shell::parse_df_k(&String::from_utf8_lossy(&outcome.stdout)).ok_or(VolumeError::NotSupported)?;
+            Ok(SpaceInfo {
+                total_bytes: parts.total_bytes,
+                available_bytes: parts.available_bytes,
+                used_bytes: parts.total_bytes.saturating_sub(parts.available_bytes),
+            })
+        }))
+    }
+
+    /// A shell round trip per poll, so well above the local 2 s.
+    fn space_poll_interval(&self) -> Option<Duration> {
+        Some(Duration::from_secs(30))
+    }
+}

--- a/crates/cmdr-adb/src/volume/volume_impl_test.rs
+++ b/crates/cmdr-adb/src/volume/volume_impl_test.rs
@@ -1,0 +1,242 @@
+//! The capability answers and the connect's refusals, against the fake server.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cmdr_fs::volume::host::VolumeHost;
+use cmdr_fs::volume::host::events::{RecordingVolumeEvents, VolumeConnection};
+use cmdr_fs::volume::{LaneKey, SignInPrompt, Volume, WatchCoverage, adb_volume_id};
+use tokio_util::sync::CancellationToken;
+
+use super::testing::{FIXTURE_SERIAL, connect_fake, detached_volume};
+use super::{ConnectionState, connect_adb_volume};
+use crate::devices::{AdbDevice, AdbDeviceState};
+use crate::errors::AdbConnectError;
+use crate::params::AdbConnectionParams;
+use crate::testing::{FakeAdbServer, FakeTree, fake_device};
+
+#[test]
+fn the_device_anchored_answers() {
+    let volume = detached_volume();
+    assert_eq!(volume.root(), Path::new("/"));
+    assert_eq!(volume.volume_id(), adb_volume_id(FIXTURE_SERIAL));
+    assert_eq!(volume.lane_key(), LaneKey::new(format!("adb:{FIXTURE_SERIAL}")));
+    assert!(volume.rerooted(Path::new("/other")).is_none());
+    assert!(volume.supports_export());
+    assert!(volume.is_writable());
+    assert!(volume.supports_streaming());
+    assert!(!volume.can_watch_listings());
+    assert_eq!(volume.listing_watch_coverage(Path::new("/sdcard")), WatchCoverage::None);
+    assert!(!volume.supports_local_fs_access());
+    assert!(!volume.paths_are_os_visible());
+    assert!(!volume.operations_are_local());
+    assert!(volume.local_path().is_none());
+    assert!(!volume.create_directory_errors_on_existing_dir());
+    assert_eq!(volume.space_poll_interval(), Some(Duration::from_secs(30)));
+    assert_eq!(volume.sign_in_prompt(), SignInPrompt::Nothing);
+    assert!(volume.retirement().is_some());
+    assert_eq!(volume.connection_state(), ConnectionState::Connected);
+    // The pure fold the frontend reads agrees with the predicates.
+    let capabilities = volume.capabilities();
+    assert!(capabilities.can_export);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connecting_names_the_device_and_says_hello() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let (volume, _) = connect_fake(&server, FIXTURE_SERIAL).await;
+    assert_eq!(volume.name(), "Fake Phone");
+    assert_eq!(volume.device_name(), "Fake Phone");
+    assert_eq!(volume.serial(), FIXTURE_SERIAL);
+    assert!(volume.features().shell_v2);
+    assert!(volume.exists(Path::new("/")).await);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_serial_the_server_does_not_list_is_device_gone() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let outcome = connect_adb_volume(
+        AdbConnectionParams::at("nope", server.endpoint()),
+        VolumeHost::detached(),
+        CancellationToken::new(),
+    )
+    .await;
+    assert!(
+        matches!(outcome, Err(AdbConnectError::DeviceGone(ref s)) if s == "nope"),
+        "{:?}",
+        outcome.err()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unauthorized_device_is_reported_as_such() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    server.push_devices(vec![AdbDevice {
+        state: AdbDeviceState::Unauthorized,
+        ..fake_device()
+    }]);
+    let outcome = connect_adb_volume(
+        AdbConnectionParams::at(FIXTURE_SERIAL, server.endpoint()),
+        VolumeHost::detached(),
+        CancellationToken::new(),
+    )
+    .await;
+    assert!(
+        matches!(outcome, Err(AdbConnectError::Unauthorized(_))),
+        "{:?}",
+        outcome.err()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_device_without_shell_v2_is_too_old() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    server.set_features("stat_v2,ls_v2");
+    let outcome = connect_adb_volume(
+        AdbConnectionParams::at(FIXTURE_SERIAL, server.endpoint()),
+        VolumeHost::detached(),
+        CancellationToken::new(),
+    )
+    .await;
+    assert!(
+        matches!(outcome, Err(AdbConnectError::DeviceTooOld { .. })),
+        "{:?}",
+        outcome.err()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_cancelled_connect_answers_cancelled() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let outcome = connect_adb_volume(
+        AdbConnectionParams::at(FIXTURE_SERIAL, server.endpoint()),
+        VolumeHost::detached(),
+        cancel,
+    )
+    .await;
+    assert!(
+        matches!(outcome, Err(AdbConnectError::Cancelled)),
+        "{:?}",
+        outcome.err()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_listing_maps_kinds_sizes_and_symlinked_folders() {
+    let mut tree = FakeTree::new();
+    tree.add_dir("/sdcard")
+        .add_file("/sdcard/a.txt", b"hello")
+        .add_dir("/sdcard/DCIM")
+        .add_symlink("/sdcard/shortcut", "/sdcard/DCIM")
+        .add_symlink("/sdcard/alias.txt", "/sdcard/a.txt");
+    let server = FakeAdbServer::start(tree).await;
+    let (volume, _) = connect_fake(&server, FIXTURE_SERIAL).await;
+
+    let progress = std::sync::Mutex::new(Vec::new());
+    let entries = volume
+        .list_directory(Path::new("/sdcard"), Some(&|p| progress.lock().unwrap().push(p)))
+        .await
+        .expect("list");
+    let by_name = |name: &str| {
+        entries
+            .iter()
+            .find(|e| e.name == name)
+            .unwrap_or_else(|| panic!("{name}"))
+    };
+    assert_eq!(by_name("a.txt").size, Some(5));
+    assert_eq!(by_name("a.txt").path, "/sdcard/a.txt");
+    assert!(by_name("DCIM").is_directory);
+    assert!(by_name("shortcut").is_symlink, "a link stays a link");
+    assert!(
+        by_name("shortcut").is_directory,
+        "a link to a folder navigates like one"
+    );
+    assert!(by_name("alias.txt").is_symlink);
+    assert!(!by_name("alias.txt").is_directory);
+    let progress = progress.lock().unwrap();
+    assert_eq!(
+        progress.last().map(|p| p.entries()),
+        Some(4),
+        "one final report at least"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_listing_of_a_missing_directory_carries_the_path() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let (volume, _) = connect_fake(&server, FIXTURE_SERIAL).await;
+    let outcome = volume.list_directory(Path::new("/nowhere"), None).await;
+    assert!(
+        matches!(outcome, Err(cmdr_fs::volume::VolumeError::NotFound(ref p)) if p == "/nowhere"),
+        "{outcome:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn space_comes_from_df() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let (volume, _) = connect_fake(&server, FIXTURE_SERIAL).await;
+    let space = volume.get_space_info().await.expect("df -k");
+    assert_eq!(space.total_bytes, 118_120_468 * 1024);
+    assert_eq!(space.available_bytes, 96_764_008 * 1024);
+    assert_eq!(space.used_bytes, space.total_bytes - space.available_bytes);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_lost_device_is_reported_once_and_a_reconnect_reports_the_way_back() {
+    let server = FakeAdbServer::start(FakeTree::new()).await;
+    let events = Arc::new(RecordingVolumeEvents::new());
+    let host = VolumeHost::builder()
+        .events(Arc::clone(&events) as Arc<dyn cmdr_fs::volume::host::events::VolumeEventSink>)
+        .build();
+    let volume = connect_adb_volume(
+        AdbConnectionParams::at(FIXTURE_SERIAL, server.endpoint()),
+        host,
+        CancellationToken::new(),
+    )
+    .await
+    .expect("connect");
+
+    volume.note_device_gone();
+    volume.note_device_gone();
+    assert_eq!(volume.connection_state(), ConnectionState::Disconnected);
+    assert_eq!(
+        events.transitions(),
+        vec![(volume.volume_id().to_string(), VolumeConnection::Disconnected)],
+        "transitions, never states"
+    );
+
+    volume.attempt_reconnect().await.expect("the fake is still there");
+    assert_eq!(volume.connection_state(), ConnectionState::Connected);
+    assert_eq!(events.transitions().len(), 2);
+    assert_eq!(events.transitions()[1].1, VolumeConnection::Connected);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn every_write_patches_the_pane_once() {
+    let mut tree = FakeTree::new();
+    tree.add_dir("/sdcard");
+    let server = FakeAdbServer::start(tree).await;
+    let (volume, listings) = connect_fake(&server, FIXTURE_SERIAL).await;
+
+    volume
+        .create_file(Path::new("/sdcard/a.txt"), b"abc")
+        .await
+        .expect("create");
+    assert_eq!(listings.change_count(), 1);
+    volume.create_directory(Path::new("/sdcard/dir")).await.expect("mkdir");
+    assert_eq!(listings.change_count(), 2);
+    volume
+        .rename(Path::new("/sdcard/a.txt"), Path::new("/sdcard/b.txt"), false)
+        .await
+        .expect("rename");
+    assert_eq!(listings.change_count(), 3);
+    volume.delete(Path::new("/sdcard/b.txt")).await.expect("delete");
+    assert_eq!(listings.change_count(), 4);
+    // A scan is a read and reports nothing.
+    volume.scan_for_copy(Path::new("/sdcard")).await.expect("scan");
+    assert_eq!(listings.change_count(), 4);
+}

--- a/crates/cmdr-adb/src/volume/writes.rs
+++ b/crates/cmdr-adb/src/volume/writes.rs
@@ -1,0 +1,223 @@
+//! Changing what's on the device: create, delete, rename, copy, and the
+//! classification a failed shell verb gets.
+//!
+//! The sync service has no verb for any of these but "write a file", so the
+//! rest is the device's shell: `mkdir -p`, `rmdir`, `rm -f`, `mv -f`, `cp -a`.
+//! `shell_v2` carries the exit code, and the connect refuses a device without
+//! it, so every verb here can tell success from failure.
+//!
+//! ## Classifying a failed verb, ❌ without reading stderr
+//!
+//! `toybox`'s wording is not a contract and the device may be localized. So a
+//! non-zero exit is read through what the sync service says is at the path and
+//! its parent ([`AdbVolume::classify_failed_verb`]): parent missing →
+//! `NotFound(parent)`; parent there but not writable (`test -w`) →
+//! `PermissionDenied(path)`; anything else → `IoError` carrying stderr for the
+//! technical-details panel.
+//!
+//! ## The two accepted TOCTOU windows
+//!
+//! `create_file` and a `force = false` rename each `stat` the destination
+//! first and refuse on a hit. Neither can be made atomic on this protocol:
+//! `SEND` truncates unconditionally and `mv -n` exits 0 whether it moved or
+//! not (verified on Android 14 `toybox 0.8.9`, 2026-09-01). The window is the
+//! round trip between the stat and the verb, on a device only this host is
+//! writing to, and `conformance_test.rs` holds the refusal itself.
+
+use std::path::Path;
+
+use cmdr_fs::volume::{DirectoryCreation, VolumeError};
+use log::debug;
+
+use super::AdbVolume;
+use crate::errors::{ENOENT, ENOTEMPTY_DEVICE, volume_error_from_errno};
+use crate::shell;
+use crate::sync::SyncEntryKind;
+
+/// What the sync service says is at a path, for the classifier and the
+/// pre-flight probes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WhatIsThere {
+    /// A directory (or a link to one).
+    Directory,
+    /// Something that isn't a directory.
+    NotADirectory,
+    /// Nothing at all.
+    Nothing,
+}
+
+impl AdbVolume {
+    /// Writes `content` to a name nothing else holds, refusing an occupied one
+    /// (`writes.rs` § "The two accepted TOCTOU windows").
+    pub(super) async fn create_file_impl(&self, path: &Path, content: &[u8]) -> Result<(), VolumeError> {
+        let device = self.to_device_path(path)?;
+        debug!("AdbVolume::create_file: {device}, size={}", content.len());
+        if self.probe(&device).await != WhatIsThere::Nothing {
+            return Err(VolumeError::AlreadyExists(device));
+        }
+        let stream = Box::new(super::streams::BytesReadStream::new(content.to_vec()));
+        self.write_from_stream_impl(path, content.len() as u64, stream, &|_, _| {
+            std::ops::ControlFlow::Continue(())
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// `mkdir -p`: creates the directory and every missing ancestor, and
+    /// succeeds on one that is already there. That is what lets
+    /// `create_directory_errors_on_existing_dir` answer `false`.
+    pub(super) async fn create_directory_impl(&self, path: &Path) -> Result<(), VolumeError> {
+        let device = self.to_device_path(path)?;
+        debug!("AdbVolume::create_directory: {device}");
+        self.shell_verb(&["mkdir", "-p", &device], &device).await?;
+        self.notify_created(path).await;
+        Ok(())
+    }
+
+    /// The same verb, answering honestly whether the leaf was there before.
+    ///
+    /// ❗ `Created` is a promise the transfer driver SPENDS by skipping its
+    /// per-file destination conflict probe, so the leaf is stat'ed before the
+    /// `mkdir` and a hit answers `AlreadyExisted`.
+    pub(super) async fn create_directory_all_impl(&self, path: &Path) -> Result<DirectoryCreation, VolumeError> {
+        let device = self.to_device_path(path)?;
+        if device == "/" || self.probe(&device).await == WhatIsThere::Directory {
+            return Ok(DirectoryCreation::AlreadyExisted);
+        }
+        self.shell_verb(&["mkdir", "-p", &device], &device).await?;
+        self.notify_created(path).await;
+        Ok(DirectoryCreation::Created)
+    }
+
+    /// Deletes one file or one EMPTY directory.
+    ///
+    /// ❗ Strictly one node: `rmdir` for a directory, `rm -f` for anything else,
+    /// ❌ never `rm -r`. Real data-safety logic leans on the refusal: a
+    /// same-volume move keeps a skipped child's only copy purely by letting its
+    /// parent's delete fail, and that refusal carries `ENOTEMPTY`.
+    pub(super) async fn delete_impl(&self, path: &Path) -> Result<(), VolumeError> {
+        let device = self.to_device_path(path)?;
+        debug!("AdbVolume::delete: {device}");
+        match self.probe(&device).await {
+            WhatIsThere::Nothing => return Err(volume_error_from_errno(ENOENT, &device)),
+            WhatIsThere::Directory => {
+                if let Err(e) = self.shell_verb(&["rmdir", &device], &device).await {
+                    // The one refusal the contract names: something is still
+                    // inside. Asked of the sync service, not of stderr.
+                    let held = self.list_directory_impl(path, None, None).await.map(|e| !e.is_empty());
+                    if matches!(held, Ok(true)) {
+                        return Err(volume_error_from_errno(ENOTEMPTY_DEVICE, &device));
+                    }
+                    return Err(e);
+                }
+            }
+            WhatIsThere::NotADirectory => self.shell_verb(&["rm", "-f", &device], &device).await?,
+        }
+        self.notify_deleted(path).await;
+        Ok(())
+    }
+
+    /// Moves an entry, clearing the destination only when the caller said it
+    /// may (`writes.rs` § "The two accepted TOCTOU windows" for `force = false`).
+    pub(super) async fn rename_impl(&self, from: &Path, to: &Path, force: bool) -> Result<(), VolumeError> {
+        let device_from = self.to_device_path(from)?;
+        let device_to = self.to_device_path(to)?;
+        debug!("AdbVolume::rename: {device_from} → {device_to}, force={force}");
+        if !force && self.probe(&device_to).await != WhatIsThere::Nothing {
+            return Err(VolumeError::AlreadyExists(device_to));
+        }
+        if self.probe(&device_from).await == WhatIsThere::Nothing {
+            return Err(volume_error_from_errno(ENOENT, &device_from));
+        }
+        self.shell_verb(&["mv", "-f", &device_from, &device_to], &device_to)
+            .await?;
+        self.notify_renamed(from, to).await;
+        Ok(())
+    }
+
+    /// Copies one file on the device, without the bytes crossing USB.
+    ///
+    /// `cp` gives no progress, so the callback hears once, at the end, with the
+    /// size the source reported. The destination is truncated if it exists,
+    /// which is `write_from_stream`'s contract too.
+    pub(super) async fn copy_within_impl(
+        &self,
+        from: &Path,
+        to: &Path,
+        on_progress: &(dyn Fn(u64, u64) -> std::ops::ControlFlow<()> + Sync),
+    ) -> Result<u64, VolumeError> {
+        let device_from = self.to_device_path(from)?;
+        let device_to = self.to_device_path(to)?;
+        let source = self.get_metadata_impl(from).await?;
+        if source.is_directory {
+            return Err(VolumeError::IsADirectory(device_from));
+        }
+        let size = source.size.unwrap_or(0);
+        self.shell_verb(&["cp", "-f", &device_from, &device_to], &device_to)
+            .await?;
+        if on_progress(size, size).is_break() {
+            let _ = shell::run(&self.inner.endpoint, &self.inner.serial, &["rm", "-f", &device_to]).await;
+            return Err(VolumeError::Cancelled(device_to));
+        }
+        self.notify_created(to).await;
+        Ok(size)
+    }
+
+    // ── The shared pieces ────────────────────────────────────────────
+
+    /// Runs one shell verb and classifies a non-zero exit against `path`.
+    pub(super) async fn shell_verb(&self, argv: &[&str], path: &str) -> Result<(), VolumeError> {
+        let outcome = shell::run(&self.inner.endpoint, &self.inner.serial, argv)
+            .await
+            .map_err(|e| self.inner.map_adb_error(e, path))?;
+        if outcome.succeeded() {
+            return Ok(());
+        }
+        Err(self.classify_failed_verb(path, &outcome.stderr).await)
+    }
+
+    /// The failure of a verb aimed at `path`, read through what is at the path
+    /// and its parent now (`writes.rs` § "Classifying a failed verb").
+    async fn classify_failed_verb(&self, path: &str, stderr: &[u8]) -> VolumeError {
+        let parent = match path.rfind('/') {
+            Some(0) | None => "/".to_string(),
+            Some(at) => path[..at].to_string(),
+        };
+        if self.probe(&parent).await == WhatIsThere::Nothing {
+            return VolumeError::NotFound(parent);
+        }
+        let writable = shell::run(&self.inner.endpoint, &self.inner.serial, &["test", "-w", &parent])
+            .await
+            .map(|o| o.succeeded());
+        if matches!(writable, Ok(false)) {
+            return VolumeError::PermissionDenied(path.to_string());
+        }
+        let message = String::from_utf8_lossy(stderr).trim().to_string();
+        debug!("AdbVolume: a shell verb on {path} failed: {message}");
+        VolumeError::IoError {
+            message,
+            raw_os_error: None,
+        }
+    }
+
+    /// What the sync service says is at `device`. A link is followed, so a
+    /// link to a folder reads as a folder.
+    pub(super) async fn probe(&self, device: &str) -> WhatIsThere {
+        let Ok(mut session) = self.open_sync(device).await else {
+            return WhatIsThere::Nothing;
+        };
+        let stat = session.stat(device).await;
+        session.quit().await;
+        match stat {
+            Ok(stat) if stat.exists() => match stat.kind() {
+                SyncEntryKind::Directory => WhatIsThere::Directory,
+                SyncEntryKind::Symlink => match self.get_metadata_impl(Path::new(device)).await {
+                    Ok(entry) if entry.is_directory => WhatIsThere::Directory,
+                    _ => WhatIsThere::NotADirectory,
+                },
+                _ => WhatIsThere::NotADirectory,
+            },
+            _ => WhatIsThere::Nothing,
+        }
+    }
+}

--- a/crates/cmdr-fs/src/volume/ids.rs
+++ b/crates/cmdr-fs/src/volume/ids.rs
@@ -220,6 +220,19 @@ pub fn mtp_device_id(serial_or_location: &str) -> String {
     derived_id("mtp", serial_or_location, &[serial_or_location])
 }
 
+/// Build the ID for an Android device reached over ADB from its (opaque,
+/// verbatim) serial.
+///
+/// Its own scheme rather than a reuse of [`mtp_device_id`]: the same phone
+/// attached over USB is both an MTP device and an ADB device at once, and they
+/// are different storages (the curated media tree vs. the real filesystem) with
+/// different indexes. Keying both on the serial would let one's cache answer
+/// for the other. Routing the serial through the funnel keeps a `/`, `:`, or
+/// `.` in it out of the `index-{id}.db` filename.
+pub fn adb_volume_id(serial: &str) -> String {
+    derived_id("adb", serial, &[serial])
+}
+
 /// Whether `id` predates the current ID scheme, so the state it keys can never
 /// be reached again.
 ///

--- a/crates/cmdr-sftp/DETAILS.md
+++ b/crates/cmdr-sftp/DETAILS.md
@@ -1041,7 +1041,9 @@ The connection state rides `volume-connection-changed` as `VolumeConnection`, wh
 - **An SFTP volume doesn't appear in the sidebar.** `connectSftpVolume` registers it in the volume registry, so
   navigating by `volumeId` works and every write path can reach it, but `volume_listing::complete` (which builds what
   `listVolumes` returns) has no SFTP arm. Adding one is the sidebar's own design question — which section, what icon,
-  what an eject means — and it belongs with the sign-in UI rather than ahead of it.
+  what an eject means — and it belongs with the sign-in UI rather than ahead of it. The device-provider seam
+  (`apps/desktop/src-tauri/src/device_volumes.rs`, which MTP and ADB register through) is NOT that arm: it lists
+  things that appear and leave on their own, and a server is signed into, not plugged in.
 - **`resolve_path_volume` / `resolve_location` don't answer for a remote path.** SFTP paths are plain server-side
   absolute paths with no `sftp://` scheme in front, so `/srv/data/x` on a server is spelled exactly like a local path.
   Whatever the sidebar does about identity, path resolution has to agree with it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,6 +152,13 @@ All under `apps/desktop/src-tauri/src/`.
 - `secrets/`: Pluggable secret storage: Keychain (macOS), Secret Service (Linux), encrypted-file fallback. SMB creds +
   AI keys
 - `mtp/`: MTP device management, file ops, event-based watching
+- `adb/`: the app-side half of the Android-over-ADB backend (`crates/cmdr-adb/`): the `host:track-devices` task, the
+  `AdbDeviceProvider`, lazy connect on first navigation, eject (forget the device client-side), and the IPC commands.
+  See `adb/CLAUDE.md`
+- `device_volumes.rs`: the device-provider seam. A `DeviceVolumeProvider` per device backend (`MtpDeviceProvider`,
+  `AdbDeviceProvider`), a registry `volume_listing::complete` folds over, and `notify_devices_changed`, the one hotplug
+  push channel (it emits `volumes-changed`). Contract in the module doc; the checklist step in
+  `file_system/volume/DETAILS.md` § "Building a new volume"
 - `mcp/`: MCP server (tools, YAML resources, agent-centric API)
 - `ai/`: llama-server lifecycle, model download, inference client
 - `analytics/`: Anonymous beta usage analytics: hourly `/heartbeat` sender (true DAU + a PII-free config-shape snapshot
@@ -208,8 +215,8 @@ All under `apps/desktop/src-tauri/src/`.
   `file_system/volume/`. `get_favorites()` reads the `favorites/` store
 - `volumes_linux/`: Linux equivalent: location discovery + mount/unmount via `/proc/mounts` and GVFS
 - `volume_listing.rs`: the one volume-list pipeline. Aliases whichever discovery module the platform has, bounds it with
-  a timeout, appends the MTP storages, and enriches from the registry; `commands/volumes.rs` and `volume_broadcast.rs`
-  both publish what it returns. See `apps/desktop/src-tauri/src/volumes/CLAUDE.md`
+  a timeout, appends every device provider's storages (`device_volumes.rs`), and enriches from the registry;
+  `commands/volumes.rs` and `volume_broadcast.rs` both publish what it returns. See `apps/desktop/src-tauri/src/volumes/CLAUDE.md`
 - `space_poller.rs`: Live disk-space polling (per-volume-type intervals) plus the low-disk-space hysteresis warning
 - `fda_gate.rs`: Full Disk Access startup gate: blocks TCC reads + `NSWorkspace` icon calls until FDA is decided. See
   the `tauri-apis` rule in `.claude/rules/`
@@ -248,8 +255,8 @@ All under `apps/desktop/src-tauri/src/`.
 
 ## Workspace crates
 
-All under `crates/`, alongside the four apps. `cmdr-fs`, `cmdr-index`, `cmdr-archive`, `cmdr-smb`, and `cmdr-sftp` carry
-no `tauri` dependency and no reach into the app; `index-crate-isolation` enforces that against the `cargo metadata`
+All under `crates/`, alongside the four apps. `cmdr-fs`, `cmdr-index`, `cmdr-archive`, `cmdr-smb`, `cmdr-sftp`, and
+`cmdr-adb` carry no `tauri` dependency and no reach into the app; `index-crate-isolation` enforces that against the `cargo metadata`
 graph, and caps the public surface of `cmdr-index`, `cmdr-archive`, `cmdr-smb`, and `cmdr-sftp` at the numbers their
 audits landed on. The two dev CLIs and the vendored fork are ordinary members.
 
@@ -276,6 +283,12 @@ audits landed on. The two dev CLIs and the vendored fork are ordinary members.
   `crates/cmdr-sftp/DETAILS.md` § "Connecting from the frontend". Its guardrails, the two crate hazards it is shaped
   around, and which side a test lives on: `crates/cmdr-sftp/CLAUDE.md`. Which crate it is built on and why:
   `docs/notes/sftp-crate-evaluation-2026-08-22.md`. Its Docker servers: `apps/desktop/test/sftp-servers/README.md`.
+- `crates/cmdr-adb/`: everything Cmdr says to an Android device over ADB. `AdbVolume` per attached device, rooted at
+  the device's real `/`, spoken to the ADB server on loopback (the sync service for stat, list, and transfers, `shell,v2`
+  for the verbs it lacks, `host:track-devices` for hotplug), with a typed errno-based error policy and a fake ADB
+  server for its suites. The device-side twin of `cmdr-sftp`; the app-side half (tracker task, device provider, lazy
+  connect, eject, IPC) is `apps/desktop/src-tauri/src/adb/`. Wire contract, `Volume` answers, and gaps:
+  `crates/cmdr-adb/DETAILS.md`; guardrails: `crates/cmdr-adb/CLAUDE.md`
 - `crates/cmdr-smb/`: everything Cmdr says to an SMB server. `SmbVolume` over a live smb2 session, with its change
   watcher, reconnect state machine, and refcounted scan-connection pool, plus the protocol layer under it (address
   building, `smb2::Error` classification, the share-listing vocabulary). The second backend in its own crate; what

--- a/docs/specs/android-adb-backend.md
+++ b/docs/specs/android-adb-backend.md
@@ -1,0 +1,41 @@
+# Android over ADB: a real-filesystem backend beside MTP
+
+**Problem.** MTP shows the curated media tree a phone chooses to expose. Developers want the real filesystem: `/data/local/tmp`, `/sdcard` as the kernel sees it, app sandboxes on a rooted or debuggable device, and the speed of the `adb sync` protocol instead of PTP object handles. `adb` is already on every Android developer's machine.
+
+**Shape.** A device-anchored `Volume`, the same shape MTP has (`rerooted` → `None`, `lane_key` = serial, `max_concurrent_ops` = 1), built as a crate the way SFTP was (`crates/cmdr-adb`, no `tauri`, no user-facing words). It talks to the **ADB server** on `127.0.0.1:5037`, never to USB itself.
+
+**The new seam it needs.** `volume_listing::complete` hardcoded MTP as the only source of device volumes, and nothing outside `mtp/` could say "a device appeared". This development adds `device_volumes.rs`: a provider registry the listing folds over, plus the one function a provider calls on hotplug (`volume_broadcast::emit_volumes_changed`). MTP becomes the first provider; ADB the second. `host:track-devices` is the push channel ADB gets that MTP never had.
+
+## Wire contract (what the crate implements)
+
+The protocol the crate speaks (host framing, `host:track-devices`, the sync service's `STAT`/`STA2`, `LIST`/`LIS2`, `RECV`/`RCV2`, `SEND`/`SND2` packets, `shell,v2,raw:` framing and the verbs, the typed errors) is canonical in `crates/cmdr-adb/DETAILS.md` § "The wire contract" and § "The error policy", with the AOSP evidence anchor. Nothing here restates it.
+
+## Volume contract
+
+- **Identity**: `volume_id` = `adb:<serial>`; root `adb://<serial>` shows the device's `/`. Paths relative to the root are absolute device paths; `root_anchored` is idempotent so a pane's `adb://<serial>/sdcard/DCIM` and a dest box's `/sdcard/DCIM` land on the same file. ❌ Never anchor an out-of-root path; refuse it.
+- **Device-anchored answers**: `rerooted` → `None` (one volume per device, the pane's path is inside it); `lane_key` = `LaneKey::Device(serial)` or the device-shaped variant the trait offers; `max_concurrent_ops` = 1 (one sync socket at a time is what a phone tolerates; `host:transport` sockets are cheap but the device's `adbd` serializes I/O anyway).
+- **Capabilities**: `supports_export` true, `is_writable` true (a read-only mount answers `ReadOnly` per path when the shell says so), `supports_streaming` true, `can_watch_listings` false (`listing_watch_coverage` → `None`; the pane refreshes on `notify_mutation`), `supports_local_fs_access` false, `paths_are_os_visible` false, `operations_are_local` false, `create_directory_errors_on_existing_dir` false (`mkdir -p`).
+- **Streams**: `open_read_stream` is one `RECV` socket per file, chunk by chunk; `write_from_stream` is one `SEND` socket per file into the staging name, then `mv`. ❌ Never collect a file into a `Vec<u8>`.
+- **Mutation**: every write path calls `notify_mutation`; there is no watcher.
+- **Liveness**: like SFTP, operations are the detector; `track-devices` additionally retires the volume when its serial leaves the list.
+- **Space**: `df -k` on the volume root, polled at `space_poll_interval` = 30 s.
+
+## App wiring
+
+- `device_volumes.rs` (new): `DeviceVolumeProvider` trait + registry + `append_device_volumes` + `device_volume_for_path`. `volume_listing::complete` folds over it. `mtp/` registers `MtpDeviceProvider`; `adb/` (new app module) registers `AdbDeviceProvider`, owns the tracker task, and calls `volume_broadcast::emit_volumes_changed` on every device-list change.
+- `apps/desktop/src-tauri/src/adb/`: the app-side half (tracker task, `AdbDeviceProvider`, lazy connect on first navigation, IPC commands). The crate is reached from there directly; there is no `backends/adb.rs` re-export.
+- `file_system/backend_settings.rs`: `"adb"` reads the constant 1.
+- Eject: an ADB entry has nothing to unmount; "eject" retires and unregisters the volume, and the device stays listed while `adb` still sees it (`adb` has no per-client detach). Documented in `adb/DETAILS.md`.
+- IPC: `list_adb_devices`, `connect_adb_device(serial)`; `adb-devices-changed` rides the existing `volumes-changed`.
+- Frontend: recognize `adb://` next to `mtp://` in the path helpers and `volume-capabilities.ts`; category `MobileDevice`, `fs_type: "adb"`; the switcher shows the device's model name with an "ADB" suffix when the same phone is also listed over MTP.
+
+## Cost to finish (after this development)
+
+- [ ] Real-device pass: authorize prompt, `unauthorized` → `device` transition mid-session, a 2 GB `RECV`/`SEND`, a `/data` listing on a non-rooted phone (expect `PermissionDenied` with the path).
+- [ ] `sendrecv_v2` compression flags (brotli/lz4/zstd): off on purpose; measure before enabling.
+- [ ] Wireless debugging (`adb pair`) is out of scope: the server owns pairing, the backend sees the device the same way.
+- [ ] A settings switch for the `adb` binary path when it's not on `PATH` / in `$ANDROID_HOME`, and a `fileOperations.adbEnabled` toggle beside the MTP one.
+- [ ] `crates/cmdr-index` path routing for `adb://` (`indexing/paths/routing.rs`, `IndexVolumeKind`): until then an ADB volume isn't indexed.
+- [ ] Frontend connect flow: nothing calls `connectAdbDevice` / `adbConnectErrorMessage` yet (the pane's `adb://` navigation connects lazily on the Rust side; a device picker and the `unauthorized` prompt need a surface). After `pnpm bindings:regen`, delete the `TODO(bindings-shim)` block in `tauri-commands/adb.ts`.
+- [ ] `go_to_path` scheme short-circuit and MCP `select_volume` via `volume_listing::complete`, so `adb://` paths resolve the way `mtp://` ones do.
+- [ ] Full `pnpm check` and `pnpm check --include-slow` locally; this branch was built in a cloud environment where the crate suites ran but the app-side lanes couldn't all be exercised.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -10,6 +10,15 @@ that lives beside the code, and git holds the history.
 
 ## In progress
 
+- [ ] 2026-09-01 `android-adb-backend.md` - **MTP shows the tree a phone chooses to expose; developers want the real
+      one.** `crates/cmdr-adb` is a device-anchored `Volume` over the ADB server's sync service and `shell,v2`, beside
+      MTP rather than replacing it, and the development adds the seam MTP never had: `device_volumes.rs`, a provider
+      registry the volume list folds over, with `host:track-devices` as the first push-channel hotplug. The crate,
+      the seam, and the app wiring are documented beside the code (`crates/cmdr-adb/DETAILS.md`, `adb/DETAILS.md`).
+      What finishing costs: a real-device pass (authorize prompt, `unauthorized` → `device` mid-session, a 2 GB
+      transfer, a `/data` listing on a non-rooted phone), then three deliberate deferrals (`sendrecv_v2` compression
+      off until measured, wireless pairing left to the server, a settings switch for the `adb` binary path).
+
 - [ ] 2026-08-29 `unify-rollback-plan.md` - **Cmdr still carries three rollback implementations, and nobody has decided
       whether that stays.** The journal-driven engine (the safest, since it rechecks every item against its recorded
       snapshot before touching it) now runs behind a history-dialog button with progress, pause, and mid-file cancel;

--- a/docs/specs/later/sftp-follow-ups.md
+++ b/docs/specs/later/sftp-follow-ups.md
@@ -13,7 +13,8 @@ discoverable by someone already reading the crate.
 nothing puts it on screen. `volume_listing::complete` has no SFTP arm, so the sidebar never shows one, and
 `resolve_path_volume` / `resolve_location` don't answer for a remote path — an SFTP path is a plain server-side absolute
 path with no scheme in front, spelled exactly like a local one, so whatever the sidebar decides about identity, path
-resolution has to agree with it.
+resolution has to agree with it. The device-provider seam the ADB development added (`device_volumes.rs`) is not the
+answer: SFTP is not device-anchored, so the sidebar arm stays a separate design question.
 
 **Why it isn't specced here**: David designs and builds this, and the build guide already exists as one file —
 `crates/cmdr-sftp/DETAILS.md` § "Connecting from the frontend" carries every command, the connect outcomes a sign-in UI

--- a/feature-status.json
+++ b/feature-status.json
@@ -56,6 +56,12 @@
       "note": "Fast transfers on most devices, but macOS sometimes claims the device first and some phones need a reconnect."
     },
     {
+      "id": "android-adb",
+      "name": "Android devices (ADB)",
+      "status": "alpha",
+      "note": "The device's real filesystem over the adb tool, for developers. Needs Android platform-tools installed and USB debugging on; not yet tested on a wide range of phones."
+    },
+    {
       "id": "git-browser",
       "name": "Git browser",
       "status": "beta",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "oxfmt": "^0.63.0",
     "typescript": "~6.0.3"
   },
-  "packageManager": "pnpm@11.22.0",
+  "packageManager": "pnpm@11.25.0",
   "engines": {
     "pnpm": ">=11"
   }

--- a/scripts/check/checks/desktop-message-key-naming.go
+++ b/scripts/check/checks/desktop-message-key-naming.go
@@ -39,6 +39,7 @@ var messageKeyKnownAreas = map[string]bool{
 	"ai":             true,
 	"goToPath":       true,
 	"mtp":            true,
+	"adb":            true,
 	"ui":             true,
 	"updates":        true,
 	"whatsNew":       true,


### PR DESCRIPTION
## Summary

Adds an **Android over ADB** storage backend beside MTP: a device-anchored `Volume` over the device's real filesystem, built as `crates/cmdr-adb` in the shape `cmdr-sftp` set (no `tauri`, no user-facing words, typed errors only). It talks to the local ADB server (`127.0.0.1:5037`), not USB, using the `sync:` service for file transfer and `shell,v2` for the verbs sync has none for.

It also adds the **device-provider seam** the volume list needed: `device_volumes.rs` replaces the hardcoded `append_mtp_volumes` with a `DeviceVolumeProvider` registry that `volume_listing::complete` folds over, and generalizes eject from `MtpDisconnect` to `DeviceDisconnect { provider, volume_id }`. MTP becomes the first provider (behavior unchanged); ADB the second, with `host:track-devices` as the push channel for hotplug.

## What's in it

- `crates/cmdr-adb/`: `server` (endpoint + one-shot `adb start-server`), `transport` (the only module that knows the wire framing), `devices` (list + `track-devices` tracker with backoff), `features`, `sync` (STAT/STA2, LIST/LIS2, RECV/RCV2, SEND/SND2), `shell` (`shell,v2,raw` with framed exit code), `errors` (errno → `VolumeError`, path-carrying), and `volume/` (the `impl Volume`, staging-then-`mv` writes, chunked streams, the seven shared conformance assertions against a fake ADB server on loopback).
- `cmdr-fs`: `adb_volume_id(serial)` in the id funnel.
- App: `device_volumes.rs` seam, `adb/` module (tracker, provider, lazy connect on first navigation, IPC commands), `backend_settings` `"adb"` row (1 op), eject generalization, `adb://` path resolution.
- Frontend: `adb://` recognized beside `mtp://` in path helpers, capabilities, breadcrumbs, tabs, tint; `tauri-commands/adb.ts`; `adb.*` i18n keys in every locale (machine-drafted).
- Docs: `crates/cmdr-adb/CLAUDE.md` + `DETAILS.md` (the wire contract's canonical home), `src-tauri/src/adb/` pair, seam notes in the volume docs, architecture map, spec at `docs/specs/android-adb-backend.md`.

## Verification state (built in a cloud env; see the spec's "Cost to finish")

- `crates/cmdr-adb`: compiles clean with all targets; clippy `-D warnings` clean on the protocol half; the suite was at 60–61 of 62 green in the last completed runs (one listing/symlink cell and one tracker-silence assertion were being fixed at the cutoff). A final run is in flight and will be reported on the PR.
- App crate: `cargo check -p cmdr --lib` did not complete before the cutoff (the full dependency build didn't fit in the hour), so the app-side wiring and the eject rename need a local `pnpm check`. `pnpm bindings:regen` has not run yet: `tauri-commands/adb.ts` carries a marked shim to delete after it.
- Frontend: Vitest on every touched file green; the i18n lanes and `svelte-check` pass except for the `deviceDisconnectRefused` type that bindings regen will add.

## Not done yet

- Real-device pass (authorize prompt, unauthorized → device mid-session, a 2 GB transfer, `/data` on a non-rooted phone).
- `crates/cmdr-index` path routing for `adb://` (ADB volumes aren't indexed until then).
- Frontend connect flow / device picker (Rust connects lazily on navigation; nothing calls `connectAdbDevice` yet).
- Settings toggle + `adb` binary path setting; `go_to_path` scheme short-circuit; MCP `select_volume` via `volume_listing::complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ1Fmz58tf5TwwNG3mWFyY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ1Fmz58tf5TwwNG3mWFyY)_