### PR TITLE
Icons: fix the home badge on every folder, and missing custom icons

### DIFF
--- a/apps/desktop/src-tauri/src/icons/CLAUDE.md
+++ b/apps/desktop/src-tauri/src/icons/CLAUDE.md
@@ -3,8 +3,7 @@
 OS icon retrieval and caching for the file list. Entries carry only an `iconId`; the frontend batches the unique ids for
 visible rows and fetches each once via `get_icons`, so 50k files never transmit 50k icon blobs.
 
-This is the Rust `src/icons/` module. (`src-tauri/icons/`, a sibling at the crate root, holds the app *bundle* icons,
-unrelated.)
+The Rust `src/icons/` module. (`src-tauri/icons/` at the crate root holds the app *bundle* icons, unrelated.)
 
 ## Icon-id scheme
 
@@ -13,34 +12,37 @@ data URL. The namespace, by tier:
 
 | Tier | Id | Assigned to | Fetched from |
 | --- | --- | --- | --- |
-| A | `dir` / `symlink-dir` | every plain folder (~99%) | the home dir (sample) |
+| A | `dir` / `symlink-dir` | every plain folder (~99%) | a temp sample folder |
 | A | `ext:{x}` / `file` / `symlink*` | files | a per-extension temp sample / `/etc/hosts` |
 | B | `special:{name}` | the finite special system folders | the folder's REAL path (8 MB thread) |
 | C | `path:{dir}` / `pkg:{dir}` | per-path icons (volumes, packages, custom-icon folders) | the real path (8 MB thread) |
 | n/a | `git:{branch,tag,commit,fork}` | git-portal virtual entries | rendered by the FE via Lucide, never here |
 
-Full details (tier narratives, the package vs custom-icon detection-timing decision, disk-cache mechanism, FE wiring):
-`DETAILS.md`.
+Full details: `DETAILS.md`.
 
 ## Must-knows
 
 - **The two per-entry classifiers live in `cmdr-fs`, re-exported here.** `special_folders` and the package half of
   `per_path` run inside `FileEntry::new`, so they had to move where `FileEntry` is; everything expensive (NSWorkspace,
-  `getxattr`, the disk cache) stayed. Keep it that way: anything reachable from `get_icon_id` must be pure and cheap.
+  `getxattr`, the disk cache) stayed. Anything reachable from `get_icon_id` must stay pure and cheap.
 - **Special folders are detected by canonical path, NOT by name, with no disk I/O.** `classify` is a lexical `HashMap`
   lookup; never add a `canonicalize` (it blocks on dead mounts and runs per entry during listing).
 - **Custom-icon detection (`getxattr`) must NOT run during bulk listing.** A syscall per directory in a 100k-entry
   listing regresses the hot path. It runs only for the bounded set of visible directory paths the FE asks about via
   `get_custom_folder_icon_ids`. Packages (`is_package_dir`, a pure suffix check, no syscall) are the exception and stay
-  inline in `get_icon_id`.
+  inline in `get_icon_id`. So a custom-icon folder KEEPS the `dir` id: the FE resolves it by PATH
+  (`getCachedCustomFolderIcon`), ❌ never by `iconId`, or the icon is fetched and never drawn.
+- **`dir` / `symlink-dir` sample a Cmdr-owned empty temp folder, ❌ never `~`.** macOS bakes the home folder's house
+  badge (and any custom icon on `~`) into the bitmap, stamping it onto ~99% of rows.
 - **Real-folder NSWorkspace fetches run on dedicated 8 MB-stack OS threads (`fetch_path_icons`), never rayon.** Real
   folders can be cloud folders whose icon lookup descends through deep FileProvider XPC chains that overflow rayon's
   2 MB worker stack. The extension branch (sample temp paths, never cloud) stays on rayon.
 - **All NSWorkspace fetches are FDA-gated in `commands/icons.rs`** (they touch TCC services); the FE re-requests after
   the gate clears.
 - **Bounded vs unbounded key lifecycle**: `dir` / `ext:*` / `file` / `symlink*` / `special:*` are bounded (uncapped
-  in-memory, persisted to localStorage). `path:*` / `pkg:*` are unbounded (`PATH_KEY_CAP` LRU, never persisted). `pkg:*`
-  shares the `path:*` lifecycle via `is_per_path_key`.
+  in-memory, persisted to localStorage), so changing how one is PRODUCED needs a `CACHE_SCHEMA` bump in
+  `$lib/icon-cache` or every existing install serves the old pixels forever. `path:*` / `pkg:*` are unbounded
+  (`PATH_KEY_CAP` LRU, never persisted). `pkg:*` shares the `path:*` lifecycle via `is_per_path_key`.
 - **A theme/accent change must drop the appearance-tinted keys AND the disk cache.** macOS tints folder glyphs by
   appearance; the mtime token can't catch a system-only change. `clear_directory_icon_cache` handles both.
 - **Disk-cache staleness token is the folder's mtime.** Don't replace it with a watcher: Finder bumps the folder mtime

--- a/apps/desktop/src-tauri/src/icons/DETAILS.md
+++ b/apps/desktop/src-tauri/src/icons/DETAILS.md
@@ -16,6 +16,24 @@ for the real-folder ids (`special:*` / `pkg:*` / `path:*`), keyed by folder mtim
 `clear_directory_icon_cache` drops the keys macOS appearance-tints (`dir`, `symlink-dir`, `path:*`, `pkg:*`,
 `special:*`) plus the whole disk cache, on a theme/accent change.
 
