### PR TITLE
fix(dialogs): F7 lands the cursor in the name box, so the folder name is typeable without a click first

### DIFF
--- a/apps/desktop/src/lib/file-operations/mkdir/DETAILS.md
+++ b/apps/desktop/src/lib/file-operations/mkdir/DETAILS.md
@@ -24,6 +24,12 @@ The dialog opens immediately with a focused input; AI runs in the background. If
 suggestion strip doesn't render and the dialog stays fully usable. `aiAvailable` starts at `null` ("checking") to avoid
 a flash-of-empty-strip on slow `getAiStatus()` responses.
 
+### The name box is typeable the instant F7 opens
+
+`../NewEntryNameField.svelte` focuses and selects the box in its own `onMount`, and `ModalDialog` skips its scrim focus
+when something inside already owns it (why, and the ordering that made this a bug: `$lib/ui/DETAILS.md` § ModalDialog).
+Guarded by `NewFolderDialog.focus.test.ts` and the F7 round-trip in `file-operations.spec.ts`.
+
 ### Timeout warning vs error
 
 A slow `createDirectory` returns a timeout-shaped error after the backend's deadline. Rather than a red "failed" error,

--- a/apps/desktop/src/lib/file-operations/mkdir/NewFolderDialog.focus.test.ts
+++ b/apps/desktop/src/lib/file-operations/mkdir/NewFolderDialog.focus.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The F7 dialog must be typeable the instant it opens: `NewEntryNameField` focuses
+ * (and selects) the name box on mount, and nothing in `ModalDialog` may take that
+ * focus back to the scrim. Reported as vdavid/cmdr#84.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { mount, tick } from 'svelte'
+import NewFolderDialog from './NewFolderDialog.svelte'
+
+vi.mock('$lib/tauri-commands', () => ({
+  notifyDialogOpened: vi.fn(() => Promise.resolve()),
+  notifyDialogClosed: vi.fn(() => Promise.resolve()),
+  createDirectory: vi.fn(() => Promise.resolve()),
+  findFileIndex: vi.fn(() => Promise.resolve(null)),
+  getAiStatus: vi.fn(() => Promise.resolve('unavailable')),
+  getFileAt: vi.fn(() => Promise.resolve(null)),
+  streamFolderSuggestions: vi.fn(() => ({ promise: Promise.resolve(), cancel: () => Promise.resolve() })),
+  onDirectoryDiff: vi.fn(() => Promise.resolve(() => {})),
+  refreshListing: vi.fn(() => Promise.resolve()),
+}))
+
+function mountDialog(initialName: string) {
+  const target = document.createElement('div')
+  document.body.appendChild(target)
+  mount(NewFolderDialog, {
+    target,
+    props: {
+      currentPath: '/Users/test/Projects',
+      listingId: 'listing-1',
+      showHiddenFiles: false,
+      initialName,
+      volumeId: 'root',
+      onCreated: () => {},
+      onCancel: () => {},
+    },
+  })
+  return target
+}
+
+describe('NewFolderDialog focus', () => {
+  it('focuses the name input on open, so typing starts immediately', async () => {
+    const target = mountDialog('')
+    await tick()
+    await tick()
+
+    const input = target.querySelector('input')
+    expect(document.activeElement).toBe(input)
+    target.remove()
+  })
+
+  it('selects a pre-filled name so typing replaces it', async () => {
+    const target = mountDialog('my-project')
+    await tick()
+    await tick()
+
+    const input = target.querySelector('input')
+    expect(document.activeElement).toBe(input)
+    expect(input?.selectionStart).toBe(0)
+    expect(input?.selectionEnd).toBe('my-project'.length)
+    target.remove()
+  })
+})

--- a/apps/desktop/src/lib/ui/Button.svelte
+++ b/apps/desktop/src/lib/ui/Button.svelte
@@ -31,8 +31,8 @@
         'aria-describedby'?: string
         /**
          * Focus this button after mount. Uses `requestAnimationFrame` so it lands
-         * after a parent `ModalDialog`'s post-`tick()` overlay focus, which would
-         * otherwise win and steal focus to the scrim.
+         * after a parent `ModalDialog` has settled its own mount-time focus (the
+         * dialog leaves the scrim unfocused once something inside owns focus).
          */
         autoFocus?: boolean
         children: Snippet

--- a/apps/desktop/src/lib/ui/DETAILS.md
+++ b/apps/desktop/src/lib/ui/DETAILS.md
@@ -207,6 +207,13 @@ carries `use:trapFocus={{ onEscape: onclose }}` (see § "Focus trapping" below),
 containment and the Escape fallback for free. `trapFocus` deliberately doesn't move focus on mount, so the scrim KEEPS
 focus for the dialog's whole life unless a control takes it.
 
