### PR TITLE
Navigation: catch side-button swipes from mouse drivers (issue #31)

### DIFF
--- a/apps/desktop/src-tauri/src/ipc.rs
+++ b/apps/desktop/src-tauri/src/ipc.rs
@@ -81,7 +81,7 @@ use crate::volume_broadcast::{VolumeContextAction, VolumeMounted, VolumeUnmounte
 // Window-management events: emit_to-targeted window lifecycle.
 use crate::window_events::{
     CloseAbout, CloseAllFileViewers, CloseConfirmation, CloseFileViewer, ExecuteCommand, FocusAbout, FocusConfirmation,
-    FocusFileViewer, FocusSettings, ForegroundOperation, McpSettingsClose, OpenFileViewer, OpenSettings,
+    FocusFileViewer, FocusSettings, ForegroundOperation, McpSettingsClose, MouseNav, OpenFileViewer, OpenSettings,
     PersistRestrictedSetting, RevealPath, TabContextAction, ViewerWordWrapToggled,
 };
 // AI + system/misc events.
@@ -1065,6 +1065,7 @@ pub fn builder() -> Builder<tauri::Wry> {
             McpSettingsClose,
             ViewerWordWrapToggled,
             TabContextAction,
+            MouseNav,
             PersistRestrictedSetting,
             // FE-emitted, like `execute-command`: the queue window asks the main
             // window to foreground one operation, and the settings window asks it to show

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -142,6 +142,8 @@ mod location;
 mod macos_icons;
 mod mcp;
 mod menu;
+#[cfg(target_os = "macos")]
+mod mouse_nav;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 mod mtp;
 #[cfg(target_os = "macos")]
@@ -651,6 +653,13 @@ pub fn run() {
             reduce_transparency::observe_reduce_transparency_changes(app.handle().clone());
             #[cfg(not(target_os = "macos"))]
             stubs::reduce_transparency::observe_reduce_transparency_changes(app.handle().clone());
+
+            // Watch the mouse's back / forward navigation. macOS only: the mouse's own
+            // driver decides what the press becomes, and a Logi Options+ mouse posts a
+            // swipe gesture with no button behind it, so AppKit is the only layer that
+            // sees both shapes. On Linux the frontend reads the buttons off the DOM.
+            #[cfg(target_os = "macos")]
+            mouse_nav::install(app.handle().clone());
 
             // Observe macOS Accessibility > Display > Text Size changes
             #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/src/mouse_nav.rs
+++ b/apps/desktop/src-tauri/src/mouse_nav.rs
@@ -1,0 +1,270 @@
+//! macOS: a mouse's dedicated back / forward navigation, read from AppKit rather
+//! than from the DOM.
+//!
+//! The frontend maps `MouseEvent.button === 3 / 4` to `nav.back` / `nav.forward`
+//! (`routes/(main)/mouse-nav.ts`), which is what a plain five-button mouse
+//! delivers. On macOS that path can't be relied on, because the mouse's own
+//! driver often replaces the button entirely:
+//!
+//! **Gotcha / Why:** with Logi Options+ installed, an MX-series mouse's thumb
+//! buttons emit NO mouse button at all. Options+ binds them to
+//! `OSX_GESTURE_BACK` / `OSX_GESTURE_FORWARD` with `hidUsage: 0`, and posts a
+//! macOS swipe instead — `NSEventType::Swipe`, `deltaX` `+1` for back and `-1`
+//! for forward. So neither the DOM's `button === 3 / 4` nor an `otherMouseDown`
+//! monitor ever fires for them. (Verified with an AppKit event probe against a
+//! Logitech MX Master 4 + Logi Options+, macOS 27, 2026-09-04; probe output and
+//! the Options+ config trail in `docs/notes/mx-side-buttons-swipe-2026-09-04.md`.)
+//!
+//! Both roads therefore land here: this module watches the `otherMouse` buttons
+//! AND the swipe gesture, and emits `mouse-nav` to the main window, which
+//! dispatches the same bus command as `⌘[` / `⌘]`. The DOM path stays as the
+//! Linux/WebKitGTK route.
+//!
+//! ## Why the monitor swallows the events it recognizes
+//!
+//! Returning `null` from the handler drops the event before any window sees it.
+//! That's deliberate on both roads. For the BUTTONS: WebKit's mapping of extra
+//! mouse buttons onto the DOM's three-button vocabulary is not something we
+//! control, and Cmdr gives the MIDDLE button real gestures (close a tab, open a
+//! folder in a background tab); an X1 press that arrived as a middle click would
+//! close whatever it happened to be over. For the SWIPE: it's the gesture
+//! WKWebView's own back / forward navigation reads, which would pop the SvelteKit
+//! SPA history underneath us. Every other `otherMouse` event (the middle button
+//! included) is handed straight back.
+//!
+//! The monitor is LOCAL, so it only sees events already destined for this app —
+//! no accessibility permission, and nothing observed while another app is front.
+
+use std::ptr::NonNull;
+
+use log::{debug, warn};
+use objc2::MainThreadMarker;
+use objc2::rc::Retained;
+use objc2_app_kit::{NSEvent, NSEventMask, NSEventType};
+use tauri::{AppHandle, Manager, Runtime};
+use tauri_specta::Event as _;
+
+use crate::window_events::{MouseNav, MouseNavDirection};
+
+/// Fourth mouse button (X1), conventionally "back". Same numbering the UI Events
+/// spec gives `MouseEvent.button`, which is why the two sides agree.
+const BUTTON_BACK: isize = 3;
+
+/// Fifth mouse button (X2), conventionally "forward".
+const BUTTON_FORWARD: isize = 4;
+
+/// The only window a pane-history walk means anything in.
+const MAIN_WINDOW_LABEL: &str = "main";
+
+/// What one AppKit event means to us. Three outcomes, because "ours" and
+/// "carries a direction" aren't the same thing: a swipe arrives as a pair, and
+/// only its second half knows which way it went.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Action {
+    /// Not ours. Hand the event back untouched.
+    PassThrough,
+    /// Ours, but there's nothing to dispatch: the press half of a button
+    /// (we navigate on release) or the `Began` half of a swipe (`deltaX` is 0
+    /// until the gesture ends). Swallowed so the pair is consistent.
+    SwallowOnly,
+    /// Ours, and it says which way to walk the history.
+    Navigate(MouseNavDirection),
+}
+
+/// The history direction a side button drives, or `None` for a button we don't
+/// own (the middle button, and anything past the fifth).
+fn direction_for_button(button_number: isize) -> Option<MouseNavDirection> {
+    match button_number {
+        BUTTON_BACK => Some(MouseNavDirection::Back),
+        BUTTON_FORWARD => Some(MouseNavDirection::Forward),
+        _ => None,
+    }
+}
+
+/// The history direction a swipe drives, or `None` when it carries no direction
+/// yet. AppKit's `swipeWithEvent:` sign convention: a swipe to the RIGHT
+/// (positive `deltaX`) goes back, to the left goes forward — the same way the
+/// gesture reads in every macOS app, and what Options+ posts for the thumb
+/// buttons.
+fn direction_for_swipe(delta_x: f64) -> Option<MouseNavDirection> {
+    if delta_x > 0.0 {
+        Some(MouseNavDirection::Back)
+    } else if delta_x < 0.0 {
+        Some(MouseNavDirection::Forward)
+    } else {
+        None
+    }
+}
+
+/// Classifies one event. Pure, so the whole decision table is unit-testable
+/// without an `NSEvent`; the handler below only reads the fields and acts.
+fn action_for(event_type: NSEventType, button_number: isize, delta_x: f64) -> Action {
+    if event_type == NSEventType::Swipe {
+        // A swipe is ours whichever half it is: swallowing only the half that
+        // carries a direction would leak the `Began` event to the webview.
+        return match direction_for_swipe(delta_x) {
+            Some(direction) => Action::Navigate(direction),
+            None => Action::SwallowOnly,
+        };
+    }
+
+    let Some(direction) = direction_for_button(button_number) else {
+        return Action::PassThrough;
+    };
+
+    // Navigate on the UP edge (the press is only swallowed), mirroring the DOM
+    // path and every other click gesture in the app.
+    if event_type == NSEventType::OtherMouseUp {
+        Action::Navigate(direction)
+    } else {
+        Action::SwallowOnly
+    }
+}
+
+/// Installs the local `NSEvent` monitor. Call once, from the Tauri setup hook.
+///
+/// The monitor lives for the whole session: there's no teardown point, and the
+/// buttons should work for as long as the app is up. Same shape as the
+/// notification observers in `accent_color.rs` / `reduce_transparency.rs`.
+pub fn install<R: Runtime>(app_handle: AppHandle<R>) {
+    // Compile-time proof of the AppKit main thread; `addLocalMonitor…` is an
+    // AppKit call, and the setup hook is where we are.
+    let _mtm = MainThreadMarker::new().expect("install runs on the main thread (Tauri setup hook)");
+
+    let block = block2::RcBlock::new(move |event: NonNull<NSEvent>| -> *mut NSEvent {
+        // SAFETY: AppKit passes the monitor a live `NSEvent` that stays valid for
+        // the duration of the callback, and we only read from it here.
+        let ns_event = unsafe { event.as_ref() };
+
+        let event_type = ns_event.r#type();
+        // `deltaX` is only meaningful on the gesture events; the button branch
+        // ignores it, and the mask keeps anything else out.
+        let delta_x = if event_type == NSEventType::Swipe {
+            ns_event.deltaX()
+        } else {
+            0.0
+        };
+        let action = action_for(event_type, ns_event.buttonNumber(), delta_x);
+        if action == Action::PassThrough {
+            return event.as_ptr(); // not ours: hand it back untouched
+        }
+
+        // The gestures stay inert unless the main window is the one being used;
+        // a settings or viewer window has no pane history to walk, and swallowing
+        // there would eat an event its own webview might want.
+        // (`Manager::get_focused_window` would say this directly, but it's behind
+        // Tauri's `unstable` feature, so ask the main window itself.)
+        let focused_is_main = app_handle
+            .get_webview_window(MAIN_WINDOW_LABEL)
+            .and_then(|window| window.is_focused().ok())
+            .unwrap_or(false);
+        if !focused_is_main {
+            return event.as_ptr();
+        }
+
+        if let Action::Navigate(direction) = action {
+            debug!(target: "mouse_nav", "Navigation gesture {:?}", direction);
+            if let Err(e) = (MouseNav { direction }).emit_to(&app_handle, MAIN_WINDOW_LABEL) {
+                warn!(target: "mouse_nav", "Couldn't emit mouse-nav: {e}");
+            }
+        }
+        std::ptr::null_mut()
+    });
+
+    // SAFETY: `block` is a live `RcBlock` with the
+    // `(NonNull<NSEvent>) -> *mut NSEvent` signature the handler parameter
+    // declares, and AppKit copies it. The mask covers only the three event types
+    // the handler inspects.
+    let monitor = unsafe {
+        NSEvent::addLocalMonitorForEventsMatchingMask_handler(
+            NSEventMask::OtherMouseDown | NSEventMask::OtherMouseUp | NSEventMask::Swipe,
+            &block,
+        )
+    };
+
+    match monitor {
+        // Leaking the monitor token is what keeps it installed: dropping the
+        // `Retained` would release it and the buttons would go dead. There's no
+        // point in the app's life where we'd want to remove it.
+        Some(monitor) => {
+            let _installed = Retained::into_raw(monitor);
+            debug!(target: "mouse_nav", "Side-button monitor installed");
+        }
+        None => warn!(
+            target: "mouse_nav",
+            "AppKit refused the side-button event monitor; the mouse's back / forward buttons won't navigate"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A button number no gesture owns, for the swipe cases (a swipe's
+    /// `buttonNumber` is meaningless and must never be consulted).
+    const UNOWNED_BUTTON: isize = 0;
+
+    #[test]
+    fn maps_only_the_two_side_buttons() {
+        assert_eq!(direction_for_button(BUTTON_BACK), Some(MouseNavDirection::Back));
+        assert_eq!(direction_for_button(BUTTON_FORWARD), Some(MouseNavDirection::Forward));
+    }
+
+    #[test]
+    fn leaves_every_other_button_alone() {
+        // 2 is the middle button, which Cmdr's own gestures use.
+        for button in [0, 1, 2, 5, 6] {
+            assert_eq!(
+                direction_for_button(button),
+                None,
+                "button {button} should not navigate"
+            );
+        }
+    }
+
+    #[test]
+    fn maps_swipe_direction_by_the_appkit_sign_convention() {
+        assert_eq!(direction_for_swipe(1.0), Some(MouseNavDirection::Back));
+        assert_eq!(direction_for_swipe(-1.0), Some(MouseNavDirection::Forward));
+    }
+
+    #[test]
+    fn a_directionless_swipe_navigates_nowhere() {
+        assert_eq!(direction_for_swipe(0.0), None);
+    }
+
+    #[test]
+    fn a_side_button_navigates_on_release_only() {
+        assert_eq!(
+            action_for(NSEventType::OtherMouseUp, BUTTON_BACK, 0.0),
+            Action::Navigate(MouseNavDirection::Back)
+        );
+        assert_eq!(
+            action_for(NSEventType::OtherMouseDown, BUTTON_BACK, 0.0),
+            Action::SwallowOnly
+        );
+    }
+
+    #[test]
+    fn the_middle_button_is_handed_back_on_both_edges() {
+        // Cmdr's own middle-click gestures live in the webview, so both halves
+        // have to reach it.
+        assert_eq!(action_for(NSEventType::OtherMouseDown, 2, 0.0), Action::PassThrough);
+        assert_eq!(action_for(NSEventType::OtherMouseUp, 2, 0.0), Action::PassThrough);
+    }
+
+    #[test]
+    fn both_halves_of_a_swipe_are_swallowed() {
+        // Options+ posts the pair `deltaX: 0` (Began) then `deltaX: ±1` (Ended).
+        assert_eq!(action_for(NSEventType::Swipe, UNOWNED_BUTTON, 0.0), Action::SwallowOnly);
+        assert_eq!(
+            action_for(NSEventType::Swipe, UNOWNED_BUTTON, 1.0),
+            Action::Navigate(MouseNavDirection::Back)
+        );
+        assert_eq!(
+            action_for(NSEventType::Swipe, UNOWNED_BUTTON, -1.0),
+            Action::Navigate(MouseNavDirection::Forward)
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/window_events.rs
+++ b/apps/desktop/src-tauri/src/window_events.rs
@@ -112,6 +112,28 @@ pub struct TabContextAction {
     pub action: String,
 }
 
+/// Which way a mouse gesture walks the pane history. A typed direction rather
+/// than a raw button number or swipe delta: the frontend dispatches a command
+/// from it, and reading either shape is `mouse_nav.rs`'s job alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum MouseNavDirection {
+    Back,
+    Forward,
+}
+
+/// `mouse-nav`: a back / forward navigation gesture finished over the main
+/// window — a mouse's X1/X2 side button, or the swipe a Logi Options+ mouse
+/// substitutes for it. macOS only, emitted by the AppKit event monitor in
+/// `mouse_nav.rs`; on Linux the frontend reads the buttons straight off the DOM.
+/// Emitted to the main window, which dispatches `nav.back` / `nav.forward` on
+/// the same bus as `⌘[` / `⌘]`.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, Event)]
+#[serde(rename_all = "camelCase")]
+pub struct MouseNav {
+    pub direction: MouseNavDirection,
+}
+
 /// `foreground-operation`: the operation queue asks the main window to show one
 /// operation in its progress dialog (the row's Foreground button). Carries only
 /// the id: the registry snapshot both windows already receive is the single

--- a/apps/desktop/src/lib/ipc/bindings.ts
+++ b/apps/desktop/src/lib/ipc/bindings.ts
@@ -4246,6 +4246,7 @@ export const events = {
   mediaIndexFolderExclusion: makeEvent<MediaIndexFolderExclusion>('media-index-folder-exclusion'),
   menuBarRebuilt: makeEvent<MenuBarRebuilt>('menu-bar-rebuilt'),
   menuSort: makeEvent<MenuSort>('menu-sort'),
+  mouseNav: makeEvent<MouseNav>('mouse-nav'),
   mtpDeviceConnected: makeEvent<MtpDeviceConnected>('mtp-device-connected'),
   mtpDeviceDisconnected: makeEvent<MtpDeviceDisconnected>('mtp-device-disconnected'),
   mtpExclusiveAccessError: makeEvent<MtpExclusiveAccessError>('mtp-exclusive-access-error'),
@@ -8523,6 +8524,25 @@ export type MountResult = {
   mountPath: string
   alreadyMounted: boolean
 }
+
+/**
+ *  `mouse-nav`: a back / forward navigation gesture finished over the main
+ *  window — a mouse's X1/X2 side button, or the swipe a Logi Options+ mouse
+ *  substitutes for it. macOS only, emitted by the AppKit event monitor in
+ *  `mouse_nav.rs`; on Linux the frontend reads the buttons straight off the DOM.
+ *  Emitted to the main window, which dispatches `nav.back` / `nav.forward` on
+ *  the same bus as `⌘[` / `⌘]`.
+ */
+export type MouseNav = {
+  direction: MouseNavDirection
+}
+
+/**
+ *  Which way a mouse gesture walks the pane history. A typed direction rather
+ *  than a raw button number or swipe delta: the frontend dispatches a command
+ *  from it, and reading either shape is `mouse_nav.rs`'s job alone.
+ */
+export type MouseNavDirection = 'back' | 'forward'
 
 /**
  *  Why an MTP operation couldn't happen, in a shape the app can act on.

--- a/apps/desktop/src/lib/tauri-commands/DETAILS.md
+++ b/apps/desktop/src/lib/tauri-commands/DETAILS.md
@@ -100,7 +100,9 @@ commands, and notable non-obvious placements.
   main window opens Settings on behalf of a window without window-creation perms), `onViewerWordWrapToggled`,
   `onPersistRestrictedSetting`, and `requestForegroundOperation` / `onForegroundOperationRequested` (the queue window
   asking the main window to show one operation in its progress dialog; the payload is the id alone, because the registry
-  snapshot both windows receive is the truth about everything else).
+  snapshot both windows receive is the truth about everything else), and `onMouseNav` (macOS reads the mouse's back /
+  forward navigation in AppKit, because a Logi Options+ mouse posts a swipe rather than a button;
+  `routes/(main)/DETAILS.md` § Mouse back / forward buttons).
 - **`git.ts`**: git-browser commands (`getGitRepoInfo`, `subscribeGitState` / `unsubscribeGitState`,
   `getGitStatusForPaths`) plus `onGitStateChanged` over the per-repo `git-state-changed` event.
 - **`go-to-path.ts`**: ⌘G path resolution (`resolveGoToPath`) and the persisted recent-paths list (`getRecentPaths`,

--- a/apps/desktop/src/lib/tauri-commands/dialog-events.ts
+++ b/apps/desktop/src/lib/tauri-commands/dialog-events.ts
@@ -15,6 +15,7 @@ import {
   type ExecuteCommand,
   type FocusFileViewer,
   type ForegroundOperation,
+  type MouseNavDirection,
   type OpenFileViewer,
   type OpenSettings,
   type PersistRestrictedSetting,
@@ -202,5 +203,18 @@ export function onRevealPath(handler: (payload: RevealPath) => void): Promise<Un
 export function onPersistRestrictedSetting(handler: (payload: PersistRestrictedSetting) => void): Promise<UnlistenFn> {
   return events.persistRestrictedSetting.listen((event) => {
     handler(event.payload)
+  })
+}
+
+/**
+ * A back / forward navigation gesture (a mouse's X1/X2 side button, or the swipe
+ * a Logi Options+ mouse substitutes for it) finished over the main window. macOS
+ * only, from the AppKit event monitor in `mouse_nav.rs`, which is the only way
+ * either shape arrives there. On Linux the DOM path in `routes/(main)/mouse-nav.ts`
+ * reads the buttons straight off the event. Both ends dispatch the same bus command.
+ */
+export function onMouseNav(handler: (direction: MouseNavDirection) => void): Promise<UnlistenFn> {
+  return events.mouseNav.listen((event) => {
+    handler(event.payload.direction)
   })
 }

--- a/apps/desktop/src/lib/tauri-commands/index.ts
+++ b/apps/desktop/src/lib/tauri-commands/index.ts
@@ -511,6 +511,7 @@ export {
   onRevealPath,
   requestForegroundOperation,
   onForegroundOperationRequested,
+  onMouseNav,
 } from './dialog-events'
 
 // Licensing

--- a/apps/desktop/src/routes/(main)/+page.svelte
+++ b/apps/desktop/src/routes/(main)/+page.svelte
@@ -601,6 +601,7 @@
             },
         },
         maybeRunWhatsNew: (force: boolean) => maybeRunWhatsNew(startupGatesCtx, force),
+        isModalDialogOpen,
     }
 </script>
 

--- a/apps/desktop/src/routes/(main)/DETAILS.md
+++ b/apps/desktop/src/routes/(main)/DETAILS.md
@@ -233,17 +233,40 @@ the button, and why only the id travels: `$lib/file-operations/queue/DETAILS.md`
 ## Mouse back / forward buttons
 
 A pointer's dedicated X1/X2 side buttons drive the same `nav.back` / `nav.forward` bus commands as `⌘[` / `⌘]` (issue
-#31), so history walks the same way regardless of input device. `+page.svelte` registers two document listeners that
-both consult `navCommandForMouseButton` (`mouse-nav.ts`, mapping `button === 3 → nav.back`, `4 → nav.forward`):
+#31), so history walks the same way regardless of input device. The buttons reach the dispatch by a different road per
+platform, both mapped in `mouse-nav.ts`.
+
+**macOS: from AppKit** (`navCommandForDirection`). `mouse_nav.rs` (in `src-tauri/src/`) installs a local `NSEvent`
+monitor and emits the typed `mouse-nav` event to the main window; `setupMouseNavListener` (`listener-setup.ts`) turns
+the direction into the dispatch, behind the same `isModalDialogOpen()` guard as everything else.
+
+That monitor watches TWO kinds of event, because on macOS the mouse's driver decides which one the user's press
+becomes. It reads `buttonNumber` off `otherMouseUp` for a raw five-button mouse, and `deltaX` off `NSEventType::Swipe`
+for a Logi Options+ mouse, which substitutes a macOS swipe gesture and emits no mouse button at all. Both roads reach
+the same two directions. **Gotcha / Why:** the DOM listeners below never fire on a Logi Options+ mouse, and the reason
+is NOT that WKWebView withholds extra buttons — no mouse-button event is posted anywhere in the system, so an
+`otherMouse`-only monitor is just as blind as the webview. Confirming that took an AppKit probe;
+`docs/notes/mx-side-buttons-swipe-2026-09-04.md` is the canonical record of what each device actually delivers, and the
+one to read before touching either side of this feature.
+
+Three properties of the monitor matter here. It **swallows** the events it recognizes — an extra button so a
+webview-side reading can't fire Cmdr's middle-click gestures, a swipe so WKWebView's own back / forward gesture can't
+pop the SPA history underneath us. It only acts while the MAIN window is focused. And a swipe arrives as a PAIR whose
+first half carries no direction, so `action_for` swallows that half without dispatching; every other `otherMouse`
+event, the middle button included, is handed straight back.
+
+**Linux: from the DOM.** `+page.svelte` registers two document listeners that both consult `navCommandForMouseButton`
+(mapping `button === 3 → nav.back`, `4 → nav.forward`):
 
 - **`mouseup`** dispatches the command (gated by the same `isModalDialogOpen()` guard as the keyboard path, so the
   buttons stay inert while a dialog or overlay is up). The dispatch is left untagged for the cross-source dedup: a mouse
   button has no native-menu twin to double-fire, so it should always pass.
-- **`mousedown`** only `preventDefault`s the side buttons (no dispatch). This is what cancels WKWebView's built-in page
-  back / forward, which would otherwise pop the SvelteKit SPA history (e.g. unwinding a `/settings` visit) underneath
-  us. The suppression can't move to `mouseup` — the webview commits its default nav on the press — so the two halves
-  stay split across the two events. Suppression runs even while a modal is open (we never want the webview navigating
-  itself); only the dispatch is gated.
+- **`mousedown`** only `preventDefault`s the side buttons (no dispatch). This is what cancels the webview's built-in
+  page back / forward, which would otherwise pop the SvelteKit SPA history (e.g. unwinding a `/settings` visit)
+  underneath us. The suppression can't move to `mouseup` — the webview commits its default nav on the press — so the two
+  halves stay split across the two events. Suppression runs even while a modal is open (we never want the webview
+  navigating itself); only the dispatch is gated. On macOS the AppKit monitor above swallows the events first, so these
+  two listeners are the Linux path's alone.
 
 ## Right-click ownership
 

--- a/apps/desktop/src/routes/(main)/listener-setup.ts
+++ b/apps/desktop/src/routes/(main)/listener-setup.ts
@@ -34,9 +34,11 @@ import {
   onSettingsChanged,
   onForegroundOperationRequested,
   onRevealPath,
+  onMouseNav,
 } from '$lib/tauri-commands'
 import { getAppLogger } from '$lib/logging/logger'
 import { markDispatchSource } from './dispatch-dedup'
+import { navCommandForDirection } from './mouse-nav'
 import { setFolderExcluded } from '$lib/media-index/excluded-folders'
 import { setFolderChosen } from '$lib/media-index/always-index-folders'
 import { isCommandId, type CommandId, type CommandDispatchArgs } from '$lib/commands'
@@ -81,6 +83,11 @@ export interface ListenerSetupContext {
    * reads reactive startup-modal `$state`; the E2E rerun listener calls it.
    */
   maybeRunWhatsNew: (force: boolean) => Promise<void>
+  /**
+   * Whether a modal dialog or overlay is up, so a listener can stay inert while
+   * the user is answering something. Reads the component's dialog `$state`.
+   */
+  isModalDialogOpen: () => boolean
 }
 
 /** Safe wrapper for Tauri event listeners - handles non-Tauri environment. */
@@ -578,6 +585,26 @@ export async function setupDialogListeners(ctx: ListenerSetupContext): Promise<v
       await maybeRunWhatsNew(true)
     })()
   })
+}
+
+/**
+ * The macOS half of the mouse's back / forward navigation: AppKit reads it
+ * (`src-tauri/src/mouse_nav.rs`) because a Logi Options+ mouse posts a swipe
+ * gesture rather than a button, so nothing reaches the DOM. This turns the
+ * direction into the same `nav.back` / `nav.forward` dispatch the `⌘[` / `⌘]`
+ * shortcuts and the Linux DOM path make.
+ *
+ * Gated by the same modal guard as the keyboard path, so the buttons stay inert
+ * while a dialog is up. Left untagged for the cross-source dedup: a mouse button
+ * has no native-menu twin to double-fire.
+ */
+export async function setupMouseNavListener(ctx: ListenerSetupContext): Promise<void> {
+  await pushTauri(ctx.unlistenFns, () =>
+    onMouseNav((direction) => {
+      if (ctx.isModalDialogOpen()) return
+      void ctx.dispatch(navCommandForDirection(direction))
+    }),
+  )
 }
 
 /** Sync file-scoped menu items with main window focus state. */

--- a/apps/desktop/src/routes/(main)/mouse-nav.test.ts
+++ b/apps/desktop/src/routes/(main)/mouse-nav.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { navCommandForMouseButton } from './mouse-nav'
+import { navCommandForDirection, navCommandForMouseButton } from './mouse-nav'
 
 describe('navCommandForMouseButton', () => {
   it('maps the fourth button (X1) to nav.back', () => {
@@ -19,5 +19,12 @@ describe('navCommandForMouseButton', () => {
   it('returns null for any unknown higher button code', () => {
     expect(navCommandForMouseButton(5)).toBeNull()
     expect(navCommandForMouseButton(-1)).toBeNull()
+  })
+})
+
+describe('navCommandForDirection', () => {
+  it('maps the native (macOS) directions to the same two commands', () => {
+    expect(navCommandForDirection('back')).toBe('nav.back')
+    expect(navCommandForDirection('forward')).toBe('nav.forward')
   })
 })

--- a/apps/desktop/src/routes/(main)/mouse-nav.ts
+++ b/apps/desktop/src/routes/(main)/mouse-nav.ts
@@ -3,11 +3,22 @@
  * navigation commands, so a mouse with X1/X2 buttons walks Cmdr's history the
  * same way it walks browser and Finder history (issue #31).
  *
- * `MouseEvent.button` numbers the side buttons per the UI Events spec: 3 is the
- * fourth button (X1, "back"), 4 is the fifth (X2, "forward"). We branch on those
- * numeric codes, never a name string, so this never depends on OS/locale wording.
+ * The buttons reach us two ways, one per platform, both landing on the same two
+ * commands:
+ *
+ * - **The DOM** (`navCommandForMouseButton`), on Linux/WebKitGTK. `MouseEvent.button`
+ *   numbers the side buttons per the UI Events spec: 3 is the fourth button (X1,
+ *   "back"), 4 is the fifth (X2, "forward"). We branch on those numeric codes,
+ *   never a name string, so this never depends on OS/locale wording.
+ * - **AppKit** (`navCommandForDirection`), on macOS, where the mouse's driver
+ *   decides what the press becomes: a Logi Options+ mouse posts a swipe gesture
+ *   and no mouse button at all, so nothing reaches the DOM path.
+ *   `src-tauri/src/mouse_nav.rs` reads both shapes and emits the direction as a
+ *   typed `mouse-nav` event. What each device delivers, measured:
+ *   `docs/notes/mx-side-buttons-swipe-2026-09-04.md`.
  */
 import type { CommandId } from '$lib/commands'
+import type { MouseNavDirection } from '$lib/ipc/bindings'
 
 /** Fourth mouse button (X1), conventionally "back". */
 const MOUSE_BUTTON_BACK = 3
@@ -23,4 +34,14 @@ export function navCommandForMouseButton(button: number): CommandId | null {
   if (button === MOUSE_BUTTON_BACK) return 'nav.back'
   if (button === MOUSE_BUTTON_FORWARD) return 'nav.forward'
   return null
+}
+
+/** The history command for a direction the native (macOS) monitor reported. */
+export function navCommandForDirection(direction: MouseNavDirection): CommandId {
+  switch (direction) {
+    case 'back':
+      return 'nav.back'
+    case 'forward':
+      return 'nav.forward'
+  }
 }

--- a/apps/desktop/src/routes/(main)/window-services.ts
+++ b/apps/desktop/src/routes/(main)/window-services.ts
@@ -58,6 +58,7 @@ import {
   makeListenTauri,
   setupMenuListeners,
   setupDialogListeners,
+  setupMouseNavListener,
   setupWindowFocusListener,
 } from './listener-setup'
 import { startMenuOperationGate } from './menu-operation-gate.svelte'
@@ -88,6 +89,8 @@ export interface WindowServicesContext {
   }
   /** Re-runs the "What's new" startup trigger; component-owned because it reads startup-modal `$state`. */
   maybeRunWhatsNew: (force: boolean) => Promise<void>
+  /** Whether a modal dialog or overlay is up; the mouse side buttons stay inert while one is. */
+  isModalDialogOpen: () => boolean
 }
 
 /**
@@ -145,9 +148,12 @@ export async function startWindowServices(ctx: WindowServicesContext): Promise<v
     unlistenFns,
     dialogs: ctx.dialogs,
     maybeRunWhatsNew: ctx.maybeRunWhatsNew,
+    isModalDialogOpen: ctx.isModalDialogOpen,
   }
   await setupMenuListeners(listenerCtx)
   await setupDialogListeners(listenerCtx)
+  // macOS: the mouse's back / forward side buttons, which only AppKit sees.
+  await setupMouseNavListener(listenerCtx)
   await setupMcpListeners({
     getExplorer: ctx.getExplorer,
     // The MCP adapter dispatches through the same typed command bus as the keyboard / palette /

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -96,6 +96,14 @@ Some notes here are load-bearing rather than historical. Those are grouped below
   keeps beating from a background thread, and one install out of 765 has auto error reporting on. Read it before
   treating a quiet `#error-reports` channel as evidence that a defect did not bite.
 
+- `mx-side-buttons-swipe-2026-09-04.md` — why `mouse_nav.rs` watches a SWIPE gesture in a module about mouse buttons.
+  **With Logi Options+ installed, an MX mouse's thumb buttons emit no mouse button at all**: Options+ binds them to
+  `OSX_GESTURE_BACK` / `_FORWARD` with `hidUsage: 0` and posts `NSEventType::Swipe` (`deltaX` `+1` back, `-1` forward)
+  in a two-event pair whose first half carries no direction. Carries the AppKit probe output, the Options+ config trail
+  that names the mechanism, and the proof a swipe can't collide with the thumb wheel's horizontal scroll. Read it
+  before attributing any missing pointer input to WKWebView — that was the wrong answer we shipped first, and the note
+  records why the two failure modes look identical from inside the webview.
+
 **Load-bearing as regression anchors:**
 
 - `coverage-frontier-query-2026-08-05.md` — the search frontier query measured against its 50 ms warm budget on a real

--- a/docs/notes/mx-side-buttons-swipe-2026-09-04.md
+++ b/docs/notes/mx-side-buttons-swipe-2026-09-04.md
@@ -1,0 +1,103 @@
+# What a Logitech mouse's back / forward buttons actually deliver on macOS (2026-09-04)
+
+Why Cmdr's mouse back / forward navigation didn't work on a Logitech MX Master 4, measured rather than reasoned. The
+short version: **with Logi Options+ installed, the thumb buttons emit no mouse button at all** — they emit a macOS swipe
+gesture. Every reading that assumes a button is looking for an event that is never posted.
+
+Read this before changing `apps/desktop/src-tauri/src/mouse_nav.rs`, before "fixing" the DOM path in
+`apps/desktop/src/routes/(main)/mouse-nav.ts`, and before attributing any missing pointer input to WKWebView.
+
+## The wrong answer we shipped first
+
+The first implementation (2026-09-04, commit `594a42dd5`) read the symptom — no `MouseEvent.button === 3 / 4` in the
+DOM — and concluded that **WKWebView doesn't deliver extra mouse buttons to the webview**. The fix that followed from
+that premise was an AppKit `NSEvent` local monitor for `otherMouseDown` / `otherMouseUp`, reading `buttonNumber`.
+
+It didn't work either, because the premise was wrong. The DOM saw nothing for the same reason AppKit saw nothing: there
+was no mouse-button event anywhere in the system. The verification behind the original claim only ever covered the DOM
+half; the AppKit half was never confirmed against the device.
+
+**The lesson worth keeping:** "the webview didn't get it" and "the event doesn't exist" look identical from inside the
+webview. Confirm at the layer below the one that's failing before naming a cause there.
+
+## Method
+
+An AppKit probe: a 60-line Swift app (`NSApplication`, one window, `.regular` activation policy) installing
+`NSEvent.addLocalMonitorForEvents(matching: .any)` and printing every event's type, `buttonNumber`, `deltaX`, `phase`,
+and scroll deltas to stderr. Pointer parked over the probe's own window; back, forward, then the middle button as a
+control; the whole sequence run twice.
+
+This is the cheapest instrument for any "which event is this really?" question on macOS, and it needs no accessibility
+permission (a LOCAL monitor only sees events already destined for its own app). Rebuild it before guessing.
+
+## What came back
+
+Identical across both runs (`phase` raw values: 1 = `began`, 8 = `ended`):
+
+```
+back     ->  swipe [type=31]  deltaX= 0.000  phase=1
+             swipe [type=31]  deltaX=+1.000  phase=8
+forward  ->  swipe [type=31]  deltaX= 0.000  phase=1
+             swipe [type=31]  deltaX=-1.000  phase=8
+middle   ->  otherMouseDown   buttonNumber=2
+             otherMouseUp     buttonNumber=2
+```
+
+Four things this settles:
+
+1. **No `otherMouse` event with `buttonNumber` 3 or 4 exists**, on either press or release. A monitor watching for one
+   can never fire for these buttons.
+2. The buttons post `NSEventType::Swipe` (31), `deltaX` `+1` for back and `-1` for forward. That is AppKit's own
+   `swipeWithEvent:` sign convention, not a Logitech invention, so a Magic Mouse two-finger swipe reads the same way.
+3. **A press is a PAIR**, and only the second half carries the direction. Anything acting on `deltaX` alone must ignore
+   the `began` half, or it fires twice with no direction the first time.
+4. **A swipe can't collide with horizontal scrolling.** The thumb wheel shows up as `scrollWheel` (type 22, `deltaX`
+   ≈ −4, `hasPreciseScrollingDeltas`) — a different event type entirely, which the swipe mask never sees.
+
+## Why: the Options+ config trail
+
+Logi Options+ owns the buttons, and its stored profile says exactly what it substitutes. Two files, both readable:
+
+`~/Library/Application Support/LogiOptionsPlus/settings.db` — a SQLite file whose `data` table holds one JSON blob.
+Under the single global profile key (`profile-…`, one per configured app; there was no Cmdr-specific profile):
+
+```
+mx-master-4-2b042_c82  ->  card_global_presets_middle_button
+mx-master-4-2b042_c83  ->  card_global_presets_osx_back      (back thumb button)
+mx-master-4-2b042_c86  ->  card_global_presets_osx_forward   (forward thumb button)
+```
+
+`/Library/Application Support/Logitech.localized/LogiOptionsPlus/card_presets/card_presets_osx.json` — what those cards
+do. The contrast is the whole answer:
+
+| Card | `macro.mouse.action` | `hidUsage` |
+| --- | --- | --- |
+| `card_global_presets_middle_button` | `BUTTON` | **3** |
+| `card_global_presets_osx_back` | `OSX_GESTURE_BACK` | **0** |
+| `card_global_presets_osx_forward` | `OSX_GESTURE_FORWARD` | **0** |
+
+`hidUsage: 0` means no HID button is emitted. The middle button on the same device keeps a real one, which is why
+Cmdr's middle-click gestures (close a tab, open a folder in a background tab) worked throughout while the side buttons
+did nothing.
+
+## What shipped
+
+`mouse_nav.rs` now watches `NSEventMask::Swipe` alongside the two `otherMouse` masks, and classifies every event
+through one pure `action_for(event_type, button_number, delta_x)` so the decision table is unit-tested without an
+`NSEvent`. Three outcomes, because "ours" and "carries a direction" are not the same thing — the `began` half of a
+swipe is swallowed and dispatches nothing.
+
+The `otherMouse` path was **kept, not replaced**. It's still the live path for a plain five-button mouse, for a
+Logitech user who hasn't installed Options+, and for any vendor that passes the raw button through.
+
+## What would change the answer
+
+- **A different Options+ assignment.** These readings are the shipped default. A user who assigns the thumb buttons to
+  a keystroke, or to `card_global_presets_middle_button`, gets a different event — the keystroke case would reach Cmdr
+  through the normal shortcut path and needs nothing from this module.
+- **Options+ uninstalled**, which should restore raw HID buttons 4 / 5 and exercise the `otherMouse` path. Not measured.
+- **Another vendor's driver** (Razer Synapse, SteerMouse, USB Overdrive) may substitute something else again. The probe
+  is the way to find out; don't extrapolate from this note.
+
+_All readings: Logitech MX Master 4 (`mx-master-4-2b042`) over Bolt, Logi Options+ with `logioptionsplus_agent` and
+`LogiPluginService` running, macOS 27, 2026-09-04._


### PR DESCRIPTION
- Fix the back and forward buttons doing nothing on a Logitech mouse with Logi Options+ installed, which turns those buttons into swipes instead of button presses