+**Gotcha: changing how a BOUNDED icon is produced needs a `CACHE_SCHEMA` bump** (`$lib/icon-cache`). Those keys persist
+to localStorage and are refetched only on a miss, so an install that already ran the old build keeps serving the old
+pixels forever — the fix ships, nothing moves on screen, and it reads as the fix not working. It bit the `dir`-sampling
+fix below: the backend was correct, every machine still drew the house. The stamp lives in the persisted envelope
+(`{ version, icons }`); a mismatch or a pre-stamp bare map discards the lot and refetches. ❌ Never leave it alone
+because "the key didn't change" — the key not changing is exactly the hazard.
+
+## Tier A: the generic folder sample (`folder_sample_path`)
+
+`dir` / `symlink-dir` cover ~99% of rows, and their icon comes from asking the OS about one stand-in directory.
+
+**Decision: the stand-in is an empty `<temp>/cmdr-icon-samples/sample-folder`, ❌ never the home directory.** Sampling
+`~` looked free (it always exists, no directory to create) but macOS bakes the home folder's house badge into the
+bitmap, so every plain folder in every listing rendered with a house on it; a custom icon assigned to `~` leaked onto
+all of them by the same route. A folder Cmdr just created carries neither, so it yields the true generic glyph, still
+correctly accent- and appearance-tinted because macOS tints from system state rather than from the path. Pinned by
+`the_generic_folder_sample_is_a_cmdr_owned_directory_not_the_home_dir`.
+
 ## Tier A: extension samples (`icon_sample_path`)
 
 An `ext:{x}` icon comes from asking the OS about a real file, so Cmdr keeps one empty stand-in per extension. Only the
@@ -84,6 +102,13 @@ LRU-capped together under one `PATH_KEY_CAP` budget, and are never persisted to 
 **FE wiring** (`file-explorer/views/file-list-utils.ts` + `icon-cache.ts`): the visible-range fetch collects the
 on-screen directory rows' paths and calls `prefetchCustomFolderIcons` → `get_custom_folder_icon_ids`, then fetches the
 returned `path:` ids through the normal `prefetchIcons` path (packages already arrive as `pkg:` ids from the listing).
+
+**Gotcha: a custom-icon folder's entry still carries `iconId: "dir"`**, because the detection is deferred and nothing
+rewrites the id afterwards. So the RENDERER has to ask by path — `FileIcon.svelte` tries
+`getCachedCustomFolderIcon(entry.path)` before `getCachedIcon(entry.iconId)`. Looking up `iconId` alone drew the generic
+folder over an icon the prefetch had already fetched and cached: the whole chain worked and the result was invisible,
+with no error anywhere. The gold-recolor filter has to check the same thing, since `isFolderIcon` is true for these rows
+too and would repaint the user's artwork. Packages don't share the hazard — `pkg:` ids come straight off the listing.
 `FilePane` evicts a directory's `path:*` / `pkg:*` keys via `evictPerPathIconsForDir` when its listing ends (navigation
 away / unmount), keeping the working set tight and re-detecting a re-icon next time the folder is shown.
 