+**That mount focus is conditional: the scrim skips it when focus already sits inside the overlay.** Child components
+mount BEFORE their parent, so a field that autofocuses in its own `onMount` (`NewEntryNameField`, in the New folder and
+New file dialogs) resolves its post-`tick()` `.focus()` first, and an unconditional scrim focus would take it straight
+back — the F7 dialog opened with a dead name box that needed a click before typing (#84). A dialog that focuses a
+control from ITS own `onMount` (`GoToPathDialog`) runs AFTER the scrim and was never affected; `Button`'s `autoFocus`
+lands later still, on a `requestAnimationFrame`.
+
 **Gotcha: `.modal-overlay:focus` must keep `outline: none`.** The scrim is `inset: var(--titlebar-height) 0 0 0`, so
 three of its four edges sit outside the viewport and only the TOP ring edge is visible: the UA focus ring reads as a
 mystery 3px line spanning the whole window, tucked under the title bar (~2px above the content, the ring's offset). It

--- a/apps/desktop/src/lib/ui/ModalDialog.svelte
+++ b/apps/desktop/src/lib/ui/ModalDialog.svelte
@@ -423,7 +423,12 @@
             void notifyDialogOpened(dialogId)
         }
         await tick()
-        overlayElement?.focus()
+        // Only if nothing inside claimed focus first. A child that autofocuses (the
+        // name box in the New folder / New file dialogs) mounts BEFORE this component,
+        // so its post-`tick()` `.focus()` resolves first; focusing the scrim
+        // unconditionally would take it straight back and force the user to click the
+        // field before typing (#84).
+        if (overlayElement && !overlayElement.contains(document.activeElement)) overlayElement.focus()
 
         if (!growDownward || !dialogElement) return
         anchorToCurrentCenter()

--- a/apps/desktop/src/lib/ui/ModalDialog.svelte.test.ts
+++ b/apps/desktop/src/lib/ui/ModalDialog.svelte.test.ts
@@ -18,6 +18,17 @@ vi.mock('$lib/tauri-commands', () => ({
 const titleSnippet = createRawSnippet(() => ({ render: () => `<span>Dialog title</span>` }))
 const bodySnippet = createRawSnippet(() => ({ render: () => `<p>Body.</p>` }))
 const footerSnippet = createRawSnippet(() => ({ render: () => `<button>OK</button>` }))
+/** Stands in for `NewEntryNameField`: body content that grabs focus as it mounts. */
+const autoFocusInputSnippet = createRawSnippet(() => ({
+  render: () => `<input class="auto-focused" />`,
+  // After the microtask that inserts it, matching a real child component's
+  // post-`tick()` focus (and beating `ModalDialog`'s own).
+  setup: (node: Element) => {
+    queueMicrotask(() => {
+      ;(node as HTMLInputElement).focus()
+    })
+  },
+}))
 
 /** The resize bands the panel exposes, in DOM order (which is also their hit-test order). */
 function bandDirections(target: HTMLElement): string[] {
@@ -95,6 +106,38 @@ describe('ModalDialog focus restoration', () => {
     }).not.toThrow()
     await tick()
 
+    target.remove()
+  })
+})
+
+describe('ModalDialog mount focus', () => {
+  it('focuses the scrim when nothing inside claims focus', async () => {
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    mount(ModalDialog, {
+      target,
+      props: { titleId: 't', title: titleSnippet, children: bodySnippet },
+    })
+    await tick()
+    await tick()
+
+    expect(document.activeElement).toBe(target.querySelector('.modal-overlay'))
+    target.remove()
+  })
+
+  it('leaves focus alone when a child claimed it first', async () => {
+    // Children mount before this component, so an autofocusing field (the New folder
+    // name box) focuses first; the scrim must not take it back.
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    mount(ModalDialog, {
+      target,
+      props: { titleId: 't', title: titleSnippet, children: autoFocusInputSnippet },
+    })
+    await tick()
+    await tick()
+
+    expect(document.activeElement).toBe(target.querySelector('input'))
     target.remove()
   })
 })

--- a/apps/desktop/test/e2e-playwright/file-operations.spec.ts
+++ b/apps/desktop/test/e2e-playwright/file-operations.spec.ts
@@ -418,6 +418,19 @@ test.describe('Create folder round-trip', () => {
     await tauriPage.waitForSelector(MKDIR_DIALOG, 5000)
 
     await tauriPage.waitForSelector(`${MKDIR_DIALOG} input.text-field-control`, 3000)
+
+    // The name box owns focus the moment the dialog opens, so F7 is followed by
+    // typing, never by a click into the field (#84).
+    await expect
+      .poll(
+        () =>
+          tauriPage.evaluate<boolean>(
+            `document.activeElement === document.querySelector('${MKDIR_DIALOG} input.text-field-control')`,
+          ),
+        { timeout: 3000 },
+      )
+      .toBeTruthy()
+
     await tauriPage.fill(`${MKDIR_DIALOG} input.text-field-control`, folderName)
     // Wait for the OK button to enable in response to the typed name
     await expect.poll(async () => tauriPage.isEnabled(`${MKDIR_DIALOG} .btn-primary`), { timeout: 2000 }).toBeTruthy()


### PR DESCRIPTION
`ModalDialog` focused its scrim unconditionally after `tick()`. Child components mount BEFORE their parent, so
`NewEntryNameField` (F7 new dir folder)'s own post-`tick()` `.focus()` (and `.select()`) resolved first and the scrim took focus straight back: the New folder and New file dialogs opened with a dead input, and the user had to click the field before typing, which was annoying.
Reported as #84, and `Button`'s `autoFocus` already carried a `requestAnimationFrame` hack to dodge the same steal.

The scrim now focuses only when nothing inside the overlay owns focus, which keeps Escape and the keydown handlers
landing somewhere for every dialog that doesn't autofocus a control, and leaves the ones that do alone. Dialogs that
focus from their own `onMount` (`GoToPathDialog`, the query dialogs) run after the scrim and were never affected.

Guarded three ways: the general contract in `ModalDialog.svelte.test.ts`, the reported flow in
`NewFolderDialog.focus.test.ts`, and an `activeElement` assertion in the F7 round-trip E2E, which typed via `fill()` and so never noticed.