--- a/apps/desktop/src-tauri/src/icons/mod.rs
+++ b/apps/desktop/src-tauri/src/icons/mod.rs
@@ -205,8 +205,9 @@ pub fn get_icon_for_path(path: &str) -> Option<String> {
 /// For extension-based icons, we create an actual temp file since the OS may need it to exist.
 fn get_sample_path_for_icon_id(icon_id: &str) -> Option<PathBuf> {
     if icon_id == "dir" || icon_id == "symlink-dir" {
-        // Use home directory as sample directory (symlinks to dirs get folder icon)
-        return dirs::home_dir();
+        // A Cmdr-owned empty folder, ❌ never `~` — see `folder_sample_path`.
+        // (Symlinks to dirs sample the same plain folder; the FE draws the link badge.)
+        return folder_sample_path();
     }
     if icon_id == "symlink-file" || icon_id == "symlink" || icon_id == "file" {
         // Generic file icon - use /etc/hosts which exists on all macOS systems
@@ -216,6 +217,24 @@ fn get_sample_path_for_icon_id(icon_id: &str) -> Option<PathBuf> {
         return icon_sample_path(ext);
     }
     None
+}
+
+/// The empty stand-in DIRECTORY standing in for every plain folder (`dir` /
+/// `symlink-dir`, ~99% of rows).
+///
+/// ❌ Never sample the home directory here. macOS bakes a house badge into `~`'s
+/// icon bitmap, so sampling it stamps that house onto every folder in every
+/// listing; worse, a user-assigned custom icon on `~` leaks onto all of them the
+/// same way. A folder Cmdr just created carries neither badge nor custom icon, so
+/// it yields the true generic folder — still correctly accent- and
+/// appearance-tinted, because macOS tints from system state, not from the path.
+///
+/// Shares `cmdr-icon-samples` with the per-extension file samples, for the same
+/// reasons (namespaced, removable as a unit, reused across runs).
+fn folder_sample_path() -> Option<PathBuf> {
+    let path = std::env::temp_dir().join("cmdr-icon-samples").join("sample-folder");
+    std::fs::create_dir_all(&path).ok()?;
+    Some(path)
 }
 
 /// The empty stand-in file whose EXTENSION Launch Services reads to pick a
@@ -587,6 +606,28 @@ mod tests {
             0,
             "the sample stays empty so nothing content-sniffs it"
         );
+    }
+
+    /// Pins the generic folder sample OFF the home directory. macOS bakes a house
+    /// badge into `~`'s icon, so sampling it stamped that house onto every folder
+    /// row in every listing, and leaked a custom icon assigned to `~` the same way.
+    #[test]
+    fn the_generic_folder_sample_is_a_cmdr_owned_directory_not_the_home_dir() {
+        for icon_id in ["dir", "symlink-dir"] {
+            let sample = get_sample_path_for_icon_id(icon_id).expect("a sample path for the generic folder id");
+
+            assert_ne!(
+                Some(sample.as_path()),
+                dirs::home_dir().as_deref(),
+                "{icon_id} must not sample ~: its badge and any custom icon would leak onto every folder"
+            );
+            assert_eq!(
+                sample.parent().and_then(|p| p.file_name()),
+                Some(std::ffi::OsStr::new("cmdr-icon-samples")),
+                "the folder sample shares the samples directory with the extension samples"
+            );
+            assert!(sample.is_dir(), "the OS needs a real directory to hand back a folder icon");
+        }
     }
 
     #[test]

--- a/apps/desktop/src/lib/dialog-gallery/DialogGallery.svelte.test.ts
+++ b/apps/desktop/src/lib/dialog-gallery/DialogGallery.svelte.test.ts
@@ -76,6 +76,7 @@ vi.mock('$lib/tauri-commands', () => ({
 vi.mock('$lib/icon-cache', () => ({
   iconCacheVersion: writable(0),
   getCachedIcon: vi.fn(() => undefined),
+  getCachedCustomFolderIcon: () => undefined,
 }))
 
 const warn = vi.fn()

--- a/apps/desktop/src/lib/file-explorer/drag/drag-drop.identity.test.ts
+++ b/apps/desktop/src/lib/file-explorer/drag/drag-drop.identity.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 vi.mock('@tauri-apps/api/path', () => ({ tempDir: vi.fn(), join: vi.fn() }))
-vi.mock('$lib/icon-cache', () => ({ getCachedIcon: vi.fn() }))
+vi.mock('$lib/icon-cache', () => ({ getCachedIcon: vi.fn(), getCachedCustomFolderIcon: () => undefined }))
 vi.mock('$lib/tauri-commands', () => ({
   startSelectionDrag: vi.fn(),
   startDragPaths: vi.fn(),

--- a/apps/desktop/src/lib/file-explorer/navigation/VolumeBreadcrumb.svelte.test.ts
+++ b/apps/desktop/src/lib/file-explorer/navigation/VolumeBreadcrumb.svelte.test.ts
@@ -63,6 +63,7 @@ vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
   return {
     getCachedIcon: vi.fn().mockReturnValue('/icons/dir.png'),
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
     prefetchIcons: vi.fn().mockResolvedValue(undefined),
   }

--- a/apps/desktop/src/lib/file-explorer/pane/drag-drop-controller.listeners.svelte.test.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/drag-drop-controller.listeners.svelte.test.ts
@@ -143,7 +143,7 @@ vi.mock('../drag/drag-overlay.svelte.js', () => ({
   hideOverlay: hideOverlaySpy,
 }))
 
-vi.mock('$lib/icon-cache', () => ({ getCachedIcon: getCachedIconSpy }))
+vi.mock('$lib/icon-cache', () => ({ getCachedIcon: getCachedIconSpy, getCachedCustomFolderIcon: () => undefined }))
 
 vi.mock('../modifier-key-tracker.svelte', () => ({
   startModifierTracking: startModifierTrackingSpy,

--- a/apps/desktop/src/lib/file-explorer/pane/drag-drop-controller.svelte.test.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/drag-drop-controller.svelte.test.ts
@@ -150,7 +150,7 @@ vi.mock('../drag/drag-overlay.svelte.js', () => ({
   hideOverlay: hideOverlaySpy,
 }))
 
-vi.mock('$lib/icon-cache', () => ({ getCachedIcon: getCachedIconSpy }))
+vi.mock('$lib/icon-cache', () => ({ getCachedIcon: getCachedIconSpy, getCachedCustomFolderIcon: () => undefined }))
 
 vi.mock('../modifier-key-tracker.svelte', () => ({
   startModifierTracking: startModifierTrackingSpy,

--- a/apps/desktop/src/lib/file-explorer/pane/file-pane-keyboard.test.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/file-pane-keyboard.test.ts
@@ -105,6 +105,7 @@ vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
   return {
     getCachedIcon: vi.fn().mockReturnValue('/icons/file.png'),
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
     prefetchIcons: vi.fn().mockResolvedValue(undefined),
     prefetchCustomFolderIcons: vi.fn().mockResolvedValue(undefined),

--- a/apps/desktop/src/lib/file-explorer/pane/selection-consistency.test.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/selection-consistency.test.ts
@@ -114,6 +114,7 @@ vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
   return {
     getCachedIcon: vi.fn().mockReturnValue('/icons/file.png'),
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
     iconCacheCleared: writable(0),
     prefetchIcons: vi.fn().mockResolvedValue(undefined),

--- a/apps/desktop/src/lib/file-explorer/pane/volume-breadcrumb.test.ts
+++ b/apps/desktop/src/lib/file-explorer/pane/volume-breadcrumb.test.ts
@@ -119,6 +119,7 @@ vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
   return {
     getCachedIcon: vi.fn().mockReturnValue('/icons/file.png'),
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
     prefetchIcons: vi.fn().mockResolvedValue(undefined),
     prefetchCustomFolderIcons: vi.fn().mockResolvedValue(undefined),

--- a/apps/desktop/src/lib/file-explorer/selection/CLAUDE.md
+++ b/apps/desktop/src/lib/file-explorer/selection/CLAUDE.md
@@ -7,15 +7,14 @@ lives in `FilePane.svelte` as a `Set<number>`).
 
 - **`selection-info-utils.ts`**: pure utilities (size/date formatting, display deciders), no DOM deps, fully tested.
 - **`SelectionInfo.svelte`**: status bar below each pane. Four display modes derived from props.
-- **`FileIcon.svelte`**: 16x16 icon with a bundled macOS-default fallback and overlay badges.
+- **`FileIcon.svelte`**: 16x16 icon with overlay badges (fallback below).
 - **`SortableHeader.svelte`**: clickable column header with sort-direction triangle and shortcut tooltip.
 - **`TagDots.svelte`** + **`tag-dots-utils.ts`**: Finder-tag dot cluster (Name cell, right edge); logic in the util.
 
 ## Must-knows
 
 - **`sizeTierClasses` CSS rules live in the consuming view, not in `selection-info-utils.ts`.** The util is pure
-  TypeScript with no DOM/style deps; the classes (`size-bytes` … `size-tb`) belong to the parent list view's stylesheet,
-  keeping style ownership in the view layer.
+  TypeScript with no DOM/style deps; the classes (`size-bytes` … `size-tb`) belong to the parent list view's stylesheet.
 - **Size-tier color tracks the underlying byte magnitude in every mode, not the displayed unit.** A 349-byte file shown
   as `"0.00 MB"` (forced-MB) still tiers as `size-bytes` (green), via `dynamicTierIndex(bytes, format)`. Don't tier off
   the displayed unit.
@@ -23,14 +22,13 @@ lives in `FilePane.svelte` as a `Set<number>`).
   [`$lib/settings/age-tier-utils.ts`](../../settings/age-tier-utils.ts)**, not here; they belong with the setting. The
   renderer is [`$lib/ui/DateLabel.svelte`](../../ui/DateLabel.svelte). See `$lib/settings/CLAUDE.md` § "Date display".
 - **`isBrokenSymlink` checks `iconId === 'symlink-broken'`, NOT filesystem flags.** The backend already resolves broken-
-  symlink status when computing the icon ID; re-checking via stat would be redundant and possibly stale. Keep the
-  frontend consistent with what the user sees.
+  symlink status when computing the icon ID; re-checking via stat would be redundant and possibly stale.
 - **❌ Never infer "no access" from entry metadata** (`permissions === 0`, missing `size`): `permissions` defaults to
   `0` and every non-local backend leaves it there, so the guess fires on EVERY SMB / archive / MTP folder. Proof:
   `DETAILS.md`, `getSizeDisplay`.
 - **`SelectionInfo` derives its display mode from props** (`viewMode`, `selectedCount`, `stats`), never an explicit
-  `mode` prop. Keeps mode-determination in one place. The four modes: `empty`, `selection-summary`, `no-selection`
-  (Full, no selection), `file-info` (Brief, no selection).
+  `mode` prop. The four modes: `empty`, `selection-summary`, `no-selection` (Full, no selection), `file-info` (Brief, no
+  selection).
 - **Middle truncation in `file-info` mode uses the `useShortenMiddle` action** (`$lib/utils/`) with `preferBreakAt: '.'`
   and `startRatio: 0.7`, NOT CSS `text-overflow: ellipsis`: CSS truncates from the right and loses the file extension.
 - **Counts, size decimals, and triad separators follow the active locale via `$lib/intl`** (`formatNumber`,
@@ -39,8 +37,10 @@ lives in `FilePane.svelte` as a `Set<number>`).
 - **`SortableHeader`'s shortcut shows only when `isFocused` is true** (the `sort.by*` commands act on the focused pane).
   Hovering the unfocused pane's header shows the command name only; clicking still sorts that pane. Pinned by
   `SortableHeader.svelte.test.ts`.
-- **`FileIcon` fallback is the bundled macOS default icon, not an emoji.** Shown only on cache miss; it swaps to the
-  live accent-tinted OS icon once `get_icons` repopulates (`$iconCacheVersion`).
+- **`FileIcon` resolves a folder by PATH before `iconId`** (`getCachedCustomFolderIcon`): a custom-icon folder keeps the
+  generic `dir` id, so `iconId` alone hides it and gold recolor must skip it (`src-tauri/src/icons/DETAILS.md`). On a
+  cache miss it draws the bundled macOS default icon, not an emoji, swapping to the live OS icon once `get_icons`
+  repopulates (`$iconCacheVersion`).
 
 ## Status-bar hints (`SelectionInfo`)
 

--- a/apps/desktop/src/lib/file-explorer/selection/FileIcon.custom-folder-icon.test.ts
+++ b/apps/desktop/src/lib/file-explorer/selection/FileIcon.custom-folder-icon.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests that `FileIcon.svelte` DRAWS a folder's Finder custom icon.
+ *
+ * The regression this pins: a custom-icon folder keeps the generic `dir` iconId
+ * (the backend defers the `kHasCustomIcon` getxattr off the bulk-listing hot
+ * path), so its icon is cached under a `path:{dir}` key that no entry points at.
+ * Looking up `iconId` alone drew the generic folder over an icon
+ * `prefetchCustomFolderIcons` had already fetched and cached — the icon arrived
+ * and was silently thrown away.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mount, unmount, flushSync } from 'svelte'
+
+const GENERIC_URL = '/icons/generic-folder.svg'
+const CUSTOM_URL = '/icons/custom-artwork.svg'
+const CUSTOM_PATH = '/Users/test/Projects'
+
+vi.mock('$lib/icon-cache', async () => {
+  const { writable } = await import('svelte/store')
+  return {
+    getCachedIcon: () => GENERIC_URL,
+    // Exactly one folder has been assigned a custom icon.
+    getCachedCustomFolderIcon: (path: string) => (path === CUSTOM_PATH ? CUSTOM_URL : undefined),
+    iconCacheVersion: writable(0),
+  }
+})
+
+// Gold is ON throughout, so the custom-icon cases also prove the recolor filter
+// keeps its hands off the user's own artwork.
+vi.mock('$lib/settings/reactive-settings.svelte', () => ({
+  getFileSizeFormat: () => 'binary',
+  getIsCmdrGold: () => true,
+}))
+
+import FileIcon from './FileIcon.svelte'
+
+const baseEntry = {
+  name: 'Projects',
+  path: CUSTOM_PATH,
+  isDirectory: true,
+  isSymlink: false,
+  size: 0,
+  modifiedAt: 1710000000,
+  iconId: 'dir',
+  permissions: 420,
+  owner: 'test',
+  group: 'staff',
+  extendedMetadataLoaded: false,
+}
+
+let target: HTMLElement | undefined
+let app: ReturnType<typeof mount> | undefined
+
+function render(overrides: Partial<typeof baseEntry> = {}): HTMLImageElement {
+  target = document.createElement('div')
+  document.body.appendChild(target)
+  app = mount(FileIcon, { target, props: { file: { ...baseEntry, ...overrides } } })
+  flushSync()
+  const img = target.querySelector('img.icon')
+  if (!img) throw new Error('no icon img rendered')
+  return img as HTMLImageElement
+}
+
+afterEach(() => {
+  if (app) void unmount(app)
+  app = undefined
+  target?.remove()
+  target = undefined
+})
+
+describe('FileIcon custom folder icons', () => {
+  it('draws the custom icon for a folder that has one, despite its generic dir iconId', () => {
+    expect(render().getAttribute('src')).toBe(CUSTOM_URL)
+  })
+
+  it('never gold-recolors a custom icon (it would repaint the user artwork)', () => {
+    expect(render().classList.contains('gold-folder')).toBe(false)
+  })
+
+  it('still draws the generic folder icon for a folder without a custom one', () => {
+    const img = render({ path: '/Users/test/Plain' })
+    expect(img.getAttribute('src')).toBe(GENERIC_URL)
+    // Untouched by the custom-icon path, so gold still applies.
+    expect(img.classList.contains('gold-folder')).toBe(true)
+  })
+
+  it('leaves a symlinked directory on its generic icon', () => {
+    // Mirrors `prefetchCustomFolderIcons`, which never asks about symlinks: the
+    // link-badged glyph is the salient signal.
+    const img = render({ isSymlink: true, iconId: 'symlink-dir' })
+    expect(img.getAttribute('src')).toBe(GENERIC_URL)
+  })
+
+  it('leaves files alone even at a path that collides with a custom-icon folder', () => {
+    const img = render({ isDirectory: false, iconId: 'ext:md' })
+    expect(img.getAttribute('src')).toBe(GENERIC_URL)
+  })
+})

--- a/apps/desktop/src/lib/file-explorer/selection/FileIcon.gold-recolor.test.ts
+++ b/apps/desktop/src/lib/file-explorer/selection/FileIcon.gold-recolor.test.ts
@@ -18,6 +18,10 @@ vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
   return {
     getCachedIcon: () => '/icons/stub.svg',
+    // No folder here carries a Finder custom icon, so the recolor gate depends
+    // solely on iconId. The custom-icon case is pinned in
+    // `FileIcon.custom-folder-icon.test.ts`.
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
   }
 })

--- a/apps/desktop/src/lib/file-explorer/selection/FileIcon.svelte
+++ b/apps/desktop/src/lib/file-explorer/selection/FileIcon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type { FileEntry } from '../types'
-    import { getCachedIcon, iconCacheVersion } from '$lib/icon-cache'
+    import { getCachedIcon, getCachedCustomFolderIcon, iconCacheVersion } from '$lib/icon-cache'
     import { getIsCmdrGold } from '$lib/settings/reactive-settings.svelte'
     import Icon from '$lib/ui/Icon.svelte'
     import type { IconName } from '$lib/ui/icons/icon-map'
@@ -20,10 +20,26 @@
     // Subscribe to cache version - this makes getIconUrl reactive
     const _cacheVersion = $derived($iconCacheVersion)
 
-    function getIconUrl(f: FileEntry): string | undefined {
+    // A folder the user assigned a Finder custom icon to still carries the generic
+    // `dir` iconId (the backend defers that `getxattr` off the bulk-listing hot
+    // path), so its icon lands in the cache keyed by PATH instead. Ask for it
+    // first: `iconId` alone would draw the generic folder over an icon
+    // `prefetchCustomFolderIcons` already fetched and cached.
+    // Mirrors that prefetch's own filter — real directories only, symlinks keep
+    // their link-badged glyph.
+    const customFolderIconUrl = $derived.by((): string | undefined => {
         void _cacheVersion // Track cache version for reactivity
-        return getCachedIcon(f.iconId)
-    }
+        if (!file.isDirectory || file.isSymlink) return undefined
+        return getCachedCustomFolderIcon(file.path)
+    })
+
+    // Reads `_cacheVersion` itself rather than leaning on `customFolderIconUrl`:
+    // that stays `undefined` for ~99% of rows, so a cache update wouldn't
+    // propagate through it and the generic icon would never swap in.
+    const iconUrl = $derived.by((): string | undefined => {
+        void _cacheVersion // Track cache version for reactivity
+        return customFolderIconUrl ?? getCachedIcon(file.iconId)
+    })
 
     // Which icon ids get the Cmdr-gold recolor filter. All are folders macOS
     // renders as a plain (accent-tinted) folder shape, so the grayscale-first
@@ -39,7 +55,10 @@
     const isFolderIcon = $derived(
         file.iconId === 'dir' || file.iconId === 'symlink-dir' || file.iconId.startsWith('special:'),
     )
-    const recolorToGold = $derived(isFolderIcon && getIsCmdrGold())
+    // `!customFolderIconUrl` because a custom-icon folder keeps the `dir` iconId,
+    // so `isFolderIcon` is true for it too — without this the filter would repaint
+    // the user's own artwork gold, the one thing the exclusion above forbids.
+    const recolorToGold = $derived(isFolderIcon && !customFolderIconUrl && getIsCmdrGold())
 
     // Git portal icons resolve in the frontend via Lucide instead of going
     // through the OS icon provider. The four IDs are reserved by the
@@ -67,8 +86,8 @@
         <span class="git-icon">
             <Icon name={gitIconName} size={16} />
         </span>
-    {:else if getIconUrl(file)}
-        <img class="icon" class:gold-folder={recolorToGold} src={getIconUrl(file)} alt="" width="16" height="16" />
+    {:else if iconUrl}
+        <img class="icon" class:gold-folder={recolorToGold} src={iconUrl} alt="" width="16" height="16" />
     {:else}
         <!-- Cache miss (cold first launch, or briefly after a theme/accent change clears the cache):
              show the bundled macOS default folder/file icon (from `static/icons/default-*.png`,

--- a/apps/desktop/src/lib/file-explorer/views/BriefList.a11y.test.ts
+++ b/apps/desktop/src/lib/file-explorer/views/BriefList.a11y.test.ts
@@ -22,6 +22,7 @@ vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
   return {
     getCachedIcon: () => undefined,
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
     iconCacheCleared: writable(0),
     prefetchIcons: vi.fn(),

--- a/apps/desktop/src/lib/file-explorer/views/test-file-list-mocks.ts
+++ b/apps/desktop/src/lib/file-explorer/views/test-file-list-mocks.ts
@@ -41,6 +41,7 @@ export function tauriCommandsMock(overrides: Record<string, unknown> = {}) {
 export function iconCacheMock(overrides: Record<string, unknown> = {}) {
   return {
     getCachedIcon: () => undefined,
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
     iconCacheCleared: writable(0),
     prefetchIcons: vi.fn(),

--- a/apps/desktop/src/lib/file-explorer/views/view-modes.test.ts
+++ b/apps/desktop/src/lib/file-explorer/views/view-modes.test.ts
@@ -16,6 +16,7 @@ vi.mock('$lib/tauri-commands', () => ({
 // Mock icon-cache
 vi.mock('$lib/icon-cache', () => ({
   getCachedIcon: vi.fn().mockReturnValue(undefined),
+  getCachedCustomFolderIcon: () => undefined,
   iconCacheVersion: { subscribe: vi.fn() },
   prefetchIcons: vi.fn(),
   prefetchCustomFolderIcons: vi.fn().mockResolvedValue(undefined),

--- a/apps/desktop/src/lib/icon-cache.test.ts
+++ b/apps/desktop/src/lib/icon-cache.test.ts
@@ -26,7 +26,7 @@ const STORAGE_KEY = 'cmdr-icon-cache'
 function storedKeys(): string[] {
   const raw = localStorage.getItem(STORAGE_KEY)
   if (!raw) return []
-  return Object.keys(JSON.parse(raw) as Record<string, string>)
+  return Object.keys((JSON.parse(raw) as { icons: Record<string, string> }).icons)
 }
 
 describe('icon-cache path: key bounding', () => {
@@ -232,5 +232,47 @@ describe('icon-cache special: keys (Tier B)', () => {
     }
 
     expect(getCachedIcon('special:downloads')).toBe('dl-url')
+  })
+})
+
+/**
+ * Bounded keys persist and are only refetched on a miss, so a build that changes
+ * how one is PRODUCED (`dir` no longer sampling `~`, whose house badge every
+ * folder wore) ships the fix and moves no pixels on any machine that already ran
+ * the old build. The schema stamp is what forces those entries to be re-fetched.
+ */
+describe('icon-cache persisted-schema invalidation', () => {
+  beforeEach(() => {
+    _resetIconCacheForTests()
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('discards a pre-schema flat map, so a stale bounded icon cannot outlive the build that made it', async () => {
+    // Exactly what every build before the stamp wrote: a bare id -> url map.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ dir: 'stale-house-badged-url', 'ext:txt': 'txt-url' }))
+
+    const fresh = await import('./icon-cache')
+
+    expect(fresh.getCachedIcon('dir')).toBeUndefined()
+    expect(fresh.getCachedIcon('ext:txt')).toBeUndefined()
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('discards a map stamped with an older schema', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 1, icons: { dir: 'stale-url' } }))
+
+    const fresh = await import('./icon-cache')
+
+    expect(fresh.getCachedIcon('dir')).toBeUndefined()
+  })
+
+  it('still round-trips what the current build wrote', async () => {
+    _applyIconsToCacheForTests({ dir: 'dir-url', 'ext:txt': 'txt-url' })
+
+    const fresh = await import('./icon-cache')
+
+    expect(fresh.getCachedIcon('dir')).toBe('dir-url')
+    expect(fresh.getCachedIcon('ext:txt')).toBe('txt-url')
   })
 })

--- a/apps/desktop/src/lib/icon-cache.ts
+++ b/apps/desktop/src/lib/icon-cache.ts
@@ -11,6 +11,26 @@ import {
 } from './tauri-commands'
 
 const STORAGE_KEY = 'cmdr-icon-cache'
+
+/**
+ * Bump when a BOUNDED icon's pixels can change while its key stays the same.
+ *
+ * `dir` / `ext:*` / `special:*` survive restarts in localStorage and are only
+ * refetched on a cache miss, so a backend change to how one is PRODUCED is
+ * otherwise invisible forever on every machine that already ran the old build —
+ * the fix ships, the pixels don't move, and it reads as the fix not working.
+ *
+ * 2: `dir` / `symlink-dir` stopped sampling the home directory, whose baked-in
+ *    house badge every plain folder had been wearing.
+ */
+const CACHE_SCHEMA = 2
+
+/** The persisted envelope. A bare map (no `version`) is a pre-schema build's. */
+interface StoredCache {
+  version: number
+  icons: Record<string, string>
+}
+
 const retryDelayMs = 5000
 
 /**
@@ -112,8 +132,15 @@ function loadFromStorage(): void {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (stored) {
-      const parsed = JSON.parse(stored) as Record<string, string>
-      for (const [id, url] of Object.entries(parsed)) {
+      const parsed = JSON.parse(stored) as Partial<StoredCache>
+      // Written by a build whose bounded icons may differ from what this one
+      // would fetch. Drop the lot rather than guess which entries still hold:
+      // they refetch on first use, and a stale one would never be revisited.
+      if (parsed.version !== CACHE_SCHEMA || !parsed.icons) {
+        localStorage.removeItem(STORAGE_KEY)
+        return
+      }
+      for (const [id, url] of Object.entries(parsed.icons)) {
         // Defensive: skip any per-path (`path:`/`pkg:`) keys left by an older build.
         // They're no longer persisted, and feeding them in would seed the
         // bounded-keys-only cache.
@@ -138,7 +165,7 @@ function saveToStorage(): void {
       if (isPerPathKey(id)) continue
       obj[id] = url
     }
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(obj))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: CACHE_SCHEMA, icons: obj } satisfies StoredCache))
   } catch {
     // Ignore storage errors
   }
@@ -273,6 +300,20 @@ export function evictPerPathIconsForDir(dirPath: string): void {
  */
 export function getCachedIcon(iconId: string): string | undefined {
   return memoryCache.get(iconId)
+}
+
+/**
+ * Gets a folder's Finder custom icon from the cache, or undefined when it has
+ * none (the overwhelmingly common case).
+ *
+ * A custom-icon folder keeps the generic `dir` iconId — the backend defers the
+ * `kHasCustomIcon` getxattr off the bulk-listing hot path — so its icon arrives
+ * under a `path:{dir}` key that no entry ever points at. Renderers must ask by
+ * PATH here, not by `iconId`, or `prefetchCustomFolderIcons` fetches and caches
+ * an icon nothing ever draws.
+ */
+export function getCachedCustomFolderIcon(directoryPath: string): string | undefined {
+  return memoryCache.get(`${PATH_KEY_PREFIX}${directoryPath}`)
 }
 
 /**

--- a/apps/desktop/src/lib/query-ui/QueryDialog.escape.svelte.test.ts
+++ b/apps/desktop/src/lib/query-ui/QueryDialog.escape.svelte.test.ts
@@ -27,7 +27,7 @@ vi.mock('$lib/settings', () => ({
 
 vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
-  return { getCachedIcon: () => undefined, iconCacheVersion: writable(0) }
+  return { getCachedIcon: () => undefined, getCachedCustomFolderIcon: () => undefined, iconCacheVersion: writable(0) }
 })
 
 interface Harness {

--- a/apps/desktop/src/lib/query-ui/QueryDialog.svelte.test.ts
+++ b/apps/desktop/src/lib/query-ui/QueryDialog.svelte.test.ts
@@ -35,6 +35,7 @@ vi.mock('$lib/settings', () => ({
 vi.mock('$lib/icon-cache', () => ({
   iconCacheVersion: writable(0),
   getCachedIcon: vi.fn(() => undefined),
+  getCachedCustomFolderIcon: () => undefined,
 }))
 
 interface MountedDialog {

--- a/apps/desktop/src/lib/query-ui/QueryResults.live.svelte.test.ts
+++ b/apps/desktop/src/lib/query-ui/QueryResults.live.svelte.test.ts
@@ -19,6 +19,7 @@ vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
   return {
     getCachedIcon: () => undefined,
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
   }
 })

--- a/apps/desktop/src/lib/query-ui/QueryResults.name-column.svelte.test.ts
+++ b/apps/desktop/src/lib/query-ui/QueryResults.name-column.svelte.test.ts
@@ -17,6 +17,7 @@ vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
   return {
     getCachedIcon: () => undefined,
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
   }
 })

--- a/apps/desktop/src/lib/query-ui/QueryResults.states.svelte.test.ts
+++ b/apps/desktop/src/lib/query-ui/QueryResults.states.svelte.test.ts
@@ -20,6 +20,7 @@ vi.mock('$lib/icon-cache', async () => {
   const { writable } = await import('svelte/store')
   return {
     getCachedIcon: () => undefined,
+    getCachedCustomFolderIcon: () => undefined,
     iconCacheVersion: writable(0),
   }
 })

--- a/apps/desktop/src/lib/query-ui/dialog.a11y.test.ts
+++ b/apps/desktop/src/lib/query-ui/dialog.a11y.test.ts
@@ -38,6 +38,7 @@ vi.mock('$lib/settings', () => ({
 vi.mock('$lib/icon-cache', () => ({
   iconCacheVersion: writable(0),
   getCachedIcon: vi.fn(() => undefined),
+  getCachedCustomFolderIcon: () => undefined,
 }))
 
 // Both components share one jsdom document, and axe resolves ARIA id references

--- a/apps/desktop/src/lib/search/SearchDialog.coverage.svelte.test.ts
+++ b/apps/desktop/src/lib/search/SearchDialog.coverage.svelte.test.ts
@@ -148,6 +148,7 @@ vi.mock('$lib/indexing', () => ({
 vi.mock('$lib/icon-cache', () => ({
   iconCacheVersion: writable(0),
   getCachedIcon: vi.fn(() => undefined),
+  getCachedCustomFolderIcon: () => undefined,
 }))
 
 const live: { component: ReturnType<typeof mount>; target: HTMLDivElement }[] = []

--- a/apps/desktop/src/lib/search/SearchDialog.handoff.svelte.test.ts
+++ b/apps/desktop/src/lib/search/SearchDialog.handoff.svelte.test.ts
@@ -86,7 +86,11 @@ vi.mock('$lib/indexing', () => ({
   getEntriesScanned: vi.fn(() => 0),
   ROOT_VOLUME_ID: 'root',
 }))
-vi.mock('$lib/icon-cache', () => ({ iconCacheVersion: writable(0), getCachedIcon: vi.fn(() => undefined) }))
+vi.mock('$lib/icon-cache', () => ({
+  iconCacheVersion: writable(0),
+  getCachedIcon: vi.fn(() => undefined),
+  getCachedCustomFolderIcon: () => undefined,
+}))
 
 function entry(name: string): SearchResultEntry {
   return {

--- a/apps/desktop/src/lib/search/test-search-dialog-harness.ts
+++ b/apps/desktop/src/lib/search/test-search-dialog-harness.ts
@@ -237,7 +237,11 @@ export function indexingMock(): Record<string, unknown> {
 }
 
 export function iconCacheMock(): Record<string, unknown> {
-  return { iconCacheVersion: writable(0), getCachedIcon: vi.fn(() => undefined) }
+  return {
+    iconCacheVersion: writable(0),
+    getCachedIcon: vi.fn(() => undefined),
+    getCachedCustomFolderIcon: vi.fn(() => undefined),
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/lib/selection-dialog/SelectionDialog.svelte.test.ts
+++ b/apps/desktop/src/lib/selection-dialog/SelectionDialog.svelte.test.ts
@@ -74,6 +74,7 @@ vi.mock('$lib/settings', () => ({
 vi.mock('$lib/icon-cache', () => ({
   iconCacheVersion: writable(0),
   getCachedIcon: vi.fn(() => undefined),
+  getCachedCustomFolderIcon: () => undefined,
 }))
 
 function setAiProviderForTest(value: 'off' | 'local' | 'cloud'): void {


### PR DESCRIPTION
Two separate bugs in folder icon rendering, both visual, both in the icons module.

Every plain folder drew the home folder's icon
----------------------------------------------
The dir / symlink-dir tier samples a real folder on disk to get the OS bitmap, and the sample was the home directory. macOS bakes the house badge into that icon, along with any custom icon the user has assigned to ~, so whatever ~ looks like ended up stamped on every row carrying the generic id. That's around 99% of a listing.

Samples a Cmdr-owned empty temp folder instead. Same tier, same id scheme, same caching and lifecycle; only the sample path moves. The temp folder is created once and is guaranteed to carry no badge and no custom icon of its own.

Folders with a Finder custom icon drew the generic one ------------------------------------------------------- Here the icon was being fetched and cached correctly; it just never got drawn. Custom-icon detection is deliberately kept off the bulk-listing hot path, so such a folder keeps the plain dir icon id and its real icon lands in the cache under a path:{dir} key that no entry points at. FileIcon.svelte looked up by iconId alone, so prefetchCustomFolderIcons fetched and cached an icon that was then silently discarded.

FileIcon now resolves by path first via getCachedCustomFolderIcon, falling back to the id. The listing hot path is untouched.

One side effect worth flagging: path:* was already documented as excluded from the Cmdr-gold recolor filter, but because these entries carry the dir id, that exclusion never actually fired, so Gold was repainting the user's own artwork. Resolving by path makes the existing exclusion behave the way its comment describes.

Docs
----
Updates the icon-id table in icons/CLAUDE.md, which still described the generic tier as fetched from the home dir, and adds a must-know so the sample source doesn't quietly drift